### PR TITLE
feat(profile): console profile (ttyS0 + autologin) — supersedes #20

### DIFF
--- a/mkosi/base/mkosi.profiles/console/mkosi.conf
+++ b/mkosi/base/mkosi.profiles/console/mkosi.conf
@@ -1,0 +1,30 @@
+# Profile: console
+#
+# Makes the guest observable over the host-visible isa-serial port (ttyS0):
+#   - appends `console=ttyS0` to the measured kernel cmdline, so kernel +
+#     initrd + boot output reach KubeVirt's `virtctl console` / the
+#     `guest-console-log` container (which bridge ttyS0, not virtio hvc0).
+#   - drops a passwordless-root autologin on every serial getty
+#     (this dir's mkosi.extra serial-getty@.service.d).
+#
+# NOT a platform default: in the SNP threat model the host controls the
+# serial port, so a host-readable console is a debug affordance an image
+# opts into explicitly (`steep build --profile console`). It also only does
+# anything if the kernel has the 8250 driver — steep's hardened base leaves
+# it out, so an image enables CONFIG_SERIAL_8250(_CONSOLE) via
+# --kernel-config-fragment alongside selecting this profile (the rke2 image
+# does both). Changes the launch measurement.
+
+[Content]
+# KernelCommandLine is an append-merged list in mkosi, so a bare reset line
+# first clears the base's value; the second line then sets the whole cmdline.
+# Why the full line and not just `console=ttyS0`: order matters. Linux makes
+# the LAST console= the /dev/console that systemd spawns the login getty on.
+# hvc0 must stay last — `steep run` wires hvc0 as a virtio console and passes
+# `-serial none` (no ttyS0 device), so if ttyS0 won /dev/console the
+# interactive prompt would vanish under `steep run`. With hvc0 last,
+# /dev/console = hvc0 for `steep run`, while ttyS0 still carries kernel+boot
+# output for KubeVirt's serial console. Keep in sync with the base
+# mkosi.conf line (this is base + a leading console=ttyS0).
+KernelCommandLine=
+KernelCommandLine=console=ttyS0 console=hvc0 systemd.condition-first-boot=no

--- a/mkosi/base/mkosi.profiles/console/mkosi.extra/etc/systemd/system/serial-getty@.service.d/autologin.conf
+++ b/mkosi/base/mkosi.profiles/console/mkosi.extra/etc/systemd/system/serial-getty@.service.d/autologin.conf
@@ -1,0 +1,3 @@
+[Service]
+ExecStart=
+ExecStart=-/sbin/agetty -o '-p -f -- \\u' --noclear --autologin root --keep-baud 115200,57600,38400,9600 %I $TERM

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -85,14 +85,6 @@ pub fn run(args: &BuildArgs) -> anyhow::Result<()> {
     let output = dir.canonicalize()?;
 
     // Inject debug autologin if --debug (enables passwordless root on serial console)
-    let autologin_dir = PathBuf::from(
-        "mkosi/base/mkosi.local/mkosi.extra/etc/systemd/system/serial-getty@hvc0.service.d",
-    );
-    if args.console {
-        println!("WARNING: --console enables passwordless root on serial console. Do not use in production.");
-        inject_console_autologin(&autologin_dir)?;
-    }
-
     // Inject cloud-init user-data into mkosi.local/mkosi.extra seed directory (measured in verity root)
     let seed_dir = PathBuf::from("mkosi/base/mkosi.local/mkosi.extra/var/lib/cloud/seed/nocloud");
     if let Some(ref ci) = args.cloud_init {
@@ -373,22 +365,8 @@ pub fn run(args: &BuildArgs) -> anyhow::Result<()> {
     if args.cloud_init.is_some() {
         println!("  Cloud-init: measured in verity root");
     }
-    if args.console {
-        println!("  Debug:      autologin enabled (NOT for production)");
-    }
     println!("===============================");
 
-    Ok(())
-}
-
-/// Inject a systemd drop-in that enables passwordless root autologin on ttyS0.
-/// Only used with --debug; changes the image measurement.
-fn inject_console_autologin(dir: &Path) -> anyhow::Result<()> {
-    fs_err::create_dir_all(dir)?;
-    fs_err::write(
-        dir.join("autologin.conf"),
-        "[Service]\nExecStart=\nExecStart=-/sbin/agetty -o '-p -f -- \\\\u' --noclear --autologin root --keep-baud 115200,57600,38400,9600 %I $TERM\n",
-    )?;
     Ok(())
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,12 +91,6 @@ pub struct BuildArgs {
     #[arg(short = 's', long, value_name = "FILE")]
     pub script: Option<PathBuf>,
 
-    /// Enable debug console (passwordless root autologin on serial).
-    /// WARNING: In the SNP threat model, the host controls the serial port.
-    /// This changes the image measurement.
-    #[arg(long, verbatim_doc_comment)]
-    pub console: bool,
-
     /// Skip IGVM generation (produce only disk + UKI, no SNP measurement)
     #[arg(long)]
     pub skip_igvm: bool,


### PR DESCRIPTION
Supersedes #20 (the base-cmdline approach). Reworked per review: instead of putting `console=ttyS0` in steep's shared base `mkosi.conf` — which @indirect flagged as something a default cloud image could inherit by accident — the host-visible serial console is now an **opt-in mkosi profile**, riding #19's `--profile` mechanism.

## What's in here

`mkosi/base/mkosi.profiles/console/`:
- **`mkosi.conf`** — resets and sets `KernelCommandLine=console=ttyS0 console=hvc0 systemd.condition-first-boot=no`. ttyS0 carries kernel + initrd + boot output to KubeVirt's `virtctl console` / `guest-console-log`; **hvc0 stays last** so it remains `/dev/console` for `steep run` (which wires hvc0 as a virtconsole and passes `-serial none` — if ttyS0 won `/dev/console` the interactive getty would target a device `steep run` doesn't create). The reset line is needed because mkosi merges `KernelCommandLine` as an appending list.
- **`serial-getty@.service.d/autologin.conf`** — passwordless-root autologin on any serial getty (previously injected by `--console`).

Removes the `--console` flag and `inject_console_autologin` from `build.rs`/`lib.rs`: the profile subsumes both, and adds the cmdline half `--console` never did.

## Why the driver isn't here

`CONFIG_SERIAL_8250` is a **kernel build input** (the kernel is built before mkosi, independent of `--profile`), so it stays in the consuming image's `--kernel-config-fragment` — the rke2 image sets it (lunal-dev/base-images#1). Selecting `--profile console` on a kernel without the driver is a harmless no-op, which is exactly the safety property @indirect wanted.

## Dependencies / sequencing

- **Stacked on #19** (`feat/attest-profile`) — uses its `args.profiles` / `--profile` plumbing. Merge #19 first; this PR's base is #19's branch.
- Consumers switch `--console` → `--profile console`. The base-images `build.sh` change + the `STEEP_REF` bump land together once this merges.

Closes #20 once merged.