### PR TITLE
expose qemu monitor via stdio mux

### DIFF
--- a/src/qemu.rs
+++ b/src/qemu.rs
@@ -131,13 +131,13 @@ impl QemuArgs {
                     "sev-snp-guest,id=sev0,cbitpos=51,reduced-phys-bits=1".to_string(),
                     "-no-reboot".to_string(),
                     "-chardev".to_string(),
-                    "stdio,id=hvc0,signal=off".to_string(),
+                    "stdio,id=hvc0,signal=off,mux=on".to_string(),
                     "-device".to_string(),
                     "virtio-serial-pci,id=virtser0".to_string(),
                     "-device".to_string(),
                     "virtconsole,chardev=hvc0,id=console0".to_string(),
-                    "-monitor".to_string(),
-                    "none".to_string(),
+                    "-mon".to_string(),
+                    "chardev=hvc0,mode=readline".to_string(),
                 ]
             }
             QemuTier::Kvm | QemuTier::Emulated => {
@@ -164,11 +164,13 @@ impl QemuArgs {
                 ]);
                 v.extend([
                     "-chardev".to_string(),
-                    "stdio,id=hvc0,signal=off".to_string(),
+                    "stdio,id=hvc0,signal=off,mux=on".to_string(),
                     "-device".to_string(),
                     "virtio-serial-pci,id=virtser0".to_string(),
                     "-device".to_string(),
                     "virtconsole,chardev=hvc0,id=console0".to_string(),
+                    "-mon".to_string(),
+                    "chardev=hvc0,mode=readline".to_string(),
                 ]);
                 v
             }

--- a/tests/qemu.rs
+++ b/tests/qemu.rs
@@ -420,6 +420,16 @@ fn test_qemu_args_uses_virtio_console() {
     );
     // 8250 is gone — the SNP tier no longer uses -serial mon:stdio.
     assert!(!joined.contains("-serial mon:stdio"));
+    // Monitor is multiplexed onto stdio so users can reach it with Ctrl-A C.
+    assert!(joined.contains("mux=on"), "stdio chardev should be muxed");
+    assert!(
+        joined.contains("chardev=hvc0,mode=readline"),
+        "monitor should be attached to the hvc0 mux"
+    );
+    assert!(
+        !joined.contains("-monitor none"),
+        "SNP tier should expose the monitor via the stdio mux"
+    );
 }
 
 #[test]
@@ -440,4 +450,9 @@ fn test_qemu_args_kvm_uses_virtio_console() {
     let joined = cmd.join(" ");
     assert!(joined.contains("virtio-serial-pci"));
     assert!(joined.contains("chardev=hvc0"));
+    assert!(joined.contains("mux=on"), "stdio chardev should be muxed");
+    assert!(
+        joined.contains("chardev=hvc0,mode=readline"),
+        "monitor should be attached to the hvc0 mux"
+    );
 }


### PR DESCRIPTION
Multiplexes the QEMU monitor onto the existing stdio chardev that already serves hvc0, so users running `steep run` can reach the monitor with Ctrl-A C without disturbing the virtio-console path.