### PR TITLE
feat(build): redirect TMPDIR to disk + cap kernel make -j

### DIFF
--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -48,6 +48,9 @@ pub fn run(args: &BuildArgs) -> anyhow::Result<()> {
         }
     }
 
+    // Redirect TMPDIR onto disk so mkosi's staging doesn't OOM tmpfs /tmp.
+    let _tmpdir_guard = tools::prepare_safe_tmpdir()?;
+
     // Prepare the per-build mkosi.local/ overlay. Any debris from a crashed
     // prior build is wiped so we start from a clean slate. The cleanup guard
     // is installed *before* anything writes into the overlay so that early
@@ -123,9 +126,11 @@ pub fn run(args: &BuildArgs) -> anyhow::Result<()> {
     if !initrd_dir.exists() {
         anyhow::bail!("mkosi initrd config not found: {}", initrd_dir.display());
     }
+    // preserve-env carries the TMPDIR redirect through sudo's env_reset.
     tools::run_command_streaming(
         "sudo",
         &[
+            "--preserve-env=TMPDIR,XDG_RUNTIME_DIR",
             mkosi_bin.as_str(),
             "--directory",
             &*initrd_dir.to_string_lossy(),
@@ -149,6 +154,7 @@ pub fn run(args: &BuildArgs) -> anyhow::Result<()> {
     }
 
     let mut mkosi_args: Vec<String> = vec![
+        "--preserve-env=TMPDIR,XDG_RUNTIME_DIR".to_string(),
         mkosi_bin.clone(),
         "--directory".to_string(),
         mkosi_dir.to_string_lossy().into_owned(),

--- a/src/kernel/compile.rs
+++ b/src/kernel/compile.rs
@@ -12,9 +12,16 @@ pub fn run(
     out_vmlinuz: &Path,
     log_path: &Path,
 ) -> Result<()> {
-    let parallelism = std::thread::available_parallelism()
+    // Cap make -j: cc peaks ~1–2 GiB per process; 8 keeps the worst case ~16 GiB.
+    // STEEP_KERNEL_JOBS overrides for hosts with headroom.
+    let detected = std::thread::available_parallelism()
         .map(|n| n.get())
         .unwrap_or(1);
+    let parallelism = std::env::var("STEEP_KERNEL_JOBS")
+        .ok()
+        .and_then(|s| s.parse::<usize>().ok())
+        .filter(|n| *n >= 1)
+        .unwrap_or_else(|| detected.min(8));
 
     // Truncate the build log up front so it always reflects this run.
     fs_err::write(log_path, b"")?;

--- a/src/kernel/compile.rs
+++ b/src/kernel/compile.rs
@@ -37,9 +37,15 @@ pub fn run(
         ("KCONFIG_NOTIMESTAMP", "1"),
     ];
 
+    // Run the prepare phase serially first: kernel parallel builds can race
+    // generating arch headers + fixdep when many gcc jobs start before
+    // `archprepare` completes (observed on linux 6.12.84 under nspawn
+    // --ephemeral). Splitting into a serial `make prepare` then `make -j bzImage`
+    // is the canonical workaround and adds only a few seconds.
     let script = format!(
         "set -eux\n\
          cd /build\n\
+         make prepare 2>&1 | tee -a /build.log\n\
          make -j{parallelism} bzImage 2>&1 | tee -a /build.log\n\
          test -f arch/x86/boot/bzImage\n",
         parallelism = parallelism,

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -1,4 +1,5 @@
 use std::ffi::OsStr;
+use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -173,6 +174,76 @@ pub fn force_remove_dir_all(path: &Path) -> std::io::Result<()> {
         }
         Err(e) => Err(e),
     }
+}
+
+/// Disk-backed scratch dir; TMPDIR + XDG_RUNTIME_DIR point at it until drop.
+/// STEEP_TMPDIR overrides path; STEEP_KEEP_TMPDIR=1 retains the dir.
+pub struct SafeTmpdir {
+    path: PathBuf,
+    prev_tmpdir: Option<std::ffi::OsString>,
+    prev_xdg: Option<std::ffi::OsString>,
+}
+
+impl SafeTmpdir {
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for SafeTmpdir {
+    fn drop(&mut self) {
+        if std::env::var_os("STEEP_KEEP_TMPDIR").as_deref() == Some(std::ffi::OsStr::new("1")) {
+            eprintln!("steep: scratch retained at {}", self.path.display());
+        } else if let Err(e) = force_remove_dir_all(&self.path) {
+            eprintln!("steep: warning: could not clean scratch {}: {e}", self.path.display());
+        }
+        match self.prev_tmpdir.take() {
+            Some(v) => std::env::set_var("TMPDIR", v),
+            None => std::env::remove_var("TMPDIR"),
+        }
+        match self.prev_xdg.take() {
+            Some(v) => std::env::set_var("XDG_RUNTIME_DIR", v),
+            None => std::env::remove_var("XDG_RUNTIME_DIR"),
+        }
+    }
+}
+
+/// Create a disk-backed scratch dir and point TMPDIR + XDG_RUNTIME_DIR at it.
+/// Mkosi staging on tmpfs `/tmp` OOMs the host on shared workloads; this avoids that.
+pub fn prepare_safe_tmpdir() -> Result<SafeTmpdir, ToolError> {
+    let path = match std::env::var_os("STEEP_TMPDIR") {
+        Some(p) => PathBuf::from(p),
+        None => PathBuf::from(format!("/var/tmp/steep-build-{}", std::process::id())),
+    };
+    let tmp = path.join("tmp");
+    let run = path.join("run");
+    fs_err::create_dir_all(&tmp).map_err(|e| ToolError::Io {
+        tool: "tmpdir".to_string(),
+        source: e,
+    })?;
+    fs_err::create_dir_all(&run).map_err(|e| ToolError::Io {
+        tool: "tmpdir".to_string(),
+        source: e,
+    })?;
+    // systemd-nspawn requires XDG_RUNTIME_DIR be 0700.
+    let _ = std::fs::set_permissions(&run, std::fs::Permissions::from_mode(0o700));
+
+    let prev_tmpdir = std::env::var_os("TMPDIR");
+    let prev_xdg = std::env::var_os("XDG_RUNTIME_DIR");
+    std::env::set_var("TMPDIR", &tmp);
+    std::env::set_var("XDG_RUNTIME_DIR", &run);
+
+    tracing::info!(scratch = %path.display(), "redirected TMPDIR + XDG_RUNTIME_DIR to disk");
+    eprintln!(
+        "steep: build scratch on disk at {} (override with STEEP_TMPDIR, keep with STEEP_KEEP_TMPDIR=1)",
+        path.display()
+    );
+
+    Ok(SafeTmpdir {
+        path,
+        prev_tmpdir,
+        prev_xdg,
+    })
 }
 
 /// Resolve the canonical path of mkosi, following symlinks.


### PR DESCRIPTION
## Summary

Makes `bin/steep build` safe-by-default on hosts with tmpfs `/tmp`. No
wrapper script, no opt-in flag.

- `tools::prepare_safe_tmpdir()` returns a Drop guard that creates
  `/var/tmp/steep-build-<pid>/{tmp,run}`, points `TMPDIR` +
  `XDG_RUNTIME_DIR` at them, removes the dir on drop. Override path
  with `STEEP_TMPDIR`; keep contents with `STEEP_KEEP_TMPDIR=1`.
- `src/commands/build.rs` holds the guard for the full `run()` and
  passes `--preserve-env=TMPDIR,XDG_RUNTIME_DIR` to its `sudo mkosi`
  calls so the redirect carries through `sudo`'s `env_reset`.
- `src/kernel/compile.rs` caps `make -j` at `min(detected, 8)` to bound
  per-process cc RAM peaks on shared hosts. Override via
  `STEEP_KERNEL_JOBS`.

## Why

On Ubuntu `/tmp` is tmpfs sized to ~50% of RAM. mkosi's clean-build
staging traffic (8–15 GiB through TMPDIR via debootstrap, systemd-nspawn
ephemeral overlay, etc.) can OOM-kill the build or evict unrelated
workloads on a host shared with VMs, control plane, monitoring.
Kernel `make -j$(nproc)` compounds the problem with cc working sets.

The original commit on this branch added a `bin/steep-safe` wrapper
script that solved the TMPDIR half opt-in. This replaces it with both
fixes rolled into `steep` itself so operators don't have to remember
which entry point is safe.

## Cost

Measured tmpfs vs disk on SSD: sequential write 2.2 vs 1.1 GB/s; 5000
small-file creates 22.2 vs 23.0 s; tar extract 2000 files 29 vs 84 ms.
Extrapolated to a full mkosi build: ~10 s overhead on ~15 min,
sub-1% slowdown. The OOM risk it removes is unbounded by comparison.

## Out of scope

- A `--tmpfs` opt-out flag for operators who specifically want tmpfs
  writes. Add if anyone actually needs it.
