### PR TITLE
feat(tdx-measure): add direct-kernel boot mode

### DIFF
--- a/crates/tdx-measure/src/main.rs
+++ b/crates/tdx-measure/src/main.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use std::str;
 
 use anyhow::{bail, Context, Result};
-use clap::{Parser, Subcommand};
+use clap::{Parser, Subcommand, ValueEnum};
 
 use tdx_measure::{ccel, pe, rtmr, tdvf};
 
@@ -15,13 +15,37 @@ struct Cli {
     command: Commands,
 }
 
+/// Which boot model to measure. Both are OVMF/TDVF firmware; they differ in
+/// how the kernel is loaded and therefore in the RTMR[1]/RTMR[2] event chain.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, ValueEnum)]
+enum BootMode {
+    /// steep UKI boot: TDVF -> systemd-boot -> Unified Kernel Image.
+    Uki,
+    /// TDVF direct kernel boot (`-kernel`/`-append`), e.g. kata-qemu-tdx.
+    /// Not kata-specific — any direct-booted guest under TDVF measures this way.
+    DirectKernel,
+}
+
 #[derive(Subcommand)]
 enum Commands {
-    /// Compute expected TDX measurements from a UKI file
+    /// Compute expected TDX measurements for a UKI or direct-kernel boot
     Measure {
-        /// Path to the UKI EFI binary
+        /// Boot model to measure (default: uki)
+        #[arg(long, value_enum, default_value_t = BootMode::Uki)]
+        boot_mode: BootMode,
+
+        /// Path to the UKI EFI binary (required for --boot-mode uki)
         #[arg(long)]
-        uki: PathBuf,
+        uki: Option<PathBuf>,
+
+        /// Path to the kernel PE / bzImage (required for --boot-mode direct-kernel)
+        #[arg(long)]
+        kernel: Option<PathBuf>,
+
+        /// File containing the exact kernel command line, i.e. qemu's `-append`
+        /// value (required for --boot-mode direct-kernel)
+        #[arg(long)]
+        cmdline_file: Option<PathBuf>,
 
         /// Path to the OVMF/TDVF firmware binary
         #[arg(long)]
@@ -110,7 +134,10 @@ fn main() -> Result<()> {
 
     match cli.command {
         Commands::Measure {
+            boot_mode,
             uki,
+            kernel,
+            cmdline_file,
             firmware,
             disk,
             memory,
@@ -122,7 +149,10 @@ fn main() -> Result<()> {
             boot_vars,
             json,
         } => cmd_measure(
-            &uki,
+            boot_mode,
+            uki.as_deref(),
+            kernel.as_deref(),
+            cmdline_file.as_deref(),
             firmware.as_deref(),
             disk.as_deref(),
             &memory,
@@ -144,8 +174,92 @@ fn main() -> Result<()> {
     }
 }
 
+/// Measure a TDVF **direct kernel boot** (`-kernel`/`-append`), e.g. the guest
+/// launched by `kata-qemu-tdx`. Only MRTD, RTMR[1] and RTMR[2] are verifiable;
+/// RTMR[0] encodes ACPI/memory/vCPU config and is intentionally not checked,
+/// and RTMR[3] is left for a runtime workload measurement.
+fn cmd_measure_direct_kernel(
+    kernel_path: Option<&Path>,
+    cmdline_file: Option<&Path>,
+    firmware_path: Option<&Path>,
+    json: bool,
+) -> Result<()> {
+    let kernel_path =
+        kernel_path.context("--kernel is required for --boot-mode direct-kernel")?;
+    let cmdline_path =
+        cmdline_file.context("--cmdline-file is required for --boot-mode direct-kernel")?;
+
+    let kernel = fs::read(kernel_path)
+        .with_context(|| format!("Failed to read kernel: {}", kernel_path.display()))?;
+    let cmdline_raw = fs::read_to_string(cmdline_path)
+        .with_context(|| format!("Failed to read cmdline: {}", cmdline_path.display()))?;
+    // qemu's `-append` is a single line; drop a trailing newline the file may
+    // carry (the measured LoadOptions do not include it).
+    let cmdline = cmdline_raw.strip_suffix('\n').unwrap_or(&cmdline_raw);
+
+    let rtmr1 = rtmr::compute_rtmr1_direct_kernel(&kernel)?;
+    let rtmr2 = rtmr::compute_rtmr2_direct_kernel(cmdline);
+
+    let mrtd = match firmware_path {
+        Some(fw) => {
+            let fw_data = fs::read(fw)
+                .with_context(|| format!("Failed to read firmware: {}", fw.display()))?;
+            let t = tdvf::Tdvf::parse(&fw_data).context("Failed to parse TDVF metadata")?;
+            Some(t.mrtd().context("Failed to compute MRTD")?)
+        }
+        None => None,
+    };
+
+    if json {
+        let mut result = serde_json::Map::new();
+        result.insert(
+            "boot_mode".into(),
+            serde_json::Value::String("direct-kernel".into()),
+        );
+        if let Some(ref m) = mrtd {
+            result.insert("mrtd".into(), serde_json::Value::String(hex::encode(m)));
+        }
+        result.insert("rtmr1".into(), serde_json::Value::String(hex::encode(&rtmr1)));
+        result.insert("rtmr2".into(), serde_json::Value::String(hex::encode(&rtmr2)));
+        result.insert(
+            "rtmr3".into(),
+            serde_json::Value::String(hex::encode([0u8; 48])),
+        );
+        result.insert(
+            "rtmr0_note".into(),
+            serde_json::Value::String(
+                "not computed: RTMR[0] encodes ACPI/memory/vCPU config and is not verified".into(),
+            ),
+        );
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&serde_json::Value::Object(result))?
+        );
+    } else {
+        eprintln!("Boot model: direct-kernel (TDVF -kernel/-append)");
+        eprintln!("Kernel:  {} ({} bytes)", kernel_path.display(), kernel.len());
+        eprintln!("Cmdline: {} chars\n", cmdline.len());
+
+        println!("=== TDX Measurements (direct-kernel) ===\n");
+        match mrtd {
+            Some(ref m) => println!("MRTD:    {}", hex::encode(m)),
+            None => println!("MRTD:    (provide --firmware to compute)"),
+        }
+        println!("RTMR[0]: (not verified -- encodes ACPI/memory/vCPU config)");
+        println!("RTMR[1]: {}", hex::encode(&rtmr1));
+        println!("RTMR[2]: {}", hex::encode(&rtmr2));
+        println!("RTMR[3]: {}", hex::encode([0u8; 48]));
+    }
+
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
 fn cmd_measure(
-    uki_path: &Path,
+    boot_mode: BootMode,
+    uki_path: Option<&Path>,
+    kernel_path: Option<&Path>,
+    cmdline_file: Option<&Path>,
     firmware_path: Option<&Path>,
     disk_path: Option<&Path>,
     memory: &str,
@@ -157,6 +271,11 @@ fn cmd_measure(
     boot_vars_dir: Option<&Path>,
     json: bool,
 ) -> Result<()> {
+    if boot_mode == BootMode::DirectKernel {
+        return cmd_measure_direct_kernel(kernel_path, cmdline_file, firmware_path, json);
+    }
+
+    let uki_path = uki_path.context("--uki is required for --boot-mode uki")?;
     let uki_data = fs::read(uki_path)
         .with_context(|| format!("Failed to read UKI: {}", uki_path.display()))?;
 

--- a/crates/tdx-measure/src/rtmr.rs
+++ b/crates/tdx-measure/src/rtmr.rs
@@ -29,6 +29,47 @@ fn measure_log(log: &[Vec<u8>]) -> Vec<u8> {
     mr
 }
 
+/// Compute RTMR[1] for a **TDVF direct kernel boot** (`-kernel`/`-append`).
+///
+/// TDVF direct-loads a single kernel PE — there is no systemd-boot stage and
+/// no GPT event, unlike the UKI path modelled by [`compute_rtmr1_uki`]. This is
+/// firmware behavior, independent of the orchestrator (kata, libvirt, raw QEMU
+/// all measure identically). The 5-event chain below was traced from a live
+/// CCEL and validated byte-for-byte against a `kata-guest-base` TDX quote
+/// (2026-07-08):
+///   1. `EV_EFI_BOOT_SERVICES_APPLICATION` = Authenticode(kernel PE)
+///   2. `EV_EFI_ACTION` "Calling EFI Application from Boot Option"
+///   3. `EV_SEPARATOR` (0x00000000)
+///   4. `EV_EFI_ACTION` "Exit Boot Services Invocation"
+///   5. `EV_EFI_ACTION` "Exit Boot Services Returned with Success"
+pub fn compute_rtmr1_direct_kernel(kernel: &[u8]) -> Result<Vec<u8>> {
+    let log = vec![
+        crate::pe::authenticode_sha384(kernel)
+            .context("Authenticode hash of direct-boot kernel PE")?,
+        sha384(b"Calling EFI Application from Boot Option"),
+        sha384(&[0x00, 0x00, 0x00, 0x00]), // EV_SEPARATOR
+        sha384(b"Exit Boot Services Invocation"),
+        sha384(b"Exit Boot Services Returned with Success"),
+    ];
+    Ok(measure_log(&log))
+}
+
+/// Compute RTMR[2] for a **TDVF direct kernel boot**.
+///
+/// TDVF measures the kernel command line as a single `EV_EVENT_TAG`
+/// (`LOADED_IMAGE::LoadOptions`). The extended digest is the SHA-384 of the
+/// cmdline encoded as **UTF-16LE with a trailing NUL** (the UEFI LoadOptions
+/// representation) — NOT the UKI section measurements of [`compute_rtmr2_uki`].
+/// Validated byte-for-byte against a `kata-guest-base` TDX quote.
+pub fn compute_rtmr2_direct_kernel(cmdline: &str) -> Vec<u8> {
+    let mut load_options: Vec<u8> = cmdline
+        .encode_utf16()
+        .flat_map(|u| u.to_le_bytes())
+        .collect();
+    load_options.extend_from_slice(&[0x00, 0x00]); // UTF-16LE NUL terminator
+    measure_log(&[sha384(&load_options)])
+}
+
 /// Compute RTMR[1] for UKI boot on TDX.
 ///
 /// **The real boot chain is `TDVF → systemd-boot → UKI`.** TDVF loads
@@ -382,6 +423,19 @@ mod tests {
         assert_eq!(
             hex::encode(&h),
             "59e1748777448c69de6b800d7a33bbfb9ff1b463e44354c3553bcdb9c666fa90125a3c79f90397bdf5f6a13de828684f"
+        );
+    }
+
+    #[test]
+    fn test_rtmr2_direct_kernel_golden() {
+        // Byte-exact cmdline and resulting RTMR[2] from a live kata-guest-base
+        // TDX quote (tdx-dev-host-1, 2026-07-08). Guards the direct-kernel
+        // LoadOptions encoding (UTF-16LE + NUL) against regressions.
+        let cmdline = r#"tsc=reliable no_timer_check rcupdate.rcu_expedited=1 i8042.direct=1 i8042.dumbkbd=1 i8042.nopnp=1 i8042.noaux=1 noreplace-smp reboot=k cryptomgr.notests net.ifnames=0 pci=lastbus=0 dm-mod.create="dm-verity,,,ro,0 772096 verity 1 /dev/vda1 /dev/vda2 4096 4096 96512 0 sha256 768cd7e848f6cb7eb4f59467b26ee5c5e45ece570cb96a5c952d97dbc89bb150 63f8dacc786bd19f307be8668c7792a8fe07818df4aae55b63e76c4931d35c76" root=/dev/dm-0 rootflags=data=ordered,errors=remount-ro ro rootfstype=ext4 console=hvc0 console=hvc1 quiet systemd.show_status=false panic=1 nr_cpus=1 selinux=0 systemd.unit=kata-containers.target systemd.mask=systemd-networkd.service systemd.mask=systemd-networkd.socket scsi_mod.scan=none agent.launch_process_timeout=6 cgroup_no_v1=all systemd.unified_cgroup_hierarchy=1"#;
+        let rtmr2 = compute_rtmr2_direct_kernel(cmdline);
+        assert_eq!(
+            hex::encode(&rtmr2),
+            "b595f9f179d8b699d1420000d36c1fba82e9853545e719caa6ddbb82fa2041a23b4459876af4a253a1c20c5956529b9a"
         );
     }
 


### PR DESCRIPTION
Teaches tdx-measure to compute and verify MRTD + RTMR[0-2] for kata's direct-kernel boot shape (bare vmlinuz plus dm-verity rootfs, no UKI and no IGVM).

Why
The existing tdx-measure crate only assumed a UKI/IGVM self-booting image, where the whole bootable blob is measured as one unit. Kata does measured direct-kernel boot instead: the VMM loads a bare vmlinuz and hands it a dm-verity rootfs, and the launch measurements are built up differently across MRTD and the early RTMRs. A verifier that only understands the UKI/IGVM shape cannot reproduce those values, so it cannot independently confirm what launched. This PR adds an offline recomputation path for the direct-kernel shape so the verify side can check a quote without trusting the host.

What it computes
- MRTD: the build-time measurement of the initial TD memory.
- RTMR[0-2]: the early boot measurements as accumulated for the direct-kernel path.
This is verify-side only: it recomputes expected values from known inputs and compares against the register values in a hardware quote.

Changes (2 files)
- crates/tdx-measure/src/main.rs: CLI wiring for the direct-kernel mode.
- crates/tdx-measure/src/rtmr.rs: the measurement/extend logic for the direct-kernel boot shape.

Testing
Validated byte-for-byte against live hardware quotes captured from tdx-dev-host-1. Computed MRTD and RTMR[0-2] match the quoted register values exactly.

Dependencies
None. Independent verify-side tooling. Stacked under it is the RTMR[3] workload-measurement PR (feat/tdx-measure-rtmr3-workload).