### PR TITLE
feat(kernel): --kernel-builder-package to add build-time tools

### DIFF
--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -104,7 +104,11 @@ pub fn run(args: &BuildArgs) -> anyhow::Result<()> {
 
     // Phase 1: ensure custom kernel artifact is current
     println!("\n=== Step 1/4: Ensuring custom kernel ===");
-    let kernel = kernel_cache::ensure_kernel(false, args.kernel_config_fragment.clone())?;
+    let kernel = kernel_cache::ensure_kernel(
+        false,
+        args.kernel_config_fragment.clone(),
+        args.kernel_builder_package.clone(),
+    )?;
     println!(
         "kernel: {} (linux {})",
         kernel.vmlinuz_path.display(),

--- a/src/commands/kernel.rs
+++ b/src/commands/kernel.rs
@@ -61,7 +61,7 @@ pub fn run(args: &KernelArgs) -> Result<()> {
 
     // Phase 0a: ensure tools tree
     println!("\n=== Step 0a: Ensuring kernel-builder tools tree (mkosi) ===");
-    let tools_tree = ensure_tools_tree(args.force)?;
+    let tools_tree = ensure_tools_tree(args.force, &args.kernel_builder_package)?;
 
     // Phase 0b: fetch tarball
     println!("\n=== Step 0b: Fetching kernel tarball ===");
@@ -143,15 +143,18 @@ pub fn run(args: &KernelArgs) -> Result<()> {
 /// the skip. The stamp lives under `mkosi.output/`, which `mkosi --force`
 /// wipes — so a successful rebuild always lands a fresh stamp, and a failed
 /// rebuild leaves no stamp behind to fool a later cache check.
-fn ensure_tools_tree(force: bool) -> Result<PathBuf> {
+fn ensure_tools_tree(force: bool, extra_packages: &[String]) -> Result<PathBuf> {
     let tree = Path::new(TOOLS_TREE_IMAGE);
     let stamp_path = Path::new(TOOLS_TREE_STAMP);
-    let conf_sha = fetch::sha256_file(Path::new(TOOLS_TREE_CONF))?;
+    // Cache key = mkosi.conf hash + the extra-package list. The packages come
+    // via flags, not mkosi.conf, so they must be folded in here or a changed
+    // --kernel-builder-package list would silently reuse a stale tree.
+    let stamp_key = format!("{}\n{}", fetch::sha256_file(Path::new(TOOLS_TREE_CONF))?, extra_packages.join(","));
 
     if !force && tree.exists() {
         if let Ok(stamped) = fs_err::read_to_string(stamp_path) {
-            if stamped.trim() == conf_sha {
-                println!("kernel-builder tools tree cache HIT (mkosi.conf unchanged)");
+            if stamped.trim() == stamp_key {
+                println!("kernel-builder tools tree cache HIT (mkosi.conf + packages unchanged)");
                 return Ok(tree.canonicalize()?);
             }
         }
@@ -162,14 +165,20 @@ fn ensure_tools_tree(force: bool) -> Result<PathBuf> {
     let _ = fs_err::remove_file(stamp_path);
 
     let mkosi = tools::resolve_mkosi()?;
-    tools::run_command_streaming(
-        "sudo",
-        &[mkosi.as_str(), "--directory", TOOLS_TREE_DIR, "--force"],
-    )?;
+    let mut args: Vec<String> = vec![
+        mkosi.clone(),
+        "--directory".into(),
+        TOOLS_TREE_DIR.into(),
+        "--force".into(),
+    ];
+    for pkg in extra_packages {
+        args.push(format!("--package={pkg}"));
+    }
+    tools::run_command_streaming("sudo", &args)?;
     if !tree.exists() {
         return Err(anyhow!("mkosi did not produce {}", tree.display()));
     }
-    fs_err::write(stamp_path, &conf_sha)?;
+    fs_err::write(stamp_path, &stamp_key)?;
     Ok(tree.canonicalize()?)
 }
 

--- a/src/kernel_cache.rs
+++ b/src/kernel_cache.rs
@@ -25,13 +25,18 @@ pub struct KernelArtifact {
 ///
 /// `fragment` is the caller-supplied `--kernel-config-fragment`, threaded
 /// from `steep build`.
-pub fn ensure_kernel(force: bool, fragment: Option<PathBuf>) -> Result<KernelArtifact> {
+pub fn ensure_kernel(
+    force: bool,
+    fragment: Option<PathBuf>,
+    kernel_builder_package: Vec<String>,
+) -> Result<KernelArtifact> {
     require_inputs_exist(fragment.as_deref())?;
 
     commands::kernel::run(&KernelArgs {
         force,
         output: PathBuf::from(KERNEL_OUT_DIR),
         kernel_config_fragment: fragment,
+        kernel_builder_package,
     })?;
 
     let manifest_path = Path::new(KERNEL_OUT_DIR).join("manifest.json");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,12 @@ pub struct KernelArgs {
     /// Lets a project enable extra kernel symbols without modifying steep.
     #[arg(long, value_name = "PATH")]
     pub kernel_config_fragment: Option<PathBuf>,
+
+    /// Extra packages for the kernel-builder tools tree (build-time tools a
+    /// fragment needs, e.g. `dwarves` for CONFIG_DEBUG_INFO_BTF). Repeatable
+    /// and comma-separated.
+    #[arg(long = "kernel-builder-package", value_name = "PKG", value_delimiter = ',')]
+    pub kernel_builder_package: Vec<String>,
 }
 
 #[derive(clap::Args)]
@@ -85,6 +91,14 @@ pub struct BuildArgs {
         value_delimiter = ','
     )]
     pub package: Vec<String>,
+
+    /// Extra package to install in the kernel-builder tools tree (where the
+    /// custom kernel is compiled), not the final image. Repeatable and
+    /// comma-separated. Use for build-time tools a fragment needs — e.g.
+    /// `dwarves` (pahole) when the fragment enables CONFIG_DEBUG_INFO_BTF.
+    /// Twin of `--package`, routed to the kernel-builder mkosi run.
+    #[arg(long = "kernel-builder-package", value_name = "PKG", value_delimiter = ',')]
+    pub kernel_builder_package: Vec<String>,
 
     /// Optional kernel config fragment, merged after required + hardening
     /// when building the custom kernel. Omitted: steep's hardened baseline.


### PR DESCRIPTION
Adds `--kernel-builder-package <PKG>` (repeatable, comma-separated) — the twin of `--package`, but routed to the **kernel-builder tools tree** (where the custom kernel compiles) instead of the final image.

## Why

Some kernel config fragments need build-time tools that aren't in steep's minimal builder. Concretely: `CONFIG_DEBUG_INFO_BTF` `depends on PAHOLE_VERSION`, so generating BTF needs `dwarves` (pahole) in the builder. Without it the option silently can't be satisfied, BTF isn't produced, and eBPF CO-RE consumers (Cilium socket-LB → ClusterIP service translation) break in the guest.

`--package` only feeds the **base image** mkosi run, and there was no lever for the builder. This adds one.

## Design

Matches steep's documented philosophy — a flag that selects an image-owned declarative input, keeping steep fragment-agnostic (per the README's framing of `--package` / `--kernel-config-fragment`: "enable extra ... without modifying steep"). Off by default; the consuming image declares its builder packages (e.g. base-images rke2 lists them in a `kernel-builder-packages.txt` and passes them through). The alternative — hardcoding `dwarves` in steep's `mkosi/kernel-builder/mkosi.conf` — would make every image pay for a tool only some need, and is the non-declarative "modify steep per-image" move the README designs against.

Folded into the tools-tree cache stamp so a changed package list rebuilds the tree (the list arrives via flag, not `mkosi.conf`). All 32 lib tests pass.