### PR TITLE
tmp(mkosi): switch snapshot repo to archive repo

### DIFF
--- a/mkosi/kernel-builder/mkosi.conf
+++ b/mkosi/kernel-builder/mkosi.conf
@@ -6,14 +6,15 @@ Architecture=x86-64
 Distribution=ubuntu
 Release=resolute
 Repositories=universe
-Mirror=https://snapshot.ubuntu.com/ubuntu/20260405T000000Z
+# TEMP(2026-07-06): snapshot.ubuntu.com outage — undo both mirrors to https://snapshot.ubuntu.com/ubuntu/20260405T000000Z
+Mirror=https://archive.ubuntu.com/ubuntu
 
 [Build]
 Incremental=false
 ToolsTree=default
 ToolsTreeDistribution=ubuntu
 ToolsTreeRelease=resolute
-ToolsTreeMirror=https://snapshot.ubuntu.com/ubuntu/20260405T000000Z
+ToolsTreeMirror=https://archive.ubuntu.com/ubuntu
 
 [Content]
 Bootable=false


### PR DESCRIPTION
as snapshot.ubuntu.com backends have been 503ing since 2026-07-04. builds