### PR TITLE
feat: add --script flag to steep build

### DIFF
--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -1,80 +1,80 @@
 name: Build Base Image
 
 on:
-  push:
-    branches: [main]
-  workflow_dispatch:
+    push:
+        branches: [main]
+    workflow_dispatch:
 
 permissions:
-  contents: read
-  packages: write
+    contents: read
+    packages: write
 
 jobs:
-  build-and-push:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+    build-and-push:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
 
-      - name: Setup Rust
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+            - name: Setup Rust
+              uses: actions-rust-lang/setup-rust-toolchain@v1
 
-      - name: Setup uv
-        uses: astral-sh/setup-uv@v6
+            - name: Setup uv
+              uses: astral-sh/setup-uv@v6
 
-      - name: Setup mkosi
-        uses: systemd/mkosi@v26
+            - name: Setup mkosi
+              uses: systemd/mkosi@v26
 
-      - run: sudo apt install -y systemd-container
+            - run: sudo apt install -y systemd-container
 
-      - name: Cache kernel tools
-        uses: actions/cache@v5
-        with:
-          path: mkosi/kernel-builder/mkosi.tools
-          key: ${{ runner.os }}-tools-${{ hashFiles('mkosi/kernel-builder/mkosi.conf') }}
+            - name: Cache kernel tools
+              uses: actions/cache@v5
+              with:
+                  path: mkosi/kernel-builder/mkosi.tools
+                  key: ${{ runner.os }}-tools-${{ hashFiles('mkosi/kernel-builder/mkosi.conf') }}
 
-      - name: Cache kernel
-        uses: actions/cache@v5
-        with:
-          path: output/kernel
-          key: ${{ runner.os }}-kernel-${{ hashFiles('mkosi/kernel-builder/**/*','kernel/*') }}
+            - name: Cache kernel
+              uses: actions/cache@v5
+              with:
+                  path: output/kernel
+                  key: ${{ runner.os }}-kernel-${{ hashFiles('mkosi/kernel-builder/{mkosi.conf,mkosi.tools.manifest}','kernel/*') }}
 
-      - name: Build kernel
-        run: bin/steep kernel
+            - name: Build kernel
+              run: bin/steep kernel
 
-      - name: Cache base image tools
-        uses: actions/cache@v5
-        with:
-          path: mkosi/base/mkosi.tools
-          key: ${{ runner.os }}-tools-${{ hashFiles('mkosi/base/mkosi.conf.d/tools.conf') }}
+            - name: Cache base image tools
+              uses: actions/cache@v5
+              with:
+                  path: mkosi/base/mkosi.tools
+                  key: ${{ runner.os }}-tools-${{ hashFiles('mkosi/base/mkosi.conf.d/tools.conf') }}
 
-      - name: Build base image
-        run: bin/steep build
+            - name: Build base image
+              run: bin/steep build
 
-      - name: Setup ORAS
-        uses: oras-project/setup-oras@v1
+            - name: Setup ORAS
+              uses: oras-project/setup-oras@v1
 
-      - name: Login to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+            - name: Login to GHCR
+              uses: docker/login-action@v3
+              with:
+                  registry: ghcr.io
+                  username: ${{ github.actor }}
+                  password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Push to GHCR
-        run: |
-          SHORT_SHA="${GITHUB_SHA::7}"
-          REPO=$(echo "$GITHUB_REPOSITORY" | tr '[:upper:]' '[:lower:]')
-          IMAGE="ghcr.io/${REPO}/base"
+            - name: Push to GHCR
+              run: |
+                  SHORT_SHA="${GITHUB_SHA::7}"
+                  REPO=$(echo "$GITHUB_REPOSITORY" | tr '[:upper:]' '[:lower:]')
+                  IMAGE="ghcr.io/${REPO}/base"
 
-          # include the needed OVMF firmware in the published files
-          cp output/OVMF.fd mkosi/base/mkosi.output/OVMF.fd
+                  # include the needed OVMF firmware in the published files
+                  cp output/OVMF.fd mkosi/base/mkosi.output/OVMF.fd
 
-          cd mkosi/base/mkosi.output
+                  cd mkosi/base/mkosi.output
 
-          # prevent symlink from becoming a second copy of the image
-          rm image
+                  # prevent symlink from becoming a second copy of the image
+                  rm image
 
-          oras push "${IMAGE}:${SHORT_SHA},latest" \
-            --artifact-type application/vnd.steep.base.v1 \
-            ./*
+                  oras push "${IMAGE}:${SHORT_SHA},latest" \
+                    --artifact-type application/vnd.steep.base.v1 \
+                    ./*

--- a/README.md
+++ b/README.md
@@ -62,6 +62,11 @@ steep build NAME -c path/to/cloud-init/user-data
 This will build and measure a new image, including the cloud-init file. The results will be written to `output/NAME`,
 ready to be run with `steep run output/NAME` or pushed to GHCR with `steep push output/NAME`.
 
+Pass `--script PATH` (or `-s PATH`) to run a custom finalize script during
+the build. The script is forwarded to mkosi as a `--finalize-script` and
+runs in addition to the project's built-in reproducibility cleanup. Inside
+the script, `$BUILDROOT` points at the image filesystem being assembled.
+
 ### 3. Launch the built VM
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -62,10 +62,11 @@ steep build NAME -c path/to/cloud-init/user-data
 This will build and measure a new image, including the cloud-init file. The results will be written to `output/NAME`,
 ready to be run with `steep run output/NAME` or pushed to GHCR with `steep push output/NAME`.
 
-Pass `--script PATH` (or `-s PATH`) to run a custom finalize script during
-the build. The script is forwarded to mkosi as a `--finalize-script` and
-runs in addition to the project's built-in reproducibility cleanup. Inside
-the script, `$BUILDROOT` points at the image filesystem being assembled.
+Pass `--script PATH` (or `-s PATH`) to run a custom post-install script
+during the build. The script is forwarded to mkosi as a `--postinst-script`
+with `--with-network=yes`, so it can download resources from the network.
+Inside the script, `$BUILDROOT` points at the image filesystem being
+assembled.
 
 ### 3. Launch the built VM
 

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -160,10 +160,12 @@ pub fn run(args: &BuildArgs) -> anyhow::Result<()> {
         mkosi_args.push(format!("--package={pkg}"));
     }
     if let Some(ref script) = args.script {
-        // mkosi resolves --finalize-script relative to --directory, so anchor
-        // the user's path with canonicalize before handing it off.
+        // mkosi resolves --postinst-script relative to --directory, so anchor
+        // the user's path with canonicalize before handing it off. Enable
+        // network access so the script can fetch resources from the internet.
         let canonical = script.canonicalize()?;
-        mkosi_args.push(format!("--finalize-script={}", canonical.display()));
+        mkosi_args.push(format!("--postinst-script={}", canonical.display()));
+        mkosi_args.push("--with-network=yes".to_string());
     }
     tools::run_command_streaming("sudo", &mkosi_args)?;
 

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -38,6 +38,16 @@ pub fn run(args: &BuildArgs) -> anyhow::Result<()> {
         }
     }
 
+    // Validate --script if provided
+    if let Some(ref script) = args.script {
+        if !script.exists() {
+            anyhow::bail!("--script file not found: {}", script.display());
+        }
+        if !script.is_file() {
+            anyhow::bail!("--script path is not a file: {}", script.display());
+        }
+    }
+
     // Prepare the per-build mkosi.local/ overlay. Any debris from a crashed
     // prior build is wiped so we start from a clean slate. The cleanup guard
     // is installed *before* anything writes into the overlay so that early
@@ -148,6 +158,12 @@ pub fn run(args: &BuildArgs) -> anyhow::Result<()> {
     ];
     for pkg in &args.package {
         mkosi_args.push(format!("--package={pkg}"));
+    }
+    if let Some(ref script) = args.script {
+        // mkosi resolves --finalize-script relative to --directory, so anchor
+        // the user's path with canonicalize before handing it off.
+        let canonical = script.canonicalize()?;
+        mkosi_args.push(format!("--finalize-script={}", canonical.display()));
     }
     tools::run_command_streaming("sudo", &mkosi_args)?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,6 +74,12 @@ pub struct BuildArgs {
     #[arg(short = 'p', long = "package", value_name = "PKG", value_delimiter = ',')]
     pub package: Vec<String>,
 
+    /// Path to a finalize script to run during the build. Passed through to
+    /// mkosi as --finalize-script, in addition to the built-in reproducibility
+    /// cleanup script.
+    #[arg(short = 's', long, value_name = "FILE")]
+    pub script: Option<PathBuf>,
+
     /// Enable debug console (passwordless root autologin on serial).
     /// WARNING: In the SNP threat model, the host controls the serial port.
     /// This changes the image measurement.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,9 +74,9 @@ pub struct BuildArgs {
     #[arg(short = 'p', long = "package", value_name = "PKG", value_delimiter = ',')]
     pub package: Vec<String>,
 
-    /// Path to a finalize script to run during the build. Passed through to
-    /// mkosi as --finalize-script, in addition to the built-in reproducibility
-    /// cleanup script.
+    /// Path to a post-install script to run during the build. Passed through
+    /// to mkosi as --postinst-script, with --with-network=yes so the script
+    /// can download resources from the network.
     #[arg(short = 's', long, value_name = "FILE")]
     pub script: Option<PathBuf>,
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -173,3 +173,13 @@ fn test_build_package_flag() {
         .stdout(predicates::str::contains("--package"))
         .stdout(predicates::str::contains("-p,"));
 }
+
+#[test]
+fn test_build_script_flag() {
+    let mut cmd = Command::cargo_bin("steep").unwrap();
+    cmd.args(["build", "--help"])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("--script"))
+        .stdout(predicates::str::contains("-s,"));
+}


### PR DESCRIPTION
Forwards a user-provided shell script to mkosi as an additional --finalize-script, running in addition to the built-in reproducibility cleanup.

Kettle is going to use this to run the nix installer script as part of the image build.