### PR TITLE
feat(push): add --cdi flag for KubeVirt CDI-compatible images

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -310,10 +316,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "float-cmp"
@@ -557,6 +583,16 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
 
 [[package]]
 name = "normalize-line-endings"
@@ -824,6 +860,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -844,6 +886,7 @@ dependencies = [
  "chrono",
  "clap",
  "clap-verbosity-flag",
+ "flate2",
  "fs-err",
  "hex",
  "humansize",
@@ -852,6 +895,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "tar",
  "tempfile",
  "thiserror",
  "tracing",
@@ -874,6 +918,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
 ]
 
 [[package]]
@@ -1305,6 +1360,16 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,8 @@ tempfile = "3"
 fs-err = "3"
 humansize = "2"
 chrono = "0.4"
+tar = "0.4"
+flate2 = "1"
 igvm-tools = { default-features = false, path = "crates/igvm-tools", version = "0.2.0" }
 
 [dev-dependencies]

--- a/src/commands/push.rs
+++ b/src/commands/push.rs
@@ -104,7 +104,23 @@ fn push_cdi(dir: &Path, files: &[OsString], image_ref: &str) -> anyhow::Result<(
         .file_name()
         .ok_or_else(|| anyhow::anyhow!("tarball path has no basename: {}", tarball_path.display()))?;
 
-    // oras push <ref> --artifact-type ... <file>:<media-type>
+    // Stage a minimal OCI image config alongside the tarball. CDI's
+    // registry importer rejects artifacts whose top-level `artifactType`
+    // is set (it only accepts standard OCI image manifests), so we push
+    // a real image config blob and skip `--artifact-type`. Body matches
+    // what containerd would produce for an empty rootfs.
+    let config_path = cwd.join("steep-cdi-config.json");
+    fs_err::write(
+        &config_path,
+        br#"{"architecture":"amd64","os":"linux","config":{},"rootfs":{"type":"layers","diff_ids":[]}}"#,
+    )?;
+    let config_basename = config_path.file_name().unwrap().to_owned();
+    let config_arg = {
+        let mut s = OsString::from(&config_basename);
+        s.push(":application/vnd.oci.image.config.v1+json");
+        s
+    };
+
     let layer_arg = {
         let mut s = OsString::from(tarball_basename);
         s.push(":application/vnd.oci.image.layer.v1.tar+gzip");
@@ -113,11 +129,13 @@ fn push_cdi(dir: &Path, files: &[OsString], image_ref: &str) -> anyhow::Result<(
     let oras_args: Vec<OsString> = vec![
         "push".into(),
         image_ref.into(),
-        "--artifact-type".into(),
-        "application/vnd.steep.image.v1".into(),
+        "--config".into(),
+        config_arg,
         layer_arg,
     ];
-    tools::run_command_streaming_in("oras", &oras_args, cwd)?;
+    let push_res = tools::run_command_streaming_in("oras", &oras_args, cwd.clone());
+    let _ = fs_err::remove_file(&config_path);
+    push_res?;
 
     println!("Pushed successfully.");
     Ok(())

--- a/src/commands/push.rs
+++ b/src/commands/push.rs
@@ -1,4 +1,8 @@
 use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+
+use flate2::write::GzEncoder;
+use flate2::Compression;
 
 use crate::{tools, PushArgs};
 
@@ -38,8 +42,17 @@ pub fn run(args: &PushArgs) -> anyhow::Result<()> {
         .clone()
         .unwrap_or_else(|| args.dir.file_name().unwrap().to_string_lossy().to_string());
     let image_ref = format!("{}/{}:{}", args.registry, name, args.tag);
+
+    if args.cdi {
+        push_cdi(&dir, &files, &image_ref)
+    } else {
+        push_default(&dir, &files, &image_ref)
+    }
+}
+
+fn push_default(dir: &Path, files: &[OsString], image_ref: &str) -> anyhow::Result<()> {
     println!("Pushing {} files to {}", files.len(), image_ref);
-    for f in &files {
+    for f in files {
         println!("  {}", f.to_string_lossy());
     }
 
@@ -49,10 +62,169 @@ pub fn run(args: &PushArgs) -> anyhow::Result<()> {
         "--artifact-type".into(),
         "application/vnd.steep.image.v1".into(),
     ];
-    oras_args.extend(files);
+    oras_args.extend(files.iter().cloned());
 
-    tools::run_command_streaming_in("oras", &oras_args, dir)?;
+    tools::run_command_streaming_in("oras", &oras_args, dir.to_path_buf())?;
 
     println!("Pushed successfully.");
     Ok(())
+}
+
+fn push_cdi(dir: &Path, files: &[OsString], image_ref: &str) -> anyhow::Result<()> {
+    println!(
+        "Pushing CDI-compatible single-layer image ({} files) to {}",
+        files.len(),
+        image_ref
+    );
+    for f in files {
+        println!("  {}", f.to_string_lossy());
+    }
+
+    // Stream to a temp tarball — honors TMPDIR via std::env::temp_dir().
+    let tmp_root = std::env::temp_dir();
+    fs_err::create_dir_all(&tmp_root)?;
+    let tarball = tempfile::Builder::new()
+        .prefix("steep-cdi-")
+        .suffix(".tar.gz")
+        .tempfile_in(&tmp_root)?;
+    let tarball_path: PathBuf = tarball.path().to_path_buf();
+
+    println!("Staging tarball at {}", tarball_path.display());
+    build_cdi_tarball(dir, files, &tarball_path)?;
+
+    // oras push <ref> --artifact-type ... <file>:<media-type>
+    let layer_arg = {
+        let mut s = OsString::from(&tarball_path);
+        s.push(":application/vnd.oci.image.layer.v1.tar+gzip");
+        s
+    };
+    let oras_args: Vec<OsString> = vec![
+        "push".into(),
+        image_ref.into(),
+        "--artifact-type".into(),
+        "application/vnd.steep.image.v1".into(),
+        layer_arg,
+    ];
+
+    // Run from the tarball's parent so the layer's "filename" in the manifest
+    // is just the basename, matching the historical CDI-compatible layout.
+    let cwd = tarball_path
+        .parent()
+        .map(|p| p.to_path_buf())
+        .unwrap_or_else(|| std::env::current_dir().unwrap());
+    tools::run_command_streaming_in("oras", &oras_args, cwd)?;
+
+    println!("Pushed successfully.");
+    Ok(())
+}
+
+/// Build a CDI-compatible tarball at `out_path`.
+///
+/// Layout:
+/// - `disk/disk.raw` (the raw disk image, the only file CDI's importer looks for)
+/// - all other regular files at the root of the tar (metadata: OVMF.fd, manifest.json,
+///   roothash, uki.efi, etc.)
+///
+/// Streams from disk into a gzipped tar file — never buffers a layer in RAM.
+pub(crate) fn build_cdi_tarball(
+    dir: &Path,
+    files: &[OsString],
+    out_path: &Path,
+) -> anyhow::Result<()> {
+    let out = fs_err::File::create(out_path)?;
+    let gz = GzEncoder::new(out, Compression::default());
+    let mut tar = tar::Builder::new(gz);
+    tar.follow_symlinks(false);
+
+    for f in files {
+        let src = dir.join(f);
+        let name = f.to_string_lossy();
+        let arcname = if name == "disk.raw" {
+            "disk/disk.raw".to_string()
+        } else {
+            name.into_owned()
+        };
+        let mut file = fs_err::File::open(&src)?;
+        tar.append_file(&arcname, file.file_mut())?;
+    }
+
+    let gz = tar.into_inner()?;
+    gz.finish()?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use flate2::read::GzDecoder;
+    use std::collections::BTreeSet;
+    use tempfile::TempDir;
+
+    fn write(dir: &Path, name: &str, bytes: &[u8]) {
+        fs_err::write(dir.join(name), bytes).unwrap();
+    }
+
+    #[test]
+    fn cdi_tarball_layout_places_disk_under_disk_dir_and_others_at_root() {
+        let src = TempDir::new().unwrap();
+        write(src.path(), "disk.raw", b"RAWDISK-CONTENT");
+        write(src.path(), "OVMF.fd", b"firmware");
+        write(src.path(), "manifest.json", b"{}");
+        write(src.path(), "roothash", b"deadbeef");
+        write(src.path(), "uki.efi", b"efi");
+
+        let files: Vec<OsString> = vec![
+            "OVMF.fd".into(),
+            "disk.raw".into(),
+            "manifest.json".into(),
+            "roothash".into(),
+            "uki.efi".into(),
+        ];
+
+        let out_dir = TempDir::new().unwrap();
+        let out = out_dir.path().join("layer.tar.gz");
+        build_cdi_tarball(src.path(), &files, &out).unwrap();
+
+        // Re-open and inspect.
+        let f = fs_err::File::open(&out).unwrap();
+        let gz = GzDecoder::new(f);
+        let mut ar = tar::Archive::new(gz);
+
+        let mut names: BTreeSet<String> = BTreeSet::new();
+        let mut disk_contents: Option<Vec<u8>> = None;
+        for entry in ar.entries().unwrap() {
+            let mut entry = entry.unwrap();
+            let path = entry.path().unwrap().to_path_buf();
+            let name = path.to_string_lossy().into_owned();
+            if name == "disk/disk.raw" {
+                let mut buf = Vec::new();
+                std::io::Read::read_to_end(&mut entry, &mut buf).unwrap();
+                disk_contents = Some(buf);
+            }
+            names.insert(name);
+        }
+
+        assert!(
+            names.contains("disk/disk.raw"),
+            "expected disk/disk.raw in tar, got: {:?}",
+            names
+        );
+        assert!(names.contains("OVMF.fd"), "OVMF.fd should be at tar root");
+        assert!(
+            names.contains("manifest.json"),
+            "manifest.json should be at tar root"
+        );
+        assert!(names.contains("roothash"), "roothash should be at tar root");
+        assert!(names.contains("uki.efi"), "uki.efi should be at tar root");
+
+        // Nothing else snuck under disk/.
+        let under_disk: Vec<_> = names
+            .iter()
+            .filter(|n| n.starts_with("disk/"))
+            .cloned()
+            .collect();
+        assert_eq!(under_disk, vec!["disk/disk.raw".to_string()]);
+
+        assert_eq!(disk_contents.as_deref(), Some(&b"RAWDISK-CONTENT"[..]));
+    }
 }

--- a/src/commands/push.rs
+++ b/src/commands/push.rs
@@ -92,9 +92,21 @@ fn push_cdi(dir: &Path, files: &[OsString], image_ref: &str) -> anyhow::Result<(
     println!("Staging tarball at {}", tarball_path.display());
     build_cdi_tarball(dir, files, &tarball_path)?;
 
+    // Run from the tarball's parent so the layer's "filename" in the manifest
+    // is just the basename, matching the historical CDI-compatible layout.
+    // oras also rejects absolute paths as layer args (path validation), so the
+    // layer must be referenced by its basename relative to the cwd.
+    let cwd = tarball_path
+        .parent()
+        .map(|p| p.to_path_buf())
+        .unwrap_or_else(|| std::env::current_dir().unwrap());
+    let tarball_basename = tarball_path
+        .file_name()
+        .ok_or_else(|| anyhow::anyhow!("tarball path has no basename: {}", tarball_path.display()))?;
+
     // oras push <ref> --artifact-type ... <file>:<media-type>
     let layer_arg = {
-        let mut s = OsString::from(&tarball_path);
+        let mut s = OsString::from(tarball_basename);
         s.push(":application/vnd.oci.image.layer.v1.tar+gzip");
         s
     };
@@ -105,13 +117,6 @@ fn push_cdi(dir: &Path, files: &[OsString], image_ref: &str) -> anyhow::Result<(
         "application/vnd.steep.image.v1".into(),
         layer_arg,
     ];
-
-    // Run from the tarball's parent so the layer's "filename" in the manifest
-    // is just the basename, matching the historical CDI-compatible layout.
-    let cwd = tarball_path
-        .parent()
-        .map(|p| p.to_path_buf())
-        .unwrap_or_else(|| std::env::current_dir().unwrap());
     tools::run_command_streaming_in("oras", &oras_args, cwd)?;
 
     println!("Pushed successfully.");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,6 +127,13 @@ pub struct PushArgs {
     /// Image tag
     #[arg(long, default_value = "latest")]
     pub tag: String,
+
+    /// Build a CDI-compatible single-layer tar+gzip image (for KubeVirt CDI importer).
+    ///
+    /// When set, all files are packed into one `application/vnd.oci.image.layer.v1.tar+gzip`
+    /// layer where `disk.raw` lives under `disk/` and other files sit at the tar root.
+    #[arg(long, default_value_t = false)]
+    pub cdi: bool,
 }
 
 #[derive(clap::Args)]


### PR DESCRIPTION
## Summary

The default `bin/steep push` produces an OCI image with one layer per file, each advertised as `application/vnd.oci.image.layer.v1.tar` even though the bytes are raw file contents, not tar archives (oras's default for `oras push <file>`). KubeVirt's CDI trusts the media type, tries to walk each layer as a tar, hits `archive/tar: invalid tar header` on byte 0, and crash-loops.

Add an opt-in `--cdi` flag that produces an image CDI accepts:

- One layer, real `application/vnd.oci.image.layer.v1.tar+gzip`.
- Real `application/vnd.oci.image.config.v1+json` config blob (not the empty config that sets `artifactType` on the manifest, which CDI rejects).
- Layer content is a gzipped tarball with `disk/disk.raw` at the expected location and other files (`OVMF.fd`, `manifest.json`, `roothash`, `uki.efi`) at tar root.

Default (`--cdi=false`) behavior is **byte-identical** to the existing push path, so existing CI/workflows keep working unchanged.

## Implementation

- Streams the tarball to a temp file via `tempfile::Builder::tempfile_in` (honors `TMPDIR`), no in-RAM buffering, since the disk image is ~1.6 GB.
- Splits `push.rs` into `push_default` (unchanged) and `push_cdi`.
- Tarball building factored into `build_cdi_tarball()` for unit testability, with a test that extracts the produced tarball and asserts the layout.

## Files changed

- `Cargo.toml` (`+ tar`, `+ flate2`)
- `Cargo.lock`
- `src/lib.rs` (`cdi: bool` field on `PushArgs`)
- `src/commands/push.rs` (split + new `build_cdi_tarball`)
