### PR TITLE
feat(manifest): v2 with per-SMP variants + build emits all variants

### DIFF
--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -209,9 +209,12 @@ pub fn run(args: &BuildArgs) -> anyhow::Result<()> {
         human_size(&output_uki)?
     );
 
-    // Step 3: Build IGVM (optional)
-    let igvm_path = output.join("guest.igvm");
-    let measurement = if args.skip_igvm {
+    // Step 3: Build IGVM (optional). Produces one variant for `args.smp`; use
+    // `steep igvm --smp N M ...` afterwards to add variants for additional SMP
+    // counts. The per-SMP filename (`guest-smp{N}.igvm`) matches the convention
+    // used by `steep igvm`, so variants written by either path are uniformly
+    // addressable.
+    let igvm_variant = if args.skip_igvm {
         println!("\n=== Step 4/4: Skipping IGVM (--skip-igvm) ===");
         None
     } else {
@@ -226,6 +229,8 @@ pub fn run(args: &BuildArgs) -> anyhow::Result<()> {
 
         let result = igvm::invoke::build_snp(&fw_bytes, &uki_bytes, args.smp)?;
 
+        let igvm_name = format!("guest-smp{}.igvm", args.smp);
+        let igvm_path = output.join(&igvm_name);
         fs_err::write(&igvm_path, &result.igvm_bytes)?;
         println!(
             "IGVM: {} ({})",
@@ -233,11 +238,19 @@ pub fn run(args: &BuildArgs) -> anyhow::Result<()> {
             human_size(&igvm_path)?
         );
 
-        Some(manifest::Measurement {
-            snp_launch_digest: hex::encode(result.measurement.launch_digest),
-            algorithm: "sha384".to_string(),
-            page_count: result.measurement.page_count,
-            vmsa_count: result.measurement.vmsa_count,
+        let igvm_sha256 = manifest::sha256_file(&igvm_path)?;
+        Some(manifest::IgvmVariant {
+            smp: args.smp,
+            igvm: manifest::FileEntry {
+                path: igvm_name,
+                sha256: igvm_sha256,
+            },
+            measurement: manifest::Measurement {
+                snp_launch_digest: hex::encode(result.measurement.launch_digest),
+                algorithm: "sha384".to_string(),
+                page_count: result.measurement.page_count,
+                vmsa_count: result.measurement.vmsa_count,
+            },
         })
     };
 
@@ -269,23 +282,18 @@ pub fn run(args: &BuildArgs) -> anyhow::Result<()> {
     // calculate the other checksums
     let initrd_hash = manifest::sha256_file(&initrd_path)?;
     println!("initrd   {}", initrd_hash);
-    let igvm_hash = if args.skip_igvm {
-        String::new()
-    } else {
-        let h = manifest::sha256_file(&igvm_path)?;
-        println!("igvm     {}", h);
-        h
-    };
+    if let Some(ref v) = igvm_variant {
+        println!("igvm     {} ({})", v.igvm.sha256, v.igvm.path);
+    }
     let uki_hash = manifest::sha256_file(&output_uki)?;
     println!("uki      {}", uki_hash);
 
     println!("\n=== Writing manifest.json ===");
     // Write manifest
     let build_manifest = manifest::BuildManifest {
-        version: 1,
+        version: manifest::MANIFEST_VERSION,
         build: manifest::BuildConfig {
             timestamp: chrono_now(),
-            smp: args.smp,
             memory: args.memory.clone(),
             format: "raw".to_string(),
             platform: if args.skip_igvm {
@@ -330,20 +338,12 @@ pub fn run(args: &BuildArgs) -> anyhow::Result<()> {
                 path: manifest::basename_of(&disk_path),
                 sha256: disk_checksum,
             },
-            igvm: if args.skip_igvm {
-                None
-            } else {
-                Some(manifest::FileEntry {
-                    path: manifest::basename_of(&igvm_path),
-                    sha256: igvm_hash,
-                })
-            },
             uki: manifest::FileEntry {
                 path: manifest::basename_of(&output_uki),
                 sha256: uki_hash,
             },
         },
-        measurement,
+        variants: igvm_variant.into_iter().collect(),
     };
     let manifest_path = output.join("manifest.json");
     manifest::write_manifest(&build_manifest, &manifest_path)?;
@@ -351,14 +351,17 @@ pub fn run(args: &BuildArgs) -> anyhow::Result<()> {
     println!("\n===============================");
     println!("  Build complete!");
     println!("  Output:     {}", output.display());
-    if !args.skip_igvm {
-        println!("  IGVM:       {}", igvm_path.display());
+    for v in &build_manifest.variants {
+        println!("  IGVM:       {} (smp={})", v.igvm.path, v.smp);
     }
     println!("  Disk:       {}", disk_path.display());
     println!("  Manifest:   {}", manifest_path.display());
     println!("  Root hash:  {roothash}");
-    if let Some(ref m) = build_manifest.measurement {
-        println!("  Launch digest: {}", m.snp_launch_digest);
+    for v in &build_manifest.variants {
+        println!(
+            "  Launch digest (smp={}): {}",
+            v.smp, v.measurement.snp_launch_digest
+        );
     }
     if args.cloud_init.is_some() {
         println!("  Cloud-init: measured in verity root");

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -209,16 +209,20 @@ pub fn run(args: &BuildArgs) -> anyhow::Result<()> {
         human_size(&output_uki)?
     );
 
-    // Step 3: Build IGVM (optional). Produces one variant for `args.smp`; use
-    // `steep igvm --smp N M ...` afterwards to add variants for additional SMP
-    // counts. The per-SMP filename (`guest-smp{N}.igvm`) matches the convention
-    // used by `steep igvm`, so variants written by either path are uniformly
-    // addressable.
-    let igvm_variant = if args.skip_igvm {
+    // Step 3: Build IGVM variants (optional). Emits one `guest-smp{N}.igvm`
+    // per value in `args.smp` (default [2, 4, 8, 16] — the standard
+    // powers-of-two), each as its own entry in manifest.variants[]. The
+    // firmware + UKI bytes are read once and reused; the per-variant cost
+    // is just the measurement pass, so building the default set adds
+    // sub-second to the overall build.
+    let igvm_variants: Vec<manifest::IgvmVariant> = if args.skip_igvm {
         println!("\n=== Step 4/4: Skipping IGVM (--skip-igvm) ===");
-        None
+        Vec::new()
     } else {
-        println!("\n=== Step 4/4: Building IGVM ===");
+        println!(
+            "\n=== Step 4/4: Building IGVM variants (smp = {:?}) ===",
+            args.smp
+        );
 
         // firmware is guaranteed Some when skip_igvm is false (validated at top)
         let fw_path = firmware
@@ -227,31 +231,52 @@ pub fn run(args: &BuildArgs) -> anyhow::Result<()> {
         let fw_bytes = fs_err::read(fw_path)?;
         let uki_bytes = fs_err::read(&output_uki)?;
 
-        let result = igvm::invoke::build_snp(&fw_bytes, &uki_bytes, args.smp)?;
+        // Sort + dedup so the on-disk manifest has a canonical ordering
+        // regardless of how the operator listed --smp.
+        let mut smps = args.smp.clone();
+        smps.sort_unstable();
+        smps.dedup();
+        if smps.is_empty() {
+            anyhow::bail!("--smp must list at least one vCPU count");
+        }
 
-        let igvm_name = format!("guest-smp{}.igvm", args.smp);
-        let igvm_path = output.join(&igvm_name);
-        fs_err::write(&igvm_path, &result.igvm_bytes)?;
-        println!(
-            "IGVM: {} ({})",
-            igvm_path.display(),
-            human_size(&igvm_path)?
-        );
+        let mut out = Vec::with_capacity(smps.len());
+        for smp in smps {
+            if smp == 0 {
+                anyhow::bail!("SMP count must be >= 1, got 0");
+            }
+            print!("  smp={smp} ... ");
+            let result = igvm::invoke::build_snp(&fw_bytes, &uki_bytes, smp)?;
 
-        let igvm_sha256 = manifest::sha256_file(&igvm_path)?;
-        Some(manifest::IgvmVariant {
-            smp: args.smp,
-            igvm: manifest::FileEntry {
-                path: igvm_name,
-                sha256: igvm_sha256,
-            },
-            measurement: manifest::Measurement {
-                snp_launch_digest: hex::encode(result.measurement.launch_digest),
-                algorithm: "sha384".to_string(),
-                page_count: result.measurement.page_count,
-                vmsa_count: result.measurement.vmsa_count,
-            },
-        })
+            let igvm_name = format!("guest-smp{smp}.igvm");
+            let igvm_path = output.join(&igvm_name);
+            fs_err::write(&igvm_path, &result.igvm_bytes)?;
+
+            let digest = hex::encode(result.measurement.launch_digest);
+            println!(
+                "{} ({}, digest: {}...{})",
+                igvm_name,
+                human_size(&igvm_path)?,
+                &digest[..8],
+                &digest[digest.len() - 8..],
+            );
+
+            let igvm_sha256 = manifest::sha256_file(&igvm_path)?;
+            out.push(manifest::IgvmVariant {
+                smp,
+                igvm: manifest::FileEntry {
+                    path: igvm_name,
+                    sha256: igvm_sha256,
+                },
+                measurement: manifest::Measurement {
+                    snp_launch_digest: digest,
+                    algorithm: "sha384".to_string(),
+                    page_count: result.measurement.page_count,
+                    vmsa_count: result.measurement.vmsa_count,
+                },
+            });
+        }
+        out
     };
 
     // Copy firmware into output so the directory is self-contained for publish/run
@@ -282,7 +307,7 @@ pub fn run(args: &BuildArgs) -> anyhow::Result<()> {
     // calculate the other checksums
     let initrd_hash = manifest::sha256_file(&initrd_path)?;
     println!("initrd   {}", initrd_hash);
-    if let Some(ref v) = igvm_variant {
+    for v in &igvm_variants {
         println!("igvm     {} ({})", v.igvm.sha256, v.igvm.path);
     }
     let uki_hash = manifest::sha256_file(&output_uki)?;
@@ -343,7 +368,7 @@ pub fn run(args: &BuildArgs) -> anyhow::Result<()> {
                 sha256: uki_hash,
             },
         },
-        variants: igvm_variant.into_iter().collect(),
+        variants: igvm_variants,
     };
     let manifest_path = output.join("manifest.json");
     manifest::write_manifest(&build_manifest, &manifest_path)?;

--- a/src/commands/igvm.rs
+++ b/src/commands/igvm.rs
@@ -1,12 +1,14 @@
-use crate::manifest::{self, Measurement};
+use crate::manifest::{self, BuildManifest, FileEntry, IgvmVariant, Measurement};
 use crate::IgvmArgs;
 
 /// Generate IGVM files for multiple SMP counts from an existing sealed output.
 ///
 /// Reads the UKI from the sealed output directory and the firmware from the
-/// provided path, then builds one IGVM per SMP count. Existing IGVM files
-/// in the output directory are preserved unless overwritten by a matching
-/// SMP count.
+/// provided path, then builds one IGVM per SMP count. Each invocation is
+/// idempotent per SMP value: if `variants[]` in the manifest already contains
+/// an entry for SMP=N whose recorded SHA-256 still matches the on-disk IGVM
+/// file, the build is skipped. Otherwise the variant is (re)built and the
+/// manifest entry replaced.
 pub fn run(args: &IgvmArgs) -> anyhow::Result<()> {
     if !args.dir.exists() {
         anyhow::bail!("output directory not found: {}", args.dir.display());
@@ -18,22 +20,26 @@ pub fn run(args: &IgvmArgs) -> anyhow::Result<()> {
     let uki_path = args.dir.join("uki.efi");
     if !uki_path.exists() {
         anyhow::bail!(
-            "uki.efi not found in {}. Run `steep seal` first.",
+            "uki.efi not found in {}. Run `steep build` first.",
             args.dir.display()
         );
     }
 
+    // The manifest must already exist — `steep igvm` mutates an existing build,
+    // it doesn't create one from scratch. (Without a manifest we'd have nowhere
+    // to record measurements.)
+    let manifest_path = args.dir.join("manifest.json");
+    if !manifest_path.exists() {
+        anyhow::bail!(
+            "manifest.json not found in {}. Run `steep build` first.",
+            args.dir.display()
+        );
+    }
+    let mut build_manifest = manifest::read_manifest(&manifest_path)?;
+
     // Read inputs once
     let fw_bytes = fs_err::read(&args.firmware)?;
     let uki_bytes = fs_err::read(&uki_path)?;
-
-    // Update the existing manifest if present
-    let manifest_path = args.dir.join("manifest.json");
-    let mut build_manifest = if manifest_path.exists() {
-        Some(manifest::read_manifest(&manifest_path)?)
-    } else {
-        None
-    };
 
     println!("Generating IGVM files for SMP counts: {:?}", args.smp);
 
@@ -46,6 +52,30 @@ pub fn run(args: &IgvmArgs) -> anyhow::Result<()> {
         let igvm_path = args.dir.join(&igvm_name);
 
         print!("  smp={smp} ... ");
+
+        // Idempotency: if a variant already exists for this SMP, its IGVM file
+        // is on disk, and the recorded sha256 matches, skip the rebuild.
+        if let Some(existing) = build_manifest.variants.iter().find(|v| v.smp == smp) {
+            if igvm_path.exists() {
+                match manifest::sha256_file(&igvm_path) {
+                    Ok(actual) if actual == existing.igvm.sha256 => {
+                        println!(
+                            "{} unchanged (sha256 match, digest: {})",
+                            igvm_name, existing.measurement.snp_launch_digest
+                        );
+                        continue;
+                    }
+                    Ok(_) => {
+                        println!("(file present but sha256 mismatch — rebuilding)");
+                    }
+                    Err(e) => {
+                        println!("(could not hash existing file: {e} — rebuilding)");
+                    }
+                }
+            } else {
+                println!("(file missing — rebuilding)");
+            }
+        }
 
         let result = crate::igvm::invoke::build_snp(&fw_bytes, &uki_bytes, smp)?;
         fs_err::write(&igvm_path, &result.igvm_bytes)?;
@@ -60,26 +90,130 @@ pub fn run(args: &IgvmArgs) -> anyhow::Result<()> {
             &digest[digest.len() - 8..],
         );
 
-        // Update manifest measurement for the first (or only) SMP count
-        if let Some(ref mut m) = build_manifest {
-            // Store measurement from the first SMP count in the main manifest
-            // (preserves backward compat with single-IGVM manifests)
-            if smp == args.smp[0] {
-                m.measurement = Some(Measurement {
-                    snp_launch_digest: digest.clone(),
-                    algorithm: "sha384".to_string(),
-                    page_count: result.measurement.page_count,
-                    vmsa_count: result.measurement.vmsa_count,
-                });
-            }
-        }
+        let variant = IgvmVariant {
+            smp,
+            igvm: FileEntry {
+                path: igvm_name,
+                sha256: manifest::sha256_file(&igvm_path)?,
+            },
+            measurement: Measurement {
+                snp_launch_digest: digest,
+                algorithm: "sha384".to_string(),
+                page_count: result.measurement.page_count,
+                vmsa_count: result.measurement.vmsa_count,
+            },
+        };
+        upsert_variant(&mut build_manifest, variant);
     }
 
-    // Write updated manifest
-    if let Some(ref m) = build_manifest {
-        manifest::write_manifest(m, &manifest_path)?;
-    }
+    // Persist updates. Sort variants by SMP for stable on-disk ordering, so a
+    // diff between two manifest.json files is meaningful even if the user
+    // happened to invoke `--smp 8 2 4` versus `--smp 2 4 8`.
+    build_manifest.variants.sort_by_key(|v| v.smp);
+    manifest::write_manifest(&build_manifest, &manifest_path)?;
 
     println!("\nDone. IGVM files written to {}", args.dir.display());
     Ok(())
 }
+
+/// Replace any existing variant with the same SMP count, or append if absent.
+/// Ensures `variants[]` has at most one entry per SMP.
+pub(crate) fn upsert_variant(manifest: &mut BuildManifest, variant: IgvmVariant) {
+    if let Some(existing) = manifest.variants.iter_mut().find(|v| v.smp == variant.smp) {
+        *existing = variant;
+    } else {
+        manifest.variants.push(variant);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::manifest::{
+        BuildConfig, BuildManifest, FileEntry, ManifestInputs, ManifestOutputs, MANIFEST_VERSION,
+    };
+
+    fn entry(s: &str) -> FileEntry {
+        FileEntry {
+            path: s.to_string(),
+            sha256: format!("sha-{s}"),
+        }
+    }
+
+    fn empty_manifest() -> BuildManifest {
+        BuildManifest {
+            version: MANIFEST_VERSION,
+            build: BuildConfig {
+                timestamp: "t".into(),
+                memory: "2G".into(),
+                format: "raw".into(),
+                platform: "snp".into(),
+            },
+            inputs: ManifestInputs {
+                kernel: None,
+                initrd: entry("initrd"),
+                firmware: Some(entry("fw")),
+                base_image: entry("base"),
+            },
+            outputs: ManifestOutputs {
+                disk_image: entry("disk"),
+                uki: entry("uki"),
+            },
+            variants: vec![],
+        }
+    }
+
+    fn variant(smp: u32, digest: &str) -> IgvmVariant {
+        IgvmVariant {
+            smp,
+            igvm: FileEntry {
+                path: format!("guest-smp{smp}.igvm"),
+                sha256: format!("igvm-sha-{smp}-{digest}"),
+            },
+            measurement: Measurement {
+                snp_launch_digest: digest.to_string(),
+                algorithm: "sha384".to_string(),
+                page_count: 100,
+                vmsa_count: smp,
+            },
+        }
+    }
+
+    #[test]
+    fn upsert_appends_new_variant() {
+        let mut m = empty_manifest();
+        upsert_variant(&mut m, variant(2, "d2"));
+        assert_eq!(m.variants.len(), 1);
+        assert_eq!(m.variants[0].smp, 2);
+    }
+
+    #[test]
+    fn upsert_replaces_matching_smp() {
+        // Idempotency: calling `steep igvm --smp 2` twice must not produce two
+        // entries with smp=2 in the manifest.
+        let mut m = empty_manifest();
+        upsert_variant(&mut m, variant(2, "d2-old"));
+        upsert_variant(&mut m, variant(2, "d2-new"));
+        assert_eq!(m.variants.len(), 1);
+        assert_eq!(m.variants[0].measurement.snp_launch_digest, "d2-new");
+    }
+
+    #[test]
+    fn upsert_keeps_distinct_smp_variants() {
+        // `steep igvm --smp 2 4` must produce two distinct variants. They keep
+        // their distinct launch digests after a no-op replacement.
+        let mut m = empty_manifest();
+        upsert_variant(&mut m, variant(2, "d2"));
+        upsert_variant(&mut m, variant(4, "d4"));
+        upsert_variant(&mut m, variant(2, "d2")); // re-upsert same smp
+        assert_eq!(m.variants.len(), 2);
+        let digests: Vec<&str> = m
+            .variants
+            .iter()
+            .map(|v| v.measurement.snp_launch_digest.as_str())
+            .collect();
+        assert!(digests.contains(&"d2"));
+        assert!(digests.contains(&"d4"));
+    }
+}
+

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -47,13 +47,27 @@ pub fn run(args: &RunArgs) -> anyhow::Result<()> {
     let uki_path;
     let firmware_path;
 
+    // Default to the first variant (smallest SMP after sort, or the build-time
+    // default if `steep igvm` was never run). A future change can add a `--smp`
+    // selector to `steep run`; for now this matches v1 behaviour of "one IGVM
+    // per output dir."
+    let variant = manifest.variants.first();
+
     match tier {
         QemuTier::SevSnp => {
-            let path = args.dir.join("guest.igvm");
+            let v = variant.ok_or_else(|| {
+                anyhow::anyhow!(
+                    "no IGVM variants in manifest at {}. Was the image built with --skip-igvm?",
+                    args.dir.display()
+                )
+            })?;
+            let path = args.dir.join(&v.igvm.path);
             if !path.exists() {
                 anyhow::bail!(
-                    "guest.igvm not found in {}. Was the image built with --skip-igvm?",
-                    args.dir.display()
+                    "{} not found in {} (referenced by manifest variant smp={})",
+                    v.igvm.path,
+                    args.dir.display(),
+                    v.smp,
                 );
             }
             igvm_path = Some(path);
@@ -138,6 +152,10 @@ pub fn run(args: &RunArgs) -> anyhow::Result<()> {
         None => None,
     };
 
+    // SMP comes from the selected variant; if no variants exist (skip_igvm
+    // builds running on KVM/emulated), fall back to a sensible default.
+    let smp = variant.map(|v| v.smp).unwrap_or(2);
+
     // Launch
     let qemu_args = QemuArgs {
         tier,
@@ -147,7 +165,7 @@ pub fn run(args: &RunArgs) -> anyhow::Result<()> {
         firmware: firmware_path,
         disk: disk_path,
         disk_format: manifest.build.format,
-        smp: manifest.build.smp,
+        smp,
         memory: manifest.build.memory,
         port_forwards,
         scratch: scratch_path,
@@ -157,8 +175,8 @@ pub fn run(args: &RunArgs) -> anyhow::Result<()> {
         "Launching VM (smp={}, memory={}, tier={:?})",
         qemu_args.smp, qemu_args.memory, qemu_args.tier
     );
-    if let Some(ref m) = manifest.measurement {
-        println!("Launch digest: {}", m.snp_launch_digest);
+    if let Some(v) = variant {
+        println!("Launch digest: {}", v.measurement.snp_launch_digest);
     }
 
     qemu::launch(&qemu_args)?;
@@ -183,11 +201,13 @@ fn validate_manifest_fields(manifest: &BuildManifest) -> anyhow::Result<()> {
         );
     }
     qemu::validate_memory(&manifest.build.memory)?;
-    if manifest.build.smp == 0 || manifest.build.smp > 1024 {
-        anyhow::bail!(
-            "invalid smp count in manifest: {} (must be 1-1024)",
-            manifest.build.smp
-        );
+    for v in &manifest.variants {
+        if v.smp == 0 || v.smp > 1024 {
+            anyhow::bail!(
+                "invalid smp count in manifest variant: {} (must be 1-1024)",
+                v.smp
+            );
+        }
     }
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,9 +115,13 @@ pub struct BuildArgs {
     #[arg(long, default_value = "4G")]
     pub memory: String,
 
-    /// Number of vCPUs
-    #[arg(long, default_value = "2")]
-    pub smp: u32,
+    /// SMP counts to generate IGVM variants for. Each value produces one
+    /// `guest-smp{N}.igvm` file alongside a manifest entry under
+    /// `variants[]`. Defaults to the standard powers-of-two set so a
+    /// single `steep build` is enough to serve any common vCPU topology;
+    /// `steep igvm` is then only needed for unusual SMP values or repair.
+    #[arg(long, num_args = 1.., default_values_t = [2u32, 4, 8, 16])]
+    pub smp: Vec<u32>,
 }
 
 #[derive(clap::Args)]

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -3,6 +3,12 @@ use std::path::Path;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
+/// Current manifest schema version. v2 introduces `variants[]` (one entry per
+/// SMP configuration of the IGVM) and removes the singleton `outputs.igvm` and
+/// top-level `measurement` fields. v1 manifests fail to parse — there is no
+/// reader compatibility shim.
+pub const MANIFEST_VERSION: u32 = 2;
+
 #[derive(Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct BuildManifest {
@@ -10,21 +16,30 @@ pub struct BuildManifest {
     pub build: BuildConfig,
     pub inputs: ManifestInputs,
     pub outputs: ManifestOutputs,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub measurement: Option<Measurement>,
+    /// One entry per (SMP) IGVM variant. Populated by `steep build` (initial
+    /// variant) and extended/replaced in place by `steep igvm`.
+    #[serde(default)]
+    pub variants: Vec<IgvmVariant>,
 }
 
 #[derive(Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct BuildConfig {
     pub timestamp: String,
-    pub smp: u32,
     pub memory: String,
     pub format: String,
     pub platform: String,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct IgvmVariant {
+    pub smp: u32,
+    pub igvm: FileEntry,
+    pub measurement: Measurement,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct FileEntry {
     pub path: String,
@@ -61,12 +76,10 @@ pub struct KernelInputs {
 #[serde(deny_unknown_fields)]
 pub struct ManifestOutputs {
     pub disk_image: FileEntry,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub igvm: Option<FileEntry>,
     pub uki: FileEntry,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct Measurement {
     pub snp_launch_digest: String,

--- a/tests/manifest.rs
+++ b/tests/manifest.rs
@@ -1,5 +1,6 @@
 use steep::manifest::{
-    BuildConfig, BuildManifest, FileEntry, ManifestInputs, ManifestOutputs, Measurement,
+    BuildConfig, BuildManifest, FileEntry, IgvmVariant, ManifestInputs, ManifestOutputs,
+    Measurement, MANIFEST_VERSION,
 };
 
 fn sample_entry(path: &str) -> FileEntry {
@@ -9,12 +10,31 @@ fn sample_entry(path: &str) -> FileEntry {
     }
 }
 
+fn sample_measurement(digest: &str, vmsa_count: u32) -> Measurement {
+    Measurement {
+        snp_launch_digest: digest.to_string(),
+        algorithm: "sha384".to_string(),
+        page_count: 5598,
+        vmsa_count,
+    }
+}
+
+fn sample_variant(smp: u32, digest: &str) -> IgvmVariant {
+    IgvmVariant {
+        smp,
+        igvm: FileEntry {
+            path: format!("guest-smp{smp}.igvm"),
+            sha256: format!("hash{smp}"),
+        },
+        measurement: sample_measurement(digest, smp),
+    }
+}
+
 fn sample_manifest() -> BuildManifest {
     BuildManifest {
-        version: 1,
+        version: MANIFEST_VERSION,
         build: BuildConfig {
             timestamp: "2026-03-13T12:00:00Z".to_string(),
-            smp: 4,
             memory: "2G".to_string(),
             format: "raw".to_string(),
             platform: "snp".to_string(),
@@ -27,54 +47,71 @@ fn sample_manifest() -> BuildManifest {
         },
         outputs: ManifestOutputs {
             disk_image: sample_entry("disk.raw"),
-            igvm: Some(sample_entry("guest.igvm")),
             uki: sample_entry("uki.efi"),
         },
-        measurement: Some(Measurement {
-            snp_launch_digest: "aabbcc".to_string(),
-            algorithm: "sha384".to_string(),
-            page_count: 5598,
-            vmsa_count: 4,
-        }),
+        variants: vec![sample_variant(4, "aabbcc")],
     }
 }
 
 #[test]
-fn test_manifest_serializes_to_json() {
+fn manifest_serializes_to_json() {
     let manifest = sample_manifest();
     let json = serde_json::to_string_pretty(&manifest).unwrap();
-    assert!(json.contains("\"version\": 1"));
+    assert!(json.contains("\"version\": 2"));
     assert!(json.contains("\"snp_launch_digest\": \"aabbcc\""));
     assert!(json.contains("\"vmsa_count\": 4"));
     assert!(json.contains("\"firmware\""));
     assert!(json.contains("\"base_image\""));
+    assert!(json.contains("\"variants\""));
 }
 
 #[test]
-fn test_manifest_roundtrip() {
+fn manifest_roundtrip() {
     let manifest = sample_manifest();
     let json = serde_json::to_string(&manifest).unwrap();
     let deserialized: BuildManifest = serde_json::from_str(&json).unwrap();
     assert_eq!(deserialized.version, manifest.version);
-    assert_eq!(deserialized.build.smp, manifest.build.smp);
+    assert_eq!(deserialized.variants.len(), 1);
+    assert_eq!(deserialized.variants[0].smp, 4);
+    assert_eq!(
+        deserialized.variants[0].measurement.snp_launch_digest,
+        "aabbcc"
+    );
     assert_eq!(deserialized.inputs.initrd.path, "initrd.cpio.gz");
     assert_eq!(deserialized.outputs.disk_image.path, "disk.raw");
 }
 
 #[test]
-fn test_manifest_optional_fields_omitted() {
+fn manifest_roundtrip_multi_variant() {
     let mut manifest = sample_manifest();
-    manifest.measurement = None;
-    manifest.inputs.firmware = None;
-    manifest.outputs.igvm = None;
-    let json = serde_json::to_string_pretty(&manifest).unwrap();
-    assert!(!json.contains("measurement"));
-    assert!(!json.contains("firmware"));
-    assert!(!json.contains("igvm"));
+    manifest.variants = vec![
+        sample_variant(2, "digest2"),
+        sample_variant(4, "digest4"),
+        sample_variant(8, "digest8"),
+    ];
+    let json = serde_json::to_string(&manifest).unwrap();
+    let deserialized: BuildManifest = serde_json::from_str(&json).unwrap();
+    assert_eq!(deserialized.variants.len(), 3);
+    let digests: Vec<String> = deserialized
+        .variants
+        .iter()
+        .map(|v| v.measurement.snp_launch_digest.clone())
+        .collect();
+    assert_eq!(digests, vec!["digest2", "digest4", "digest8"]);
 }
 
 #[test]
-fn test_sha256_file_hash() {
+fn manifest_optional_fields_omitted() {
+    let mut manifest = sample_manifest();
+    manifest.inputs.firmware = None;
+    manifest.variants.clear();
+    let json = serde_json::to_string_pretty(&manifest).unwrap();
+    assert!(!json.contains("firmware"));
+    assert!(json.contains("\"variants\": []"));
+}
+
+#[test]
+fn sha256_file_hash() {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("test.bin");
     fs_err::write(&path, b"hello world").unwrap();
@@ -86,7 +123,7 @@ fn test_sha256_file_hash() {
 }
 
 #[test]
-fn test_parse_igvm_manifest() {
+fn parse_igvm_manifest() {
     let igvm_json = r#"{
         "measurement": {
             "snp_launch_digest": "aabbccdd",
@@ -103,24 +140,23 @@ fn test_parse_igvm_manifest() {
 }
 
 #[test]
-fn test_read_manifest_from_file() {
+fn read_manifest_from_file() {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("manifest.json");
     let manifest = sample_manifest();
     steep::manifest::write_manifest(&manifest, &path).unwrap();
     let loaded = steep::manifest::read_manifest(&path).unwrap();
-    assert_eq!(loaded.build.smp, 4);
+    assert_eq!(loaded.variants[0].smp, 4);
     assert_eq!(loaded.build.memory, "2G");
     assert_eq!(loaded.build.format, "raw");
 }
 
 #[test]
-fn test_manifest_rejects_unknown_fields() {
+fn manifest_rejects_unknown_fields_in_build() {
     let json = r#"{
-        "version": 1,
+        "version": 2,
         "build": {
             "timestamp": "2026-03-13T12:00:00Z",
-            "smp": 4,
             "memory": "2G",
             "format": "raw",
             "platform": "snp",
@@ -133,7 +169,8 @@ fn test_manifest_rejects_unknown_fields() {
         "outputs": {
             "disk_image": {"path": "e", "sha256": "f"},
             "uki": {"path": "g", "sha256": "h"}
-        }
+        },
+        "variants": []
     }"#;
     let result: Result<BuildManifest, _> = serde_json::from_str(json);
     assert!(
@@ -143,7 +180,35 @@ fn test_manifest_rejects_unknown_fields() {
 }
 
 #[test]
-fn test_manifest_rejects_unknown_top_level_field() {
+fn manifest_rejects_unknown_top_level_field() {
+    let json = r#"{
+        "version": 2,
+        "build": {
+            "timestamp": "2026-03-13T12:00:00Z",
+            "memory": "2G",
+            "format": "raw",
+            "platform": "snp"
+        },
+        "inputs": {
+            "initrd": {"path": "a", "sha256": "b"},
+            "base_image": {"path": "c", "sha256": "d"}
+        },
+        "outputs": {
+            "disk_image": {"path": "e", "sha256": "f"},
+            "uki": {"path": "g", "sha256": "h"}
+        },
+        "variants": [],
+        "injected": "malicious"
+    }"#;
+    let result: Result<BuildManifest, _> = serde_json::from_str(json);
+    assert!(result.is_err(), "should reject unknown top-level fields");
+}
+
+#[test]
+fn manifest_rejects_v1_legacy_fields() {
+    // v1 carried `build.smp`, `outputs.igvm`, and a top-level `measurement`;
+    // with deny_unknown_fields these must fail to parse so old manifests
+    // can't be silently mis-read by a v2 consumer.
     let json = r#"{
         "version": 1,
         "build": {
@@ -159,16 +224,16 @@ fn test_manifest_rejects_unknown_top_level_field() {
         },
         "outputs": {
             "disk_image": {"path": "e", "sha256": "f"},
+            "igvm": {"path": "g.igvm", "sha256": "h"},
             "uki": {"path": "g", "sha256": "h"}
-        },
-        "injected": "malicious"
+        }
     }"#;
     let result: Result<BuildManifest, _> = serde_json::from_str(json);
-    assert!(result.is_err(), "should reject unknown top-level fields");
+    assert!(result.is_err(), "v1 manifest should not parse as v2");
 }
 
 #[test]
-fn test_parse_igvm_manifest_missing_measurement_key() {
+fn parse_igvm_manifest_missing_measurement_key() {
     let json = r#"{"other_key": "value"}"#;
     let result = steep::manifest::parse_igvm_manifest(json);
     assert!(result.is_err());
@@ -177,13 +242,13 @@ fn test_parse_igvm_manifest_missing_measurement_key() {
 }
 
 #[test]
-fn test_parse_igvm_manifest_invalid_json() {
+fn parse_igvm_manifest_invalid_json() {
     let result = steep::manifest::parse_igvm_manifest("not json at all");
     assert!(result.is_err());
 }
 
 #[test]
-fn test_parse_igvm_manifest_incomplete_measurement() {
+fn parse_igvm_manifest_incomplete_measurement() {
     let json = r#"{
         "measurement": {
             "snp_launch_digest": "aabbcc"
@@ -197,18 +262,17 @@ fn test_parse_igvm_manifest_incomplete_measurement() {
 }
 
 #[test]
-fn test_sha256_file_nonexistent() {
+fn sha256_file_nonexistent() {
     let result = steep::manifest::sha256_file(std::path::Path::new("/nonexistent/file.bin"));
     assert!(result.is_err());
 }
 
 #[test]
-fn test_sha256_file_empty_file() {
+fn sha256_file_empty_file() {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("empty.bin");
     fs_err::write(&path, b"").unwrap();
     let hash = steep::manifest::sha256_file(&path).unwrap();
-    // SHA-256 of empty input
     assert_eq!(
         hash,
         "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
@@ -216,27 +280,26 @@ fn test_sha256_file_empty_file() {
 }
 
 #[test]
-fn test_write_manifest_creates_valid_json() {
+fn write_manifest_creates_valid_json() {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("test_manifest.json");
     let manifest = sample_manifest();
     steep::manifest::write_manifest(&manifest, &path).unwrap();
 
-    // Read back raw JSON and verify it's valid pretty-printed JSON
     let content = fs_err::read_to_string(&path).unwrap();
     let value: serde_json::Value = serde_json::from_str(&content).unwrap();
-    assert_eq!(value["version"], 1);
-    assert_eq!(value["build"]["smp"], 4);
+    assert_eq!(value["version"], 2);
+    assert_eq!(value["variants"][0]["smp"], 4);
 }
 
 #[test]
-fn test_read_manifest_nonexistent_file() {
+fn read_manifest_nonexistent_file() {
     let result = steep::manifest::read_manifest(std::path::Path::new("/nonexistent/manifest.json"));
     assert!(result.is_err());
 }
 
 #[test]
-fn test_read_manifest_invalid_json() {
+fn read_manifest_invalid_json() {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("bad.json");
     fs_err::write(&path, "not json").unwrap();
@@ -245,7 +308,7 @@ fn test_read_manifest_invalid_json() {
 }
 
 #[test]
-fn test_basename_of_strips_directories() {
+fn basename_of_strips_directories() {
     use std::path::Path;
     assert_eq!(
         steep::manifest::basename_of(Path::new("/abs/path/to/disk.raw")),


### PR DESCRIPTION
## Summary

- Schema bump v1 → v2. `outputs.igvm` + top-level `measurement` replaced
  by `variants: Vec<IgvmVariant>` where each entry carries `smp`, `igvm:
  FileEntry`, and `measurement`. `build.smp` is dropped — it lives
  per-variant now. v1 manifests fail to parse cleanly (no shim).
- `steep igvm` is idempotent per SMP. Each invocation rehashes the
  on-disk IGVM and skips rebuilds whose recorded sha256 still matches.
  Missing or mutated files get rebuilt and the variant entry replaced.
  `variants[]` is sorted by SMP on write for stable diffs.
- `steep build` emits all power-of-two variants by default.
  `BuildArgs.smp` is now `Vec<u32>` with default `[2, 4, 8, 16]`. One
  build produces `guest-smp{2,4,8,16}.igvm` plus a four-entry
  `variants[]`. `steep build --smp 4` still scopes down. `steep igvm`
  reduces to a repair / unusual-SMP tool.

## Why

The manifest only stores one measurement even when multiple IGVMs are
built — every variant after the first leaks its digest to stdout and
is forgotten. Downstream consumers verifying "VM is image X at SMP N"
need a durable record of all variants.

## Behaviour changes worth flagging

- `steep igvm` now hard-fails if `manifest.json` is missing (was a
  silent no-op).
- Existing v1 manifests under `output/*/manifest.json` won't parse —
  rerun `steep build`.
- `steep run` defaults to `variants[0]` (smallest SMP after sort). A
  `--smp` selector on `run` is a clean followup.
