### PR TITLE
fix(CI): log into oras before pushing with it

### DIFF
--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -58,13 +58,6 @@ jobs:
       - name: Setup ORAS
         uses: oras-project/setup-oras@v1
 
-      - name: Login to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Push to GHCR
         run: |
           SHORT_SHA="${GITHUB_SHA::7}"
@@ -79,6 +72,8 @@ jobs:
           # prevent symlink from becoming a second copy of the image
           rm image
 
+          echo ${{ secrets.GITHUB_TOKEN }} | oras login ghcr.io \
+            -u ${{ github.actor }} --password-stdin
           oras push "${IMAGE}:base,base-${SHORT_SHA}" \
             --artifact-type application/vnd.steep.base.v1 \
             ./*


### PR DESCRIPTION
## What problem does this change solve?

CI job to build and push the base image was failing with a permissions error.

## Why is this solution the best option to solve that problem?

The CI job is able to push the image now, as tested directly on this branch before merging.
