### PR TITLE
store file basenames in manifest.json so image dirs can be moved

### DIFF
--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -268,38 +268,38 @@ pub fn run(args: &BuildArgs) -> anyhow::Result<()> {
                 snapshot_config_sha256: kernel.manifest.inputs.snapshot_config_sha256.clone(),
             }),
             initrd: FileEntry {
-                path: initrd_path.to_string_lossy().to_string(),
+                path: manifest::basename_of(&initrd_path),
                 sha256: initrd_hash,
             },
             firmware: firmware
                 .as_ref()
                 .map(|fw| -> anyhow::Result<FileEntry> {
                     Ok(FileEntry {
-                        path: fw.to_string_lossy().to_string(),
+                        path: manifest::basename_of(fw),
                         sha256: manifest::sha256_file(fw)?,
                     })
                 })
                 .transpose()?,
             base_image: FileEntry {
-                path: base_abs.to_string_lossy().to_string(),
+                path: manifest::basename_of(&base_abs),
                 sha256: disk_checksum.to_owned(),
             },
         },
         outputs: ManifestOutputs {
             disk_image: FileEntry {
-                path: disk_path.to_string_lossy().to_string(),
+                path: manifest::basename_of(&disk_path),
                 sha256: disk_checksum,
             },
             igvm: if args.skip_igvm {
                 None
             } else {
                 Some(FileEntry {
-                    path: igvm_path.to_string_lossy().to_string(),
+                    path: manifest::basename_of(&igvm_path),
                     sha256: igvm_hash,
                 })
             },
             uki: FileEntry {
-                path: output_uki.to_string_lossy().to_string(),
+                path: manifest::basename_of(&output_uki),
                 sha256: uki_hash,
             },
         },

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -1,5 +1,3 @@
-use std::path::PathBuf;
-
 use crate::manifest::{self, BuildManifest};
 use crate::qemu::{self, QemuArgs, QemuTier};
 use crate::RunArgs;
@@ -71,12 +69,12 @@ pub fn run(args: &RunArgs) -> anyhow::Result<()> {
                     anyhow::bail!("firmware not found: {}", cli_fw.display());
                 }
                 cli_fw.clone()
-            } else if let Some(ref fw_entry) = manifest.inputs.firmware {
-                let fw = PathBuf::from(&fw_entry.path);
+            } else if manifest.inputs.firmware.is_some() {
+                let fw = args.dir.join("OVMF.fd");
                 if !fw.exists() {
                     anyhow::bail!(
-                        "firmware not found at {} (recorded in manifest)",
-                        fw_entry.path
+                        "firmware not found at {} (build copies firmware into the output directory)",
+                        fw.display()
                     );
                 }
                 fw

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -70,6 +70,15 @@ pub struct Measurement {
     pub vmsa_count: u32,
 }
 
+/// Extract the file basename from a path as an owned String.
+/// Manifest entries record only the basename so they're portable across hosts.
+pub fn basename_of(path: &Path) -> String {
+    path.file_name()
+        .expect("manifest paths must have a file name component")
+        .to_string_lossy()
+        .into_owned()
+}
+
 /// Compute SHA-256 hash of a file, returned as a hex string.
 /// Uses streaming reads to handle large files (disk images can be multiple GB).
 pub fn sha256_file(path: &Path) -> anyhow::Result<String> {

--- a/tests/manifest.rs
+++ b/tests/manifest.rs
@@ -243,3 +243,20 @@ fn test_read_manifest_invalid_json() {
     let result = steep::manifest::read_manifest(&path);
     assert!(result.is_err());
 }
+
+#[test]
+fn test_basename_of_strips_directories() {
+    use std::path::Path;
+    assert_eq!(
+        steep::manifest::basename_of(Path::new("/abs/path/to/disk.raw")),
+        "disk.raw"
+    );
+    assert_eq!(
+        steep::manifest::basename_of(Path::new("relative/dir/OVMF.fd")),
+        "OVMF.fd"
+    );
+    assert_eq!(
+        steep::manifest::basename_of(Path::new("uki.efi")),
+        "uki.efi"
+    );
+}


### PR DESCRIPTION
without this, moving the built directory causes the manifest to contain invalid paths.