### PR TITLE
fix(console): add ttyS0 to measured cmdline, widen autologin to all serial gettys

### DIFF
--- a/mkosi/base/mkosi.conf
+++ b/mkosi/base/mkosi.conf
@@ -56,7 +56,9 @@ Packages=
     tzdata
     udev
     util-linux
-KernelCommandLine=console=hvc0 systemd.condition-first-boot=no
+# ttyS0 first so KubeVirt/cloud serial consoles get kernel+boot output;
+# hvc0 last keeps /dev/console on virtio-console for steep run.
+KernelCommandLine=console=ttyS0 console=hvc0 systemd.condition-first-boot=no
 
 [Output]
 Format=disk

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -89,7 +89,7 @@ pub fn run(args: &BuildArgs) -> anyhow::Result<()> {
 
     // Inject debug autologin if --debug (enables passwordless root on serial console)
     let autologin_dir = PathBuf::from(
-        "mkosi/base/mkosi.local/mkosi.extra/etc/systemd/system/serial-getty@hvc0.service.d",
+        "mkosi/base/mkosi.local/mkosi.extra/etc/systemd/system/serial-getty@.service.d",
     );
     if args.console {
         println!("WARNING: --console enables passwordless root on serial console. Do not use in production.");


### PR DESCRIPTION
## Problem

Under KubeVirt the guest's only observable console is the isa-serial ttyS0 (`virtctl console` / the `guest-console-log` container). With `KernelCommandLine=console=hvc0` alone, kernel, initrd, and getty output never reach it — an SNP guest that can't be reached over the network is fully opaque. Diagnosing the first rke2-image boot on dev-c8s-integration meant inferring guest state from vCPU time, `domblkstat`, and ARP tables because the console showed exactly one EFI stub line.

## Fix

- `mkosi/base/mkosi.conf`: `console=ttyS0 console=hvc0` — ttyS0 first so serial consoles get kernel/boot output; hvc0 stays last so `/dev/console` remains on virtio-console for `steep run`.
- `src/commands/build.rs`: the `--console` autologin drop-in moves from `serial-getty@hvc0.service.d` to `serial-getty@.service.d`, so whichever console getty systemd spawns gets it.

## Deliberately NOT included

No `CONFIG_SERIAL_8250` in `kernel/required.config`. A host-readable serial console is a per-image debug affordance, not a platform default — for a production CVM, kernel logs streaming to a host-visible device is an information leak. Without the driver, `console=ttyS0` is inert, so this change is a no-op for images that don't opt in. Images that want observability add `CONFIG_SERIAL_8250(_CONSOLE)=y` to their own kernel fragment (the rke2 image does, in lunal-dev/base-images#1).

## Relationship to other branches

Same commit already cherry-picked onto `cdi-on-main` (d695edc) and verified by the rke2 image rebuild there. No file overlap with #14 or #15.