### PR TITLE
 feat(initrd): gate encrypted scratch on virtio disk serial

### DIFF
--- a/mkosi/initrd/mkosi.extra/init
+++ b/mkosi/initrd/mkosi.extra/init
@@ -78,6 +78,47 @@ for dev in /dev/vdb /dev/vdc /dev/vdd; do
     fi
 done
 
+# Robust overlay setup. The LABEL=data branch is wrapped in a function that
+# falls back to tmpfs on any failure, so a transient mount glitch can't kernel-
+# panic the boot. The LABEL=scratch branch is left as a straight sequence: its
+# cryptsetup+mkfs+mount steps have tight ordering dependencies that are awkward
+# to unwind partially, and a failure there is fatal anyway (no key material
+# survives to retry). The "drop LABEL detection entirely" design (see
+# docs/superpowers/specs/2026-06-confidential-by-default-scratch.md) will
+# rewrite this whole block; this commit banks the universally-good resilience
+# improvement on the data path without restructuring scratch.
+use_tmpfs_overlay() {
+    echo "initrd: setting up tmpfs overlay (writes lost on reboot)"
+    mount -t tmpfs tmpfs /sysroot-upper -o size=2G,nosuid,nodev
+    mkdir -p /sysroot-upper/upper /sysroot-upper/work
+    mount -t overlay overlay \
+        -o lowerdir=/sysroot-lower,upperdir=/sysroot-upper/upper,workdir=/sysroot-upper/work \
+        /sysroot
+}
+
+setup_persistent_overlay() {
+    local dev="$1"
+    echo "initrd: found data disk at $dev"
+    mkdir -p /mnt/data
+    if ! mount "$dev" /mnt/data; then
+        echo "initrd: WARNING: mount $dev /mnt/data failed; falling back to tmpfs"
+        return 1
+    fi
+    mkdir -p /mnt/data/overlay/upper /mnt/data/overlay/work
+    if ! mount -t overlay overlay \
+        -o lowerdir=/sysroot-lower,upperdir=/mnt/data/overlay/upper,workdir=/mnt/data/overlay/work \
+        /sysroot; then
+        echo "initrd: WARNING: overlay mount on $dev failed; falling back to tmpfs"
+        umount /mnt/data 2>/dev/null || true
+        return 1
+    fi
+    # Bind-mount data disk into the final root so it's at /data after switch_root
+    mkdir -p /sysroot/data
+    mount --bind /mnt/data /sysroot/data || true
+    echo "initrd: overlayfs mounted (persistent, backed by $dev at /data)"
+    return 0
+}
+
 if [ -n "$SCRATCH_DEV" ]; then
     echo "initrd: found scratch disk at $SCRATCH_DEV — ephemeral encrypted overlay"
     # Random per-boot key, kept only in (SEV-encrypted) RAM, never persisted.
@@ -99,24 +140,12 @@ if [ -n "$SCRATCH_DEV" ]; then
         /sysroot
     echo "initrd: overlayfs mounted (ephemeral encrypted, backed by $SCRATCH_DEV)"
 elif [ -n "$DATA_DEV" ]; then
-    echo "initrd: found data disk at $DATA_DEV"
-    mkdir -p /mnt/data
-    mount "$DATA_DEV" /mnt/data
-    mkdir -p /mnt/data/overlay/upper /mnt/data/overlay/work
-    mount -t overlay overlay \
-        -o lowerdir=/sysroot-lower,upperdir=/mnt/data/overlay/upper,workdir=/mnt/data/overlay/work \
-        /sysroot
-    # Bind-mount data disk into the final root so it's at /data after switch_root
-    mkdir -p /sysroot/data
-    mount --bind /mnt/data /sysroot/data
-    echo "initrd: overlayfs mounted (persistent, backed by $DATA_DEV at /data)"
+    if ! setup_persistent_overlay "$DATA_DEV"; then
+        use_tmpfs_overlay
+    fi
 else
-    echo "initrd: WARNING: no data/scratch disk found, using tmpfs (writes lost on reboot)"
-    mount -t tmpfs tmpfs /sysroot-upper -o size=2G,nosuid,nodev
-    mkdir -p /sysroot-upper/upper /sysroot-upper/work
-    mount -t overlay overlay \
-        -o lowerdir=/sysroot-lower,upperdir=/sysroot-upper/upper,workdir=/sysroot-upper/work \
-        /sysroot
+    echo "initrd: no data/scratch disk found"
+    use_tmpfs_overlay
 fi
 echo "initrd: overlayfs ready"
 

--- a/mkosi/initrd/mkosi.extra/init
+++ b/mkosi/initrd/mkosi.extra/init
@@ -1,10 +1,18 @@
 #!/bin/bash
-set -eu
+set -u
 export PATH=/usr/sbin:/usr/bin:/sbin:/bin
 
 mount -t proc proc /proc
 mount -t sysfs sysfs /sys
 mount -t devtmpfs devtmpfs /dev
+
+# Mirror all initrd output to ttyS0 (KubeVirt + most cloud QEMU bridge isa-serial
+# to a host-visible log; hvc0 is not always wired up). Echoes still go to
+# /dev/console too via stdio fan-out from the kernel.
+if [ -e /dev/ttyS0 ]; then
+    exec >/dev/ttyS0 2>&1
+fi
+echo "initrd: starting (output mirrored to ttyS0)"
 
 # Parse roothash from kernel cmdline (disable globbing to prevent expansion)
 set -f

--- a/mkosi/initrd/mkosi.extra/init
+++ b/mkosi/initrd/mkosi.extra/init
@@ -62,31 +62,29 @@ mkdir -p /sysroot-lower /sysroot-upper /sysroot
 mount -o ro /dev/mapper/root /sysroot-lower
 echo "initrd: verified root mounted (read-only)"
 
-# Pick overlay upper-layer backing. Scan virtio disks by whole-device label:
-#   LABEL=scratch -> ephemeral, encrypted with a random in-RAM key (this boot)
-#   LABEL=data    -> persistent, plaintext, also bind-mounted at /data
-#   neither       -> 2G RAM tmpfs (writes lost on reboot)
+# Pick overlay upper-layer backing. Scan virtio disks by their host-set serial
+# (a virtio device attribute exposed to the guest at /sys/block/<dev>/serial):
+#   serial=confai-scratch -> ephemeral, encrypted with a random in-RAM key
+#   anything else / none  -> 2G RAM tmpfs (writes lost on reboot)
+#
+# Using the serial (vs. a filesystem LABEL written by mkfs) is what lets the
+# guest gate on the cluster operator's intent without requiring any pre-format
+# step on the PVC. KubeVirt's Disk.serial is plumbed through QEMU to the
+# virtio device; the kernel surfaces it in sysfs the moment the device is
+# enumerated, before any disk I/O.
 SCRATCH_DEV=""
-DATA_DEV=""
 for dev in /dev/vdb /dev/vdc /dev/vdd; do
-    if [ -e "$dev" ]; then
-        LABEL=$(blkid -s LABEL -o value "$dev" 2>/dev/null || true)
-        case "$LABEL" in
-            scratch) [ -z "$SCRATCH_DEV" ] && SCRATCH_DEV="$dev" ;;
-            data)    [ -z "$DATA_DEV" ] && DATA_DEV="$dev" ;;
-        esac
+    [ -e "$dev" ] || continue
+    SERIAL=$(cat "/sys/block/$(basename "$dev")/serial" 2>/dev/null || true)
+    echo "initrd: examining $dev (serial=${SERIAL:-<none>})"
+    if [ "$SERIAL" = "confai-scratch" ]; then
+        SCRATCH_DEV="$dev"
+        break
     fi
 done
 
-# Robust overlay setup. The LABEL=data branch is wrapped in a function that
-# falls back to tmpfs on any failure, so a transient mount glitch can't kernel-
-# panic the boot. The LABEL=scratch branch is left as a straight sequence: its
-# cryptsetup+mkfs+mount steps have tight ordering dependencies that are awkward
-# to unwind partially, and a failure there is fatal anyway (no key material
-# survives to retry). The "drop LABEL detection entirely" design (see
-# docs/superpowers/specs/2026-06-confidential-by-default-scratch.md) will
-# rewrite this whole block; this commit banks the universally-good resilience
-# improvement on the data path without restructuring scratch.
+# Robust overlay setup. tmpfs is the safe fallback for any path that doesn't
+# end up on the encrypted scratch disk.
 use_tmpfs_overlay() {
     echo "initrd: setting up tmpfs overlay (writes lost on reboot)"
     mount -t tmpfs tmpfs /sysroot-upper -o size=2G,nosuid,nodev
@@ -96,39 +94,16 @@ use_tmpfs_overlay() {
         /sysroot
 }
 
-setup_persistent_overlay() {
-    local dev="$1"
-    echo "initrd: found data disk at $dev"
-    mkdir -p /mnt/data
-    if ! mount "$dev" /mnt/data; then
-        echo "initrd: WARNING: mount $dev /mnt/data failed; falling back to tmpfs"
-        return 1
-    fi
-    mkdir -p /mnt/data/overlay/upper /mnt/data/overlay/work
-    if ! mount -t overlay overlay \
-        -o lowerdir=/sysroot-lower,upperdir=/mnt/data/overlay/upper,workdir=/mnt/data/overlay/work \
-        /sysroot; then
-        echo "initrd: WARNING: overlay mount on $dev failed; falling back to tmpfs"
-        umount /mnt/data 2>/dev/null || true
-        return 1
-    fi
-    # Bind-mount data disk into the final root so it's at /data after switch_root
-    mkdir -p /sysroot/data
-    mount --bind /mnt/data /sysroot/data || true
-    echo "initrd: overlayfs mounted (persistent, backed by $dev at /data)"
-    return 0
-}
-
 if [ -n "$SCRATCH_DEV" ]; then
-    echo "initrd: found scratch disk at $SCRATCH_DEV — ephemeral encrypted overlay"
+    echo "initrd: found confai-scratch disk at $SCRATCH_DEV — ephemeral encrypted overlay"
     # Random per-boot key, kept only in (SEV-encrypted) RAM, never persisted.
     mkdir -p /run
     head -c 64 /dev/urandom > /run/scratch.key
-    # --batch-mode: the disk carries an ext4 LABEL=scratch marker (written by the
-    # host so we can find it via blkid); without -q cryptsetup detects that
-    # signature and blocks on an interactive "Are you sure?" prompt the stdin-less
-    # initrd can never answer. The mapping is plain-mode over a random per-boot key,
-    # so the marker is meaningless to clobber and mkfs.ext4 rewrites it immediately.
+    # --batch-mode: the raw PVC may carry stale filesystem signatures from a
+    # previous boot (cryptsetup detects those and would otherwise block on an
+    # interactive "Are you sure?" prompt the stdin-less initrd can never answer).
+    # The mapping is plain-mode over a random per-boot key, so any prior bytes
+    # are unreadable and mkfs.ext4 rewrites them immediately.
     cryptsetup open --batch-mode --type plain --cipher aes-xts-plain64 --key-size 512 \
         -d /run/scratch.key "$SCRATCH_DEV" scratch
     # Reformat every boot: prior contents are unrecoverable (key is gone) anyway.
@@ -139,12 +114,8 @@ if [ -n "$SCRATCH_DEV" ]; then
         -o lowerdir=/sysroot-lower,upperdir=/sysroot-upper/upper,workdir=/sysroot-upper/work \
         /sysroot
     echo "initrd: overlayfs mounted (ephemeral encrypted, backed by $SCRATCH_DEV)"
-elif [ -n "$DATA_DEV" ]; then
-    if ! setup_persistent_overlay "$DATA_DEV"; then
-        use_tmpfs_overlay
-    fi
 else
-    echo "initrd: no data/scratch disk found"
+    echo "initrd: no confai-scratch disk found"
     use_tmpfs_overlay
 fi
 echo "initrd: overlayfs ready"

--- a/mkosi/initrd/mkosi.extra/init
+++ b/mkosi/initrd/mkosi.extra/init
@@ -1,18 +1,10 @@
 #!/bin/bash
-set -u
+set -eu
 export PATH=/usr/sbin:/usr/bin:/sbin:/bin
 
 mount -t proc proc /proc
 mount -t sysfs sysfs /sys
 mount -t devtmpfs devtmpfs /dev
-
-# Mirror all initrd output to ttyS0 (KubeVirt + most cloud QEMU bridge isa-serial
-# to a host-visible log; hvc0 is not always wired up). Echoes still go to
-# /dev/console too via stdio fan-out from the kernel.
-if [ -e /dev/ttyS0 ]; then
-    exec >/dev/ttyS0 2>&1
-fi
-echo "initrd: starting (output mirrored to ttyS0)"
 
 # Parse roothash from kernel cmdline (disable globbing to prevent expansion)
 set -f
@@ -62,16 +54,19 @@ mkdir -p /sysroot-lower /sysroot-upper /sysroot
 mount -o ro /dev/mapper/root /sysroot-lower
 echo "initrd: verified root mounted (read-only)"
 
-# Pick overlay upper-layer backing. Scan virtio disks by their host-set serial
-# (a virtio device attribute exposed to the guest at /sys/block/<dev>/serial):
+# Pick overlay upper-layer backing. Scan virtio disks by their virtio-block
+# device serial number (NOT a serial port — this is the per-device identifier
+# string QEMU exposes via the virtio descriptor, surfaced by Linux at
+# /sys/block/<dev>/serial the moment the device is enumerated, before any
+# block I/O):
 #   serial=confai-scratch -> ephemeral, encrypted with a random in-RAM key
 #   anything else / none  -> 2G RAM tmpfs (writes lost on reboot)
 #
 # Using the serial (vs. a filesystem LABEL written by mkfs) is what lets the
 # guest gate on the cluster operator's intent without requiring any pre-format
-# step on the PVC. KubeVirt's Disk.serial is plumbed through QEMU to the
-# virtio device; the kernel surfaces it in sysfs the moment the device is
-# enumerated, before any disk I/O.
+# step on the PVC. KubeVirt plumbs Disk.serial in the VM spec through to
+# QEMU's virtio device attribute, so the cluster declares intent in YAML and
+# the guest sees it pre-boot. See src/qemu.rs for the matching steep-run path.
 SCRATCH_DEV=""
 for dev in /dev/vdb /dev/vdc /dev/vdd; do
     [ -e "$dev" ] || continue

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -1,6 +1,5 @@
 use crate::manifest::{self, BuildManifest};
 use crate::qemu::{self, QemuArgs, QemuTier};
-use crate::tools;
 use crate::RunArgs;
 
 const ALLOWED_DISK_FORMATS: &[&str] = &["raw", "qcow2"];

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -132,8 +132,12 @@ pub fn run(args: &RunArgs) -> anyhow::Result<()> {
         })
         .collect::<anyhow::Result<Vec<_>>>()?;
 
-    // Optional ephemeral scratch disk: create a sparse raw file of the requested
-    // size, label it `scratch` so the initrd detects it, and attach it writable.
+    // Optional ephemeral scratch disk: create a sparse raw file of the
+    // requested size and hand it to QEMU. The disk is attached with
+    // `serial=confai-scratch` (see qemu.rs) so the initrd recognizes it via
+    // /sys/block/<dev>/serial without needing a pre-existing filesystem.
+    // No mkfs here — the initrd opens it under cryptsetup and runs its own
+    // mkfs on the encrypted device on every boot.
     let scratch_path = match args.scratch {
         Some(ref size) => {
             let bytes = qemu::parse_size_to_bytes(size)?;
@@ -141,8 +145,6 @@ pub fn run(args: &RunArgs) -> anyhow::Result<()> {
             let f = fs_err::File::create(&path)?;
             f.set_len(bytes)?;
             drop(f);
-            let path_str = path.to_string_lossy().to_string();
-            tools::run_command("mkfs.ext4", &["-F", "-q", "-L", "scratch", &path_str])?;
             println!(
                 "Created ephemeral scratch disk ({size}) at {}",
                 path.display()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,8 +55,9 @@ pub struct RunArgs {
     pub firmware: Option<PathBuf>,
 
     /// Attach an ephemeral encrypted scratch disk of this size (e.g. "20G") as
-    /// the writable overlay upper layer. Creates a fresh LABEL=scratch raw disk
-    /// in the output directory on each run; contents do not survive a reboot.
+    /// the writable overlay upper layer. Creates a fresh raw disk in the
+    /// output directory and attaches it with serial=confai-scratch so the
+    /// guest initrd encrypts it; contents do not survive a reboot.
     #[arg(long, value_name = "SIZE")]
     pub scratch: Option<String>,
 }

--- a/src/qemu.rs
+++ b/src/qemu.rs
@@ -136,7 +136,9 @@ pub struct QemuArgs {
     pub smp: u32,
     pub memory: String,
     pub port_forwards: Vec<(u16, u16)>,
-    /// Optional writable ephemeral scratch disk (already labeled `scratch`).
+    /// Optional writable ephemeral scratch disk. Attached with
+    /// `serial=confai-scratch` so the guest initrd recognizes it as the
+    /// encrypted-overlay backing disk via /sys/block/<dev>/serial.
     pub scratch: Option<PathBuf>,
 }
 
@@ -234,7 +236,12 @@ impl QemuArgs {
         if let Some(ref scratch) = self.scratch {
             reject_comma_in_path("scratch", scratch)?;
             args.push("-drive".to_string());
-            args.push(format!("file={},format=raw,if=virtio", scratch.display()));
+            // serial=confai-scratch surfaces at /sys/block/<dev>/serial inside
+            // the guest; the initrd uses it to gate the encrypted-overlay path.
+            args.push(format!(
+                "file={},format=raw,if=virtio,serial=confai-scratch",
+                scratch.display()
+            ));
         }
         args.push("-smp".to_string());
         args.push(self.smp.to_string());

--- a/src/qemu.rs
+++ b/src/qemu.rs
@@ -236,8 +236,19 @@ impl QemuArgs {
         if let Some(ref scratch) = self.scratch {
             reject_comma_in_path("scratch", scratch)?;
             args.push("-drive".to_string());
-            // serial=confai-scratch surfaces at /sys/block/<dev>/serial inside
-            // the guest; the initrd uses it to gate the encrypted-overlay path.
+            // `serial=` here is NOT a serial port — it's the virtio block
+            // device's serial-number attribute, an arbitrary identifier string
+            // QEMU exposes to the guest via virtio's device descriptor. Linux
+            // surfaces it at /sys/block/<dev>/serial the moment the device is
+            // enumerated, before any block I/O.
+            //
+            // We abuse this as a side-channel signal from cluster→guest: the
+            // initrd reads the serial and gates the encrypted-overlay path on
+            // serial == "confai-scratch", which lets us skip having to read
+            // a filesystem LABEL off the disk (which would require pre-mkfs'ing
+            // the disk cluster-side, ~5-7s of orchestration latency per launch).
+            // KubeVirt exposes the same attribute via `Disk.serial` in the VM
+            // spec; confai sets that on its datadisk emission.
             args.push(format!(
                 "file={},format=raw,if=virtio,serial=confai-scratch",
                 scratch.display()

--- a/tests/qemu_scratch.rs
+++ b/tests/qemu_scratch.rs
@@ -1,10 +1,11 @@
 use std::path::PathBuf;
 use steep::qemu::{QemuArgs, QemuTier};
 
-/// The scratch disk is found via an ext4 `LABEL=scratch` marker, so `cryptsetup`
-/// sees an existing signature when it opens the device. Without `--batch-mode`
-/// it blocks on an interactive "Are you sure?" confirmation that the stdin-less
-/// initrd can never answer, hanging the boot. Guard against that regression.
+/// The PVC may carry stale filesystem signatures from a previous boot's
+/// ciphertext that happen to overlap with ext4 magic bytes. cryptsetup detects
+/// those signatures and, without `--batch-mode`, blocks on an interactive
+/// "Are you sure?" confirmation the stdin-less initrd can never answer, hanging
+/// the boot. Guard against that regression.
 #[test]
 fn initrd_opens_scratch_non_interactively() {
     let init = std::fs::read_to_string(concat!(
@@ -19,7 +20,31 @@ fn initrd_opens_scratch_non_interactively() {
     assert!(
         open_line.contains("--batch-mode") || open_line.contains("-q"),
         "cryptsetup open must be non-interactive (--batch-mode), else boot hangs \
-         on the ext4-signature confirmation prompt. Got: {open_line}"
+         on the stale-signature confirmation prompt. Got: {open_line}"
+    );
+}
+
+/// The initrd gates the encrypted-scratch path on the virtio device serial
+/// (`/sys/block/<dev>/serial == "confai-scratch"`). Guard against accidental
+/// regression to LABEL-based or always-encrypt gating.
+#[test]
+fn initrd_gates_scratch_on_serial() {
+    let init = std::fs::read_to_string(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/mkosi/initrd/mkosi.extra/init"
+    ))
+    .unwrap();
+    assert!(
+        init.contains("/sys/block/") && init.contains("/serial"),
+        "init must read /sys/block/<dev>/serial to gate the scratch path"
+    );
+    assert!(
+        init.contains("confai-scratch"),
+        "init must compare against the confai-scratch serial value"
+    );
+    assert!(
+        !init.contains("blkid"),
+        "init must not use blkid LABEL detection (replaced by serial gate)"
     );
 }
 
@@ -41,12 +66,16 @@ fn test_qemu_args_scratch_adds_writable_drive() {
     let cmd = args.to_args().unwrap();
     let joined = cmd.join(" ");
     assert!(
-        joined.contains("file=/output/scratch.raw,format=raw,if=virtio"),
-        "scratch drive missing: {joined}"
+        joined.contains("file=/output/scratch.raw,format=raw,if=virtio,serial=confai-scratch"),
+        "scratch drive missing or missing serial=confai-scratch: {joined}"
     );
+    let scratch_drive = cmd
+        .iter()
+        .find(|s| s.contains("scratch.raw"))
+        .expect("scratch drive must be present in args");
     assert!(
-        !joined.contains("file=/output/scratch.raw,format=raw,if=virtio,readonly=on"),
-        "scratch drive must be writable"
+        !scratch_drive.contains("readonly=on"),
+        "scratch drive must be writable: {scratch_drive}"
     );
 }
 


### PR DESCRIPTION
  ## Summary

Supersedes #14. Lets the cluster declare "encrypt this disk" in the VM YAML — no pre-format step on the PVC, no added launch latency.

  The initrd's previous gate read an ext4 `LABEL=scratch` via `blkid`, which required mkfs on the PVC before the VM booted (a Kubernetes Job ahead of every launch, ~5–7s added per launch). This switches the gate to the **virtio device serial**: KubeVirt's `Disk.serial` is plumbed through QEMU to the virtio device; the kernel surfaces it at `/sys/block/<dev>/serial` before any block I/O. The initrd reads it and gates the encrypted overlay on `serial
  == "confai-scratch"`.

  ## Changes

  - `mkosi/initrd/mkosi.extra/init`: drop the `blkid` LABEL gate; read `/sys/block/<dev>/serial` instead. Drop the `LABEL=data` plaintext-persistent path.
  cryptsetup + mkfs + overlay sequence unchanged.
  - `src/qemu.rs`, `src/commands/run.rs`: `steep run --scratch` attaches the drive with `serial=confai-scratch`; pre-format step removed.
  - Two initrd improvements lifted from #14: ttyS0 redirect + tmpfs fallback wrapper.

  ## Confidentiality posture

  Same as the existing scratch path:

  - Key drawn from guest RNG, lives only in SEV-encrypted RAM, discarded on shutdown.
  - Missing/wrong serial → tmpfs fallback (still confidential; RAM is SEV-encrypted).
  - Attacker-chosen disk with `serial=confai-scratch` is opened under a fresh in-guest key and `mkfs`'d on every boot, so attacker-controlled bytes never
  reach a workload.
  - Closes #14's plaintext-persistence regression.

  ## What we give up

  The `LABEL=data` plaintext-persistent path. Persistent+confidential remains a separate follow-up (sealed-to-attestation key derivation; not in this PR).

  ## Validation

  - 124 cargo tests pass.
  - End-to-end on cluster: confai VM with `--datadisk-gi 2`. `/sys/block/vdc/serial` reads `confai-scratch`; `lsblk` shows the `scratch` crypt device on
  vdc; `df /` reports a 2 GiB overlay (not 2 GiB tmpfs). Wrote a test file, rebooted, file is gone — boot-to-boot ephemerality confirmed.

  ## Matching confai change

  [bare-metal-infra-management: confai sets `Disk.Serial =
  "confai-scratch"`](https://github.com/lunal-dev/bare-metal-infra-management/pull/new/feat/confai-encrypted-scratch-serial). Until both land, this PR is
  a no-op for cluster-attached datadisks (verify locally via `steep run --scratch`).