### PR TITLE
feat(kernel): verify fragment off-requests; make hardening off-requests effective

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,3 +18,5 @@
       in [docs/ARCHITECTURE.md](https://github.com/confidential-dot-ai/confidential-os-builder/blob/main/docs/ARCHITECTURE.md))
 - [ ] If this changes the kernel config: `kernel/config-x86_64.snapshot`
       diff is committed and reviewed
+- [ ] If this bumps `kernel/version`: re-verify every
+      `# CONFIG_X is forced on` forcing chain against the new Kconfig

--- a/kernel/hardening.config
+++ b/kernel/hardening.config
@@ -58,14 +58,15 @@ CONFIG_VIRTIO_CONSOLE=y
 # CONFIG_HOTPLUG_PCI_PCIE is not set
 # CONFIG_PCI_QUIRKS is not set
 # CONFIG_PCI_IOV is not set
-# Promptless symbols select'ed by the enabled IOMMU/PCI stack (an off
-# request can never win); pinned so fragment-verify catches the forced
-# state ever changing.
-CONFIG_PCI_ATS=y
-CONFIG_PCI_PRI=y
-CONFIG_PCI_PASID=y
-CONFIG_PCI_LABEL=y
-CONFIG_IOMMU_SVA=y
+# Wanted off, but forced =y by the enabled stack (AMD_IOMMU selects
+# ATS/PRI/PASID/IOMMU_SVA; PCI_LABEL is def_bool y under ACPI), so an off
+# request can never win. Asserted, not pinned: the build fails if the
+# forcing ever goes away, and then these become real off requests.
+# CONFIG_PCI_ATS is forced on
+# CONFIG_PCI_PRI is forced on
+# CONFIG_PCI_PASID is forced on
+# CONFIG_PCI_LABEL is forced on
+# CONFIG_IOMMU_SVA is forced on
 
 # RDRAND-trusted RNG (no virtio-rng): nothing to set on kernel 6.16.
 # ARCH_RANDOM was removed in 5.19 (arch RNG support is unconditional) and
@@ -89,12 +90,12 @@ CONFIG_SLAB_FREELIST_HARDENED=y
 
 # ACPI minimization
 # CONFIG_ACPI_DOCK is not set
-# ACPI_PROCESSOR is select'ed by X86_INTEL_PSTATE (dragged in by
-# SCHED_MC_PRIO, default y), and X86 selects ACPI_HOTPLUG_CPU while
-# ACPI_PROCESSOR and HOTPLUG_CPU are on (off requests can never win);
-# pinned so fragment-verify catches the forced state ever changing.
-CONFIG_ACPI_PROCESSOR=y
-CONFIG_ACPI_HOTPLUG_CPU=y
+# Wanted off, but ACPI_PROCESSOR is select'ed by X86_INTEL_PSTATE (dragged
+# in by SCHED_MC_PRIO, default y) and X86 selects ACPI_HOTPLUG_CPU while
+# ACPI_PROCESSOR and HOTPLUG_CPU are on, so off requests can never win.
+# Asserted, not pinned: the build fails if the forcing ever goes away.
+# CONFIG_ACPI_PROCESSOR is forced on
+# CONFIG_ACPI_HOTPLUG_CPU is forced on
 # CONFIG_ACPI_HOTPLUG_MEMORY is not set
 # CONFIG_ACPI_CUSTOM_DSDT is not set
 # CONFIG_ACPI_DEBUG is not set

--- a/kernel/hardening.config
+++ b/kernel/hardening.config
@@ -40,7 +40,7 @@ CONFIG_VIRTIO_CONSOLE=y
 # CONFIG_SOUND is not set
 # CONFIG_DRM is not set
 # CONFIG_WIRELESS is not set
-# WLAN (drivers/net/wireless, =y in defconfig) selects WIRELESS, and
+# WLAN (drivers/net/wireless, defaults y in Kconfig) selects WIRELESS, and
 # CFG80211/MAC80211 are =y children under `if WIRELESS` — unset all three
 # or olddefconfig flips WIRELESS back on.
 # CONFIG_WLAN is not set
@@ -59,9 +59,9 @@ CONFIG_VIRTIO_CONSOLE=y
 # CONFIG_PCI_QUIRKS is not set
 # CONFIG_PCI_IOV is not set
 # Wanted off, but forced =y by the enabled stack (AMD_IOMMU selects
-# ATS/PRI/PASID/IOMMU_SVA; PCI_LABEL is def_bool y under ACPI), so an off
-# request can never win. Asserted, not pinned: the build fails if the
-# forcing ever goes away, and then these become real off requests.
+# ATS/PRI/PASID/IOMMU_SVA; PCI_LABEL is def_bool y under ACPI or DMI), so
+# an off request can never win. Asserted, not pinned: the build fails if
+# the forcing ever goes away, and then these become real off requests.
 # CONFIG_PCI_ATS is forced on
 # CONFIG_PCI_PRI is forced on
 # CONFIG_PCI_PASID is forced on
@@ -106,8 +106,8 @@ CONFIG_SLAB_FREELIST_HARDENED=y
 # Port-IO surface reduction (legacy devices off; switching console to hvc0)
 # CONFIG_SERIAL_8250 is not set
 # CONFIG_KEYBOARD_ATKBD is not set
-# MOUSE_PS2 (=y in defconfig) selects SERIO_I8042; unset it so the i8042
-# off request below can take effect.
+# MOUSE_PS2 (defaults y in Kconfig) selects SERIO_I8042; unset it so the
+# i8042 off request below can take effect.
 # CONFIG_MOUSE_PS2 is not set
 # CONFIG_SERIO_I8042 is not set
 # CONFIG_RTC_DRV_CMOS is not set

--- a/kernel/hardening.config
+++ b/kernel/hardening.config
@@ -89,8 +89,9 @@ CONFIG_SLAB_FREELIST_HARDENED=y
 
 # ACPI minimization
 # CONFIG_ACPI_DOCK is not set
-# ACPI_PROCESSOR is select'ed by X86_ACPI_CPUFREQ (=y in defconfig) and
-# drags ACPI_HOTPLUG_CPU (def_bool) with it (off requests can never win);
+# ACPI_PROCESSOR is select'ed by X86_INTEL_PSTATE (dragged in by
+# SCHED_MC_PRIO, default y), and X86 selects ACPI_HOTPLUG_CPU while
+# ACPI_PROCESSOR and HOTPLUG_CPU are on (off requests can never win);
 # pinned so fragment-verify catches the forced state ever changing.
 CONFIG_ACPI_PROCESSOR=y
 CONFIG_ACPI_HOTPLUG_CPU=y

--- a/kernel/hardening.config
+++ b/kernel/hardening.config
@@ -60,12 +60,17 @@ CONFIG_VIRTIO_CONSOLE=y
 # CONFIG_PCI_IOV is not set
 # Wanted off, but forced =y by the enabled stack (AMD_IOMMU selects
 # ATS/PRI/PASID/IOMMU_SVA; PCI_LABEL is def_bool y under ACPI or DMI), so
-# an off request can never win. Asserted, not pinned: the build fails if
-# the forcing ever goes away, and then these become real off requests.
+# these off requests cannot win today. The assertion metadata makes the
+# build fail if a forcing condition goes away and an off request takes effect.
+# CONFIG_PCI_ATS is not set
 # CONFIG_PCI_ATS is forced on
+# CONFIG_PCI_PRI is not set
 # CONFIG_PCI_PRI is forced on
+# CONFIG_PCI_PASID is not set
 # CONFIG_PCI_PASID is forced on
+# CONFIG_PCI_LABEL is not set
 # CONFIG_PCI_LABEL is forced on
+# CONFIG_IOMMU_SVA is not set
 # CONFIG_IOMMU_SVA is forced on
 
 # RDRAND-trusted RNG (no virtio-rng): nothing to set on kernel 6.16.
@@ -93,8 +98,10 @@ CONFIG_SLAB_FREELIST_HARDENED=y
 # Wanted off, but ACPI_PROCESSOR is select'ed by X86_INTEL_PSTATE (dragged
 # in by SCHED_MC_PRIO, default y) and X86 selects ACPI_HOTPLUG_CPU while
 # ACPI_PROCESSOR and HOTPLUG_CPU are on, so off requests can never win.
-# Asserted, not pinned: the build fails if the forcing ever goes away.
+# Assertion metadata makes the build fail if either off request takes effect.
+# CONFIG_ACPI_PROCESSOR is not set
 # CONFIG_ACPI_PROCESSOR is forced on
+# CONFIG_ACPI_HOTPLUG_CPU is not set
 # CONFIG_ACPI_HOTPLUG_CPU is forced on
 # CONFIG_ACPI_HOTPLUG_MEMORY is not set
 # CONFIG_ACPI_CUSTOM_DSDT is not set

--- a/kernel/hardening.config
+++ b/kernel/hardening.config
@@ -58,8 +58,14 @@ CONFIG_VIRTIO_CONSOLE=y
 # CONFIG_HOTPLUG_PCI_PCIE is not set
 # CONFIG_PCI_QUIRKS is not set
 # CONFIG_PCI_IOV is not set
-# PCI_ATS/PRI/PASID, PCI_LABEL, IOMMU_SVA: promptless symbols select'ed by
-# the enabled IOMMU/PCI stack — an off request can never win; they stay =y.
+# Promptless symbols select'ed by the enabled IOMMU/PCI stack (an off
+# request can never win); pinned so fragment-verify catches the forced
+# state ever changing.
+CONFIG_PCI_ATS=y
+CONFIG_PCI_PRI=y
+CONFIG_PCI_PASID=y
+CONFIG_PCI_LABEL=y
+CONFIG_IOMMU_SVA=y
 
 # RDRAND-trusted RNG (no virtio-rng): nothing to set on kernel 6.16.
 # ARCH_RANDOM was removed in 5.19 (arch RNG support is unconditional) and
@@ -84,7 +90,10 @@ CONFIG_SLAB_FREELIST_HARDENED=y
 # ACPI minimization
 # CONFIG_ACPI_DOCK is not set
 # ACPI_PROCESSOR is select'ed by X86_ACPI_CPUFREQ (=y in defconfig) and
-# drags ACPI_HOTPLUG_CPU (def_bool) with it — off requests can never win.
+# drags ACPI_HOTPLUG_CPU (def_bool) with it (off requests can never win);
+# pinned so fragment-verify catches the forced state ever changing.
+CONFIG_ACPI_PROCESSOR=y
+CONFIG_ACPI_HOTPLUG_CPU=y
 # CONFIG_ACPI_HOTPLUG_MEMORY is not set
 # CONFIG_ACPI_CUSTOM_DSDT is not set
 # CONFIG_ACPI_DEBUG is not set

--- a/kernel/hardening.config
+++ b/kernel/hardening.config
@@ -40,12 +40,14 @@ CONFIG_VIRTIO_CONSOLE=y
 # CONFIG_SOUND is not set
 # CONFIG_DRM is not set
 # CONFIG_WIRELESS is not set
-# CFG80211 and MAC80211 live inside `if WIRELESS` in net/Kconfig, so the
-# olddefconfig walker sees them =y in x86_64_defconfig and flips WIRELESS
-# back to =y to satisfy the parent-child invariant. Unset the children so
-# the parent stays off after olddefconfig.
+# WLAN (drivers/net/wireless, =y in defconfig) selects WIRELESS, and
+# CFG80211/MAC80211 are =y children under `if WIRELESS` — unset all three
+# or olddefconfig flips WIRELESS back on.
+# CONFIG_WLAN is not set
 # CONFIG_CFG80211 is not set
 # CONFIG_MAC80211 is not set
+# rfkill core (/dev/rfkill): nothing wireless left to switch.
+# CONFIG_RFKILL is not set
 # CONFIG_BLUETOOTH is not set
 # CONFIG_INPUT_MISC is not set
 # CONFIG_HW_RANDOM_VIRTIO is not set
@@ -55,12 +57,9 @@ CONFIG_VIRTIO_CONSOLE=y
 # CONFIG_HOTPLUG_PCI_ACPI is not set
 # CONFIG_HOTPLUG_PCI_PCIE is not set
 # CONFIG_PCI_QUIRKS is not set
-# CONFIG_PCI_ATS is not set
 # CONFIG_PCI_IOV is not set
-# CONFIG_PCI_PRI is not set
-# CONFIG_PCI_PASID is not set
-# CONFIG_PCI_LABEL is not set
-# CONFIG_IOMMU_SVA is not set
+# PCI_ATS/PRI/PASID, PCI_LABEL, IOMMU_SVA: promptless symbols select'ed by
+# the enabled IOMMU/PCI stack — an off request can never win; they stay =y.
 
 # RDRAND-trusted RNG (no virtio-rng): nothing to set on kernel 6.16.
 # ARCH_RANDOM was removed in 5.19 (arch RNG support is unconditional) and
@@ -84,8 +83,8 @@ CONFIG_SLAB_FREELIST_HARDENED=y
 
 # ACPI minimization
 # CONFIG_ACPI_DOCK is not set
-# CONFIG_ACPI_PROCESSOR is not set
-# CONFIG_ACPI_HOTPLUG_CPU is not set
+# ACPI_PROCESSOR is select'ed by X86_ACPI_CPUFREQ (=y in defconfig) and
+# drags ACPI_HOTPLUG_CPU (def_bool) with it — off requests can never win.
 # CONFIG_ACPI_HOTPLUG_MEMORY is not set
 # CONFIG_ACPI_CUSTOM_DSDT is not set
 # CONFIG_ACPI_DEBUG is not set
@@ -96,6 +95,9 @@ CONFIG_SLAB_FREELIST_HARDENED=y
 # Port-IO surface reduction (legacy devices off; switching console to hvc0)
 # CONFIG_SERIAL_8250 is not set
 # CONFIG_KEYBOARD_ATKBD is not set
+# MOUSE_PS2 (=y in defconfig) selects SERIO_I8042; unset it so the i8042
+# off request below can take effect.
+# CONFIG_MOUSE_PS2 is not set
 # CONFIG_SERIO_I8042 is not set
 # CONFIG_RTC_DRV_CMOS is not set
 # CONFIG_PCSPKR_PLATFORM is not set

--- a/src/kernel/config.rs
+++ b/src/kernel/config.rs
@@ -117,26 +117,36 @@ pub fn run_configure_phase(
     verify_fragment_options(&fragments, &kernel_dir_abs.join(".config"))
 }
 
-/// Fail if any `CONFIG_X=y` requested by the fragments is absent from the
-/// resolved `.config`. `olddefconfig` drops an option whose Kconfig
-/// dependency is unmet (or whose symbol no longer exists) without any error
-/// — the miss otherwise surfaces only as runtime misbehavior, long after the
-/// expensive build (e.g. NETFILTER_XT_MATCH_OWNER silently dropped because
-/// NETFILTER_ADVANCED was unset). (`=m` collapses to `=y` via mod2yesconfig
-/// before olddefconfig, so checking `=y` is sufficient for this module-less
-/// build.)
+/// Fail if the resolved `.config` disagrees with what the fragments
+/// requested, in either direction. `olddefconfig` silently drops a
+/// `CONFIG_X=y` whose Kconfig dependency is unmet (e.g.
+/// NETFILTER_XT_MATCH_OWNER dropped because NETFILTER_ADVANCED was unset),
+/// and just as silently force-enables a `# CONFIG_X is not set` when the
+/// symbol is promptless or select'ed by an enabled one (e.g. MOUSE_PS2
+/// selects SERIO_I8042) — both otherwise surface only as runtime
+/// misbehavior or a quietly weaker kernel, long after the expensive build.
+/// (`=m` counts as an on-request: mod2yesconfig collapses it to `=y` in
+/// this module-less build. Non-boolean values are not verified.)
 ///
 /// Fragments merge with last-wins semantics (see [`run_configure_phase`]),
 /// so only each symbol's final requested state is checked: a later fragment
 /// that sets `# CONFIG_X is not set` retracts an earlier `CONFIG_X=y`
 /// request (e.g. c8s.config disables hardening.config's RANDSTRUCT_FULL,
-/// which DEBUG_INFO_BTF is incompatible with).
+/// which DEBUG_INFO_BTF is incompatible with) — and vice versa.
 fn verify_fragment_options(fragments: &[&Path], resolved: &Path) -> Result<()> {
     let config = fs_err::read_to_string(resolved)?;
-    let enabled: std::collections::HashSet<&str> = config.lines().collect();
-    // symbol -> Some((requesting fragment, `CONFIG_X=y` line)) for a live
-    // `=y` request, None once a later fragment sets any other value.
-    let mut requested: std::collections::BTreeMap<String, Option<(String, String)>> =
+    // symbol -> full `CONFIG_X=...` line from the resolved .config.
+    let resolved_set: std::collections::HashMap<&str, &str> = config
+        .lines()
+        .filter(|l| l.starts_with("CONFIG_"))
+        .filter_map(|l| l.split_once('=').map(|(symbol, _)| (symbol, l)))
+        .collect();
+    // symbol -> final request across fragments (last fragment wins):
+    //   Some((fragment, true))  — must resolve `=y` (`=m` collapses via
+    //                             mod2yesconfig in this module-less build)
+    //   Some((fragment, false)) — must resolve off (`# is not set`/absent)
+    //   None                    — non-boolean value; not verified
+    let mut requested: std::collections::BTreeMap<String, Option<(String, bool)>> =
         Default::default();
     for frag in fragments {
         let name = frag.file_name().unwrap_or_default().to_string_lossy();
@@ -144,36 +154,43 @@ fn verify_fragment_options(fragments: &[&Path], resolved: &Path) -> Result<()> {
             // Match on the first whitespace-delimited token so a trailing
             // comment can't smuggle a request past verification.
             let token = line.split_whitespace().next().unwrap_or("");
-            if let Some((symbol, _)) = token
+            if let Some((symbol, value)) = token
                 .split_once('=')
                 .filter(|_| token.starts_with("CONFIG_"))
             {
-                let request = token
-                    .ends_with("=y")
-                    .then(|| (name.to_string(), token.to_string()));
+                let request = matches!(value, "y" | "m").then(|| (name.to_string(), true));
                 requested.insert(symbol.to_string(), request);
             } else if let Some(symbol) = line
                 .strip_prefix("# ")
                 .and_then(|r| r.strip_suffix(" is not set"))
                 .filter(|s| s.starts_with("CONFIG_"))
             {
-                requested.insert(symbol.to_string(), None);
+                requested.insert(symbol.to_string(), Some((name.to_string(), false)));
             }
         }
     }
     let missing: Vec<String> = requested
-        .into_values()
-        .flatten()
-        .filter(|(_, line)| !enabled.contains(line.as_str()))
-        .map(|(name, line)| format!("  - {}: {}", name, line.trim_end_matches("=y")))
+        .iter()
+        .filter_map(|(symbol, req)| req.as_ref().map(|(name, want_on)| (symbol, name, want_on)))
+        .filter_map(|(symbol, name, want_on)| {
+            let line = resolved_set.get(symbol.as_str()).copied();
+            match (want_on, line) {
+                (true, Some(l)) if l == format!("{symbol}=y") => None,
+                (true, _) => Some(format!("  - {name}: {symbol} requested on, dropped")),
+                (false, Some(l)) => Some(format!("  - {name}: {symbol} requested off, got {l}")),
+                (false, None) => None,
+            }
+        })
         .collect();
     if missing.is_empty() {
         Ok(())
     } else {
         Err(anyhow!(
-            "kernel options requested in a config fragment were dropped by olddefconfig \
-             (unmet Kconfig dependency or removed symbol):\n{}\n\
-             Add the missing dependency to the fragment and rebuild.",
+            "kernel options requested in a config fragment do not match the resolved \
+             .config (olddefconfig drops =y requests with unmet dependencies and \
+             force-enables `is not set` requests for selected/promptless symbols):\n{}\n\
+             Fix the fragment (add the missing dependency, or unset the selecting \
+             symbol / document the force-enable) and rebuild.",
             missing.join("\n")
         ))
     }
@@ -251,7 +268,7 @@ mod tests {
     fn verify_fragment_options_passes_when_all_requested_options_present() {
         let d = TempDir::new().unwrap();
         let frag = write(&d, "frag.config", "# comment\nCONFIG_A=y\nCONFIG_B=m\n");
-        let resolved = write(&d, "resolved", "CONFIG_A=y\nCONFIG_C=y\n");
+        let resolved = write(&d, "resolved", "CONFIG_A=y\nCONFIG_B=y\nCONFIG_C=y\n");
         verify_fragment_options(&[frag.as_path()], &resolved).unwrap();
     }
 
@@ -268,9 +285,52 @@ mod tests {
     }
 
     #[test]
-    fn verify_fragment_options_ignores_not_set_and_comment_lines() {
+    fn verify_fragment_options_ignores_comment_lines() {
         let d = TempDir::new().unwrap();
-        let frag = write(&d, "frag.config", "# CONFIG_A is not set\n# CONFIG_B=y\n");
+        let frag = write(&d, "frag.config", "# CONFIG_B=y\n# plain comment\n");
+        let resolved = write(&d, "resolved", "CONFIG_C=y\n");
+        verify_fragment_options(&[frag.as_path()], &resolved).unwrap();
+    }
+
+    #[test]
+    fn verify_fragment_options_passes_when_off_request_resolves_off() {
+        let d = TempDir::new().unwrap();
+        let frag = write(&d, "frag.config", "# CONFIG_A is not set\n");
+        // Off in the resolved config as absent (A) or as a not-set comment.
+        let frag2 = write(&d, "frag2.config", "# CONFIG_B is not set\n");
+        let resolved = write(&d, "resolved", "# CONFIG_B is not set\nCONFIG_C=y\n");
+        verify_fragment_options(&[frag.as_path(), frag2.as_path()], &resolved).unwrap();
+    }
+
+    #[test]
+    fn verify_fragment_options_fails_when_off_request_is_force_enabled() {
+        let d = TempDir::new().unwrap();
+        let frag = write(&d, "hardening.config", "# CONFIG_SERIO_I8042 is not set\n");
+        let resolved = write(&d, "resolved", "CONFIG_SERIO_I8042=y\n");
+        let err = verify_fragment_options(&[frag.as_path()], &resolved)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("hardening.config: CONFIG_SERIO_I8042 requested off"));
+    }
+
+    #[test]
+    fn verify_fragment_options_treats_module_request_as_on_request() {
+        let d = TempDir::new().unwrap();
+        let frag = write(&d, "frag.config", "CONFIG_A=m\n");
+        let resolved = write(&d, "resolved", "CONFIG_A=y\n");
+        verify_fragment_options(&[frag.as_path()], &resolved).unwrap();
+        let dropped = write(&d, "resolved2", "CONFIG_B=y\n");
+        assert!(verify_fragment_options(&[frag.as_path()], &dropped).is_err());
+    }
+
+    #[test]
+    fn verify_fragment_options_skips_non_boolean_values() {
+        let d = TempDir::new().unwrap();
+        let frag = write(
+            &d,
+            "frag.config",
+            "CONFIG_PANIC_TIMEOUT=-1\nCONFIG_PATH=\"\"\n",
+        );
         let resolved = write(&d, "resolved", "CONFIG_C=y\n");
         verify_fragment_options(&[frag.as_path()], &resolved).unwrap();
     }

--- a/src/kernel/config.rs
+++ b/src/kernel/config.rs
@@ -190,7 +190,11 @@ fn verify_fragment_options(fragments: &[&Path], resolved: &Path) -> Result<()> {
     let mut mismatches = Vec::new();
     for (symbol, request) in &requested {
         match (request, resolved_values.get(symbol.as_str())) {
-            (Request::Skip, _) | (Request::On(_), Some(&"y")) | (Request::Off(_), None) => {}
+            (Request::Skip, _) | (Request::On(_), Some(&"y")) => {}
+            // Absent also covers a typo'd or removed symbol, which passes
+            // silently; dependency-hidden symbols are absent too, so
+            // treating absence as an error would false-positive.
+            (Request::Off(_), None) => {}
             (Request::On(name), Some(v)) => {
                 mismatches.push(format!("  - {name}: {symbol} requested on, got {symbol}={v}"));
             }

--- a/src/kernel/config.rs
+++ b/src/kernel/config.rs
@@ -177,6 +177,13 @@ fn verify_fragment_options(fragments: &[&Path], resolved: &Path) -> Result<()> {
                 .filter(|s| s.starts_with("CONFIG_"))
             {
                 requested.insert(symbol.to_string(), Request::Off(name.to_string()));
+            } else if line.starts_with("# CONFIG_") && line.contains(" is not set") {
+                // kconfig only honors the exact line; with trailing text the
+                // request silently no-ops in merge AND escapes verification.
+                return Err(anyhow!(
+                    "{name}: ineffective off-request {line:?} (trailing text after \
+                     \"is not set\"); kconfig ignores the whole line"
+                ));
             }
         }
     }
@@ -321,6 +328,17 @@ mod tests {
             .unwrap_err()
             .to_string();
         assert!(err.contains("hardening.config: CONFIG_SERIO_I8042 requested off"));
+    }
+
+    #[test]
+    fn verify_fragment_options_rejects_not_set_line_with_trailing_text() {
+        let d = TempDir::new().unwrap();
+        let frag = write(&d, "frag.config", "# CONFIG_A is not set  # rationale\n");
+        let resolved = write(&d, "resolved", "CONFIG_B=y\n");
+        let err = verify_fragment_options(&[frag.as_path()], &resolved)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("ineffective off-request"));
     }
 
     #[test]

--- a/src/kernel/config.rs
+++ b/src/kernel/config.rs
@@ -125,8 +125,9 @@ pub fn run_configure_phase(
 /// symbol is promptless or select'ed by an enabled one (e.g. MOUSE_PS2
 /// selects SERIO_I8042) — both otherwise surface only as runtime
 /// misbehavior or a quietly weaker kernel, long after the expensive build.
-/// (`=m` counts as an on-request: mod2yesconfig collapses it to `=y` in
-/// this module-less build. Non-boolean values are not verified.)
+/// (`=m` counts as an on-request: mod2yesconfig runs after all fragments
+/// merge and collapses it to `=y`, even when a profile fragment enables
+/// CONFIG_MODULES. Non-boolean values are not verified.)
 ///
 /// Fragments merge with last-wins semantics (see [`run_configure_phase`]),
 /// so only each symbol's final requested state is checked: a later fragment
@@ -137,8 +138,7 @@ fn verify_fragment_options(fragments: &[&Path], resolved: &Path) -> Result<()> {
     /// Final request for a symbol after last-fragment-wins merging; On/Off
     /// carry the requesting fragment's name for the error message.
     enum Request {
-        /// `=y` (or `=m`: mod2yesconfig collapses it in this module-less
-        /// build); must resolve `=y`.
+        /// `=y` (or `=m`: mod2yesconfig collapses it); must resolve `=y`.
         On(String),
         /// `# is not set` or `=n`; must resolve off (not-set comment or
         /// absent).
@@ -191,7 +191,10 @@ fn verify_fragment_options(fragments: &[&Path], resolved: &Path) -> Result<()> {
     for (symbol, request) in &requested {
         match (request, resolved_values.get(symbol.as_str())) {
             (Request::Skip, _) | (Request::On(_), Some(&"y")) | (Request::Off(_), None) => {}
-            (Request::On(name), _) => {
+            (Request::On(name), Some(v)) => {
+                mismatches.push(format!("  - {name}: {symbol} requested on, got {symbol}={v}"));
+            }
+            (Request::On(name), None) => {
                 mismatches.push(format!("  - {name}: {symbol} requested on, dropped"));
             }
             (Request::Off(name), Some(v)) => {
@@ -362,6 +365,17 @@ mod tests {
         verify_fragment_options(&[frag.as_path()], &resolved).unwrap();
         let dropped = write(&d, "resolved2", "CONFIG_B=y\n");
         assert!(verify_fragment_options(&[frag.as_path()], &dropped).is_err());
+    }
+
+    #[test]
+    fn verify_fragment_options_reports_resolved_value_on_clamped_on_request() {
+        let d = TempDir::new().unwrap();
+        let frag = write(&d, "frag.config", "CONFIG_A=y\n");
+        let resolved = write(&d, "resolved", "CONFIG_A=m\n");
+        let err = verify_fragment_options(&[frag.as_path()], &resolved)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("frag.config: CONFIG_A requested on, got CONFIG_A=m"));
     }
 
     #[test]

--- a/src/kernel/config.rs
+++ b/src/kernel/config.rs
@@ -138,9 +138,9 @@ fn verify_fragment_options(fragments: &[&Path], resolved: &Path) -> Result<()> {
     /// carry the requesting fragment's name for the error message.
     enum Request {
         /// `=y` (or `=m`: mod2yesconfig collapses it in this module-less
-        /// build) — must resolve `=y`.
+        /// build); must resolve `=y`.
         On(String),
-        /// `# is not set` — must resolve off (not-set comment or absent).
+        /// `# is not set`; must resolve off (not-set comment or absent).
         Off(String),
         /// Non-boolean value; not verified.
         Skip,

--- a/src/kernel/config.rs
+++ b/src/kernel/config.rs
@@ -139,7 +139,7 @@ pub fn run_configure_phase(
 /// wants off but that the enabled stack select's anyway: the symbol must
 /// resolve `=y` without the fragment requesting it, so the assertion fails
 /// loudly when the forcing goes away (an actual `=y` pin would keep the
-/// symbol on silently).
+/// symbol on silently, so combining a pin with an assertion is rejected).
 fn verify_fragment_options(fragments: &[&Path], resolved: &Path) -> Result<()> {
     /// Final request for a symbol after last-fragment-wins merging; On/Off
     /// carry the requesting fragment's name for the error message.
@@ -154,9 +154,13 @@ fn verify_fragment_options(fragments: &[&Path], resolved: &Path) -> Result<()> {
         /// requesting it, so the build fails if the forcing goes away
         /// instead of the fragment silently keeping the symbol on.
         Forced(String),
-        /// Non-boolean value; not verified.
-        Skip,
     }
+    fn valid_symbol(symbol: &str) -> bool {
+        symbol.strip_prefix("CONFIG_").is_some_and(|name| {
+            !name.is_empty() && name.bytes().all(|b| b.is_ascii_alphanumeric() || b == b'_')
+        })
+    }
+
     let config = fs_err::read_to_string(resolved)?;
     // symbol -> value from the resolved .config's `CONFIG_X=value` lines.
     let resolved_values: std::collections::HashMap<&str, &str> = config
@@ -165,63 +169,150 @@ fn verify_fragment_options(fragments: &[&Path], resolved: &Path) -> Result<()> {
         .filter_map(|l| l.split_once('='))
         .collect();
     let mut requested: std::collections::BTreeMap<String, Request> = Default::default();
+    // Forced assertions are comments and therefore cannot retract an actual
+    // on-request. Remember every on-pin independently of last-wins state so a
+    // pin cannot make a forced assertion pass after its forcing chain vanishes.
+    let mut on_pins: std::collections::BTreeMap<String, (String, String)> = Default::default();
+    let mut forced: std::collections::BTreeMap<String, String> = Default::default();
     for frag in fragments {
         let name = frag.file_name().unwrap_or_default().to_string_lossy();
         for line in fs_err::read_to_string(frag)?.lines() {
-            // Match on the first whitespace-delimited token so a trailing
-            // comment can't smuggle a request past verification.
-            let token = line.split_whitespace().next().unwrap_or("");
-            if let Some((symbol, value)) = token
-                .split_once('=')
-                .filter(|_| token.starts_with("CONFIG_"))
-            {
-                let request = match value {
-                    "y" | "m" => Request::On(name.to_string()),
+            let trimmed = line.trim();
+            if trimmed.starts_with("CONFIG_") {
+                if line != trimmed {
+                    return Err(anyhow!(
+                        "{name}: ineffective request {line:?}; config assignments must \
+                         start in column 0 and have no surrounding whitespace"
+                    ));
+                }
+                let (symbol, value) = line.split_once('=').ok_or_else(|| {
+                    anyhow!(
+                        "{name}: ineffective request {line:?}; expected \
+                         `CONFIG_SYMBOL=value`"
+                    )
+                })?;
+                if !valid_symbol(symbol) {
+                    return Err(anyhow!(
+                        "{name}: ineffective request {line:?}; config symbols must match \
+                         `CONFIG_[A-Za-z0-9_]+`"
+                    ));
+                }
+                match value {
+                    "y" | "m" => {
+                        on_pins
+                            .entry(symbol.to_string())
+                            .or_insert_with(|| (name.to_string(), value.to_string()));
+                        requested.insert(symbol.to_string(), Request::On(name.to_string()));
+                    }
                     // kconfig treats `=n` exactly like `# is not set`.
-                    "n" => Request::Off(name.to_string()),
-                    _ => Request::Skip,
-                };
-                requested.insert(symbol.to_string(), request);
-            } else if let Some(symbol) = line
-                .strip_prefix("# ")
-                .and_then(|r| r.strip_suffix(" is not set"))
-                .filter(|s| s.starts_with("CONFIG_"))
-            {
-                requested.insert(symbol.to_string(), Request::Off(name.to_string()));
-            } else if let Some(symbol) = line
-                .strip_prefix("# ")
-                .and_then(|r| r.strip_suffix(" is forced on"))
-                .filter(|s| s.starts_with("CONFIG_"))
-            {
-                requested.insert(symbol.to_string(), Request::Forced(name.to_string()));
-            } else if line.starts_with("# CONFIG_")
-                && (line.contains(" is not set") || line.contains(" is forced on"))
-            {
-                // kconfig only honors the exact line; with trailing text the
-                // request silently no-ops in merge AND escapes verification.
+                    "n" => {
+                        requested.insert(symbol.to_string(), Request::Off(name.to_string()));
+                    }
+                    value
+                        if value.trim_start().bytes().next().is_some_and(|b| {
+                            matches!(b.to_ascii_lowercase(), b'y' | b'm' | b'n')
+                        }) =>
+                    {
+                        // Kconfig accepts a lowercase boolean by its first
+                        // character, while other boolean-like spellings are
+                        // ineffective. Require the complete canonical value so
+                        // neither case silently escapes verification.
+                        return Err(anyhow!(
+                            "{name}: non-canonical boolean value in {line:?}; use exactly \
+                             `{symbol}=y`, `{symbol}=m`, or `{symbol}=n`"
+                        ));
+                    }
+                    // Scalar/string request: not verified and, crucially,
+                    // does not erase an earlier boolean request.
+                    _ => {}
+                }
+                continue;
+            }
+
+            // Classify near-miss markers after trimming and whitespace
+            // normalization, then require their exact kconfig spelling. This
+            // catches leading whitespace, `#CONFIG_X`, tabs/double spaces,
+            // trailing text, and invalid symbol characters instead of
+            // silently treating them as comments.
+            let Some(comment) = trimmed.strip_prefix('#') else {
+                continue;
+            };
+            let words: Vec<&str> = comment.split_whitespace().collect();
+            let (symbol, is_forced) = match words.as_slice() {
+                [symbol, "is", "not", "set", ..] if symbol.starts_with("CONFIG_") => {
+                    (*symbol, false)
+                }
+                [symbol, "is", "forced", "on", ..] if symbol.starts_with("CONFIG_") => {
+                    (*symbol, true)
+                }
+                _ => continue,
+            };
+            if !valid_symbol(symbol) {
                 return Err(anyhow!(
-                    "{name}: ineffective request {line:?} (trailing text); \
-                     kconfig ignores the whole line"
+                    "{name}: ineffective request {line:?}; config symbols must match \
+                     `CONFIG_[A-Za-z0-9_]+`"
                 ));
+            }
+            let canonical = if is_forced {
+                format!("# {symbol} is forced on")
+            } else {
+                format!("# {symbol} is not set")
+            };
+            if line != canonical {
+                return Err(anyhow!(
+                    "{name}: ineffective request {line:?}; use the exact spelling \
+                     {canonical:?}"
+                ));
+            }
+            if is_forced {
+                forced
+                    .entry(symbol.to_string())
+                    .or_insert_with(|| name.to_string());
+                requested.insert(symbol.to_string(), Request::Forced(name.to_string()));
+            } else {
+                requested.insert(symbol.to_string(), Request::Off(name.to_string()));
             }
         }
     }
+    let pin_conflicts: Vec<String> = forced
+        .iter()
+        .filter_map(|(symbol, forced_name)| {
+            on_pins.get(symbol).map(|(pin_name, value)| {
+                format!(
+                    "  - {forced_name}: {symbol} asserted forced on, but {pin_name} pins \
+                     {symbol}={value}"
+                )
+            })
+        })
+        .collect();
+    if !pin_conflicts.is_empty() {
+        return Err(anyhow!(
+            "forced-on assertions must not have an =y/=m pin in any fragment; \
+             the pin would keep the symbol on and hide a vanished forcing chain:\n{}",
+            pin_conflicts.join("\n")
+        ));
+    }
+
     let mut mismatches = Vec::new();
     for (symbol, request) in &requested {
         match (request, resolved_values.get(symbol.as_str())) {
-            (Request::Skip, _) | (Request::On(_), Some(&"y")) => {}
+            (Request::On(_), Some(&"y")) => {}
             // Absent also covers a typo'd or removed symbol, which passes
             // silently; dependency-hidden symbols are absent too, so
             // treating absence as an error would false-positive.
             (Request::Off(_), None) => {}
             (Request::On(name), Some(v)) => {
-                mismatches.push(format!("  - {name}: {symbol} requested on, got {symbol}={v}"));
+                mismatches.push(format!(
+                    "  - {name}: {symbol} requested on, got {symbol}={v}"
+                ));
             }
             (Request::On(name), None) => {
                 mismatches.push(format!("  - {name}: {symbol} requested on, dropped"));
             }
             (Request::Off(name), Some(v)) => {
-                mismatches.push(format!("  - {name}: {symbol} requested off, got {symbol}={v}"));
+                mismatches.push(format!(
+                    "  - {name}: {symbol} requested off, got {symbol}={v}"
+                ));
             }
             (Request::Forced(_), Some(&"y")) => {}
             (Request::Forced(name), Some(v)) => {
@@ -369,6 +460,17 @@ mod tests {
     }
 
     #[test]
+    fn verify_fragment_options_reports_module_value_for_failed_off_request() {
+        let d = TempDir::new().unwrap();
+        let frag = write(&d, "frag.config", "# CONFIG_A is not set\n");
+        let resolved = write(&d, "resolved", "CONFIG_A=m\n");
+        let err = verify_fragment_options(&[frag.as_path()], &resolved)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("frag.config: CONFIG_A requested off, got CONFIG_A=m"));
+    }
+
+    #[test]
     fn verify_fragment_options_rejects_not_set_line_with_trailing_text() {
         let d = TempDir::new().unwrap();
         let frag = write(&d, "frag.config", "# CONFIG_A is not set  # rationale\n");
@@ -432,6 +534,65 @@ mod tests {
     }
 
     #[test]
+    fn verify_fragment_options_rejects_forced_assertion_with_pin_in_either_order() {
+        let d = TempDir::new().unwrap();
+        let pin = write(&d, "pin.config", "CONFIG_A=y\n");
+        let assertion = write(&d, "assert.config", "# CONFIG_A is forced on\n");
+        let resolved = write(&d, "resolved", "CONFIG_A=y\n");
+
+        for fragments in [
+            [pin.as_path(), assertion.as_path()],
+            [assertion.as_path(), pin.as_path()],
+        ] {
+            let err = verify_fragment_options(&fragments, &resolved)
+                .unwrap_err()
+                .to_string();
+            assert!(err.contains("CONFIG_A asserted forced on"));
+            assert!(err.contains("pin.config pins CONFIG_A=y"));
+        }
+    }
+
+    #[test]
+    fn verify_fragment_options_rejects_noncanonical_boolean_values() {
+        let d = TempDir::new().unwrap();
+        let resolved = write(&d, "resolved", "CONFIG_A=y\n");
+        for value in ["yes", "modules", "no", "Y"] {
+            let frag = write(&d, "frag.config", &format!("CONFIG_A={value}\n"));
+            let err = verify_fragment_options(&[frag.as_path()], &resolved)
+                .unwrap_err()
+                .to_string();
+            assert!(err.contains("non-canonical boolean value"));
+            assert!(err.contains(&format!("CONFIG_A={value}")));
+        }
+    }
+
+    #[test]
+    fn verify_fragment_options_rejects_ineffective_request_spellings() {
+        let d = TempDir::new().unwrap();
+        let resolved = write(&d, "resolved", "CONFIG_A=y\n");
+        for line in [
+            "  CONFIG_A=y",
+            "CONFIG_A = y",
+            "CONFIG_A-B=y",
+            "#CONFIG_A is not set",
+            "#  CONFIG_A is not set",
+            "#\tCONFIG_A is not set",
+            " # CONFIG_A is not set",
+            "# CONFIG_A  is not set",
+            "# CONFIG_A is forced on  # rationale",
+        ] {
+            let frag = write(&d, "frag.config", &format!("{line}\n"));
+            let err = verify_fragment_options(&[frag.as_path()], &resolved)
+                .unwrap_err()
+                .to_string();
+            assert!(
+                err.contains("ineffective request"),
+                "unexpected error for {line:?}: {err}"
+            );
+        }
+    }
+
+    #[test]
     fn verify_fragment_options_skips_non_boolean_values() {
         let d = TempDir::new().unwrap();
         let frag = write(
@@ -441,6 +602,18 @@ mod tests {
         );
         let resolved = write(&d, "resolved", "CONFIG_C=y\n");
         verify_fragment_options(&[frag.as_path()], &resolved).unwrap();
+    }
+
+    #[test]
+    fn verify_fragment_options_scalar_does_not_erase_earlier_boolean_request() {
+        let d = TempDir::new().unwrap();
+        let first = write(&d, "first.config", "CONFIG_A=y\n");
+        let scalar = write(&d, "scalar.config", "CONFIG_A=42\n");
+        let resolved = write(&d, "resolved", "CONFIG_B=y\n");
+        let err = verify_fragment_options(&[first.as_path(), scalar.as_path()], &resolved)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("first.config: CONFIG_A requested on, dropped"));
     }
 
     #[test]

--- a/src/kernel/config.rs
+++ b/src/kernel/config.rs
@@ -40,10 +40,10 @@ pub fn update_snapshot(resolved: &Path, snapshot: &Path) -> Result<bool> {
 ///   make mod2yesconfig
 ///   make olddefconfig
 ///
-/// then verifies every `CONFIG_X=y` requested by the merged fragments (after
-/// last-fragment-wins overrides) is present in the resolved `.config`,
-/// failing the build if `olddefconfig` silently dropped any (unmet Kconfig
-/// dependency or removed symbol).
+/// then verifies the merged fragments' boolean requests (after
+/// last-fragment-wins overrides) against the resolved `.config`, failing
+/// the build if `olddefconfig` silently dropped an on-request or
+/// force-enabled an off-request (see [`verify_fragment_options`]).
 ///
 /// Merge order is important: `confidential.config` deliberately re-enables
 /// options the `hardening.config` fragment turned off (e.g.
@@ -134,20 +134,25 @@ pub fn run_configure_phase(
 /// request (e.g. c8s.config disables hardening.config's RANDSTRUCT_FULL,
 /// which DEBUG_INFO_BTF is incompatible with) — and vice versa.
 fn verify_fragment_options(fragments: &[&Path], resolved: &Path) -> Result<()> {
+    /// Final request for a symbol after last-fragment-wins merging; On/Off
+    /// carry the requesting fragment's name for the error message.
+    enum Request {
+        /// `=y` (or `=m`: mod2yesconfig collapses it in this module-less
+        /// build) — must resolve `=y`.
+        On(String),
+        /// `# is not set` — must resolve off (not-set comment or absent).
+        Off(String),
+        /// Non-boolean value; not verified.
+        Skip,
+    }
     let config = fs_err::read_to_string(resolved)?;
-    // symbol -> full `CONFIG_X=...` line from the resolved .config.
-    let resolved_set: std::collections::HashMap<&str, &str> = config
+    // symbol -> value from the resolved .config's `CONFIG_X=value` lines.
+    let resolved_values: std::collections::HashMap<&str, &str> = config
         .lines()
         .filter(|l| l.starts_with("CONFIG_"))
-        .filter_map(|l| l.split_once('=').map(|(symbol, _)| (symbol, l)))
+        .filter_map(|l| l.split_once('='))
         .collect();
-    // symbol -> final request across fragments (last fragment wins):
-    //   Some((fragment, true))  — must resolve `=y` (`=m` collapses via
-    //                             mod2yesconfig in this module-less build)
-    //   Some((fragment, false)) — must resolve off (`# is not set`/absent)
-    //   None                    — non-boolean value; not verified
-    let mut requested: std::collections::BTreeMap<String, Option<(String, bool)>> =
-        Default::default();
+    let mut requested: std::collections::BTreeMap<String, Request> = Default::default();
     for frag in fragments {
         let name = frag.file_name().unwrap_or_default().to_string_lossy();
         for line in fs_err::read_to_string(frag)?.lines() {
@@ -158,31 +163,33 @@ fn verify_fragment_options(fragments: &[&Path], resolved: &Path) -> Result<()> {
                 .split_once('=')
                 .filter(|_| token.starts_with("CONFIG_"))
             {
-                let request = matches!(value, "y" | "m").then(|| (name.to_string(), true));
+                let request = match value {
+                    "y" | "m" => Request::On(name.to_string()),
+                    _ => Request::Skip,
+                };
                 requested.insert(symbol.to_string(), request);
             } else if let Some(symbol) = line
                 .strip_prefix("# ")
                 .and_then(|r| r.strip_suffix(" is not set"))
                 .filter(|s| s.starts_with("CONFIG_"))
             {
-                requested.insert(symbol.to_string(), Some((name.to_string(), false)));
+                requested.insert(symbol.to_string(), Request::Off(name.to_string()));
             }
         }
     }
-    let missing: Vec<String> = requested
-        .iter()
-        .filter_map(|(symbol, req)| req.as_ref().map(|(name, want_on)| (symbol, name, want_on)))
-        .filter_map(|(symbol, name, want_on)| {
-            let line = resolved_set.get(symbol.as_str()).copied();
-            match (want_on, line) {
-                (true, Some(l)) if l == format!("{symbol}=y") => None,
-                (true, _) => Some(format!("  - {name}: {symbol} requested on, dropped")),
-                (false, Some(l)) => Some(format!("  - {name}: {symbol} requested off, got {l}")),
-                (false, None) => None,
+    let mut mismatches = Vec::new();
+    for (symbol, request) in &requested {
+        match (request, resolved_values.get(symbol.as_str())) {
+            (Request::Skip, _) | (Request::On(_), Some(&"y")) | (Request::Off(_), None) => {}
+            (Request::On(name), _) => {
+                mismatches.push(format!("  - {name}: {symbol} requested on, dropped"));
             }
-        })
-        .collect();
-    if missing.is_empty() {
+            (Request::Off(name), Some(v)) => {
+                mismatches.push(format!("  - {name}: {symbol} requested off, got {symbol}={v}"));
+            }
+        }
+    }
+    if mismatches.is_empty() {
         Ok(())
     } else {
         Err(anyhow!(
@@ -191,7 +198,7 @@ fn verify_fragment_options(fragments: &[&Path], resolved: &Path) -> Result<()> {
              force-enables `is not set` requests for selected/promptless symbols):\n{}\n\
              Fix the fragment (add the missing dependency, or unset the selecting \
              symbol / document the force-enable) and rebuild.",
-            missing.join("\n")
+            mismatches.join("\n")
         ))
     }
 }

--- a/src/kernel/config.rs
+++ b/src/kernel/config.rs
@@ -136,10 +136,11 @@ pub fn run_configure_phase(
 /// which DEBUG_INFO_BTF is incompatible with) — and vice versa.
 ///
 /// A fragment may also assert `# CONFIG_X is forced on` for a symbol it
-/// wants off but that the enabled stack select's anyway: the symbol must
-/// resolve `=y` without the fragment requesting it, so the assertion fails
-/// loudly when the forcing goes away (an actual `=y` pin would keep the
-/// symbol on silently, so combining a pin with an assertion is rejected).
+/// wants off but that the enabled stack select's anyway. The marker must be
+/// paired with a real off request, so the symbol must resolve `=y` despite
+/// that request and the assertion fails loudly when the forcing goes away.
+/// (An actual `=y` pin would keep the symbol on silently, so combining a pin
+/// with an assertion is rejected.)
 fn verify_fragment_options(fragments: &[&Path], resolved: &Path) -> Result<()> {
     /// Final request for a symbol after last-fragment-wins merging; On/Off
     /// carry the requesting fragment's name for the error message.
@@ -150,10 +151,16 @@ fn verify_fragment_options(fragments: &[&Path], resolved: &Path) -> Result<()> {
         /// absent).
         Off(String),
         /// `# CONFIG_X is forced on`: a symbol wanted off that the enabled
-        /// stack select's anyway. Must resolve `=y` WITHOUT the fragment
-        /// requesting it, so the build fails if the forcing goes away
-        /// instead of the fragment silently keeping the symbol on.
+        /// stack select's anyway. Must have an effective off request and
+        /// resolve `=y`, so the build fails if the forcing goes away.
         Forced(String),
+    }
+    /// Last merge-visible request for a symbol. Forced markers are metadata
+    /// comments and deliberately do not update this state.
+    enum SubmittedRequest {
+        On,
+        Off,
+        Scalar,
     }
     fn valid_symbol(symbol: &str) -> bool {
         symbol.strip_prefix("CONFIG_").is_some_and(|name| {
@@ -169,6 +176,7 @@ fn verify_fragment_options(fragments: &[&Path], resolved: &Path) -> Result<()> {
         .filter_map(|l| l.split_once('='))
         .collect();
     let mut requested: std::collections::BTreeMap<String, Request> = Default::default();
+    let mut submitted: std::collections::BTreeMap<String, SubmittedRequest> = Default::default();
     // Forced assertions are comments and therefore cannot retract an actual
     // on-request. Remember every on-pin independently of last-wins state so a
     // pin cannot make a forced assertion pass after its forcing chain vanishes.
@@ -199,6 +207,7 @@ fn verify_fragment_options(fragments: &[&Path], resolved: &Path) -> Result<()> {
                 }
                 match value {
                     "y" | "m" => {
+                        submitted.insert(symbol.to_string(), SubmittedRequest::On);
                         on_pins
                             .entry(symbol.to_string())
                             .or_insert_with(|| (name.to_string(), value.to_string()));
@@ -206,6 +215,7 @@ fn verify_fragment_options(fragments: &[&Path], resolved: &Path) -> Result<()> {
                     }
                     // kconfig treats `=n` exactly like `# is not set`.
                     "n" => {
+                        submitted.insert(symbol.to_string(), SubmittedRequest::Off);
                         requested.insert(symbol.to_string(), Request::Off(name.to_string()));
                     }
                     value
@@ -224,7 +234,9 @@ fn verify_fragment_options(fragments: &[&Path], resolved: &Path) -> Result<()> {
                     }
                     // Scalar/string request: not verified and, crucially,
                     // does not erase an earlier boolean request.
-                    _ => {}
+                    _ => {
+                        submitted.insert(symbol.to_string(), SubmittedRequest::Scalar);
+                    }
                 }
                 continue;
             }
@@ -268,8 +280,8 @@ fn verify_fragment_options(fragments: &[&Path], resolved: &Path) -> Result<()> {
                 forced
                     .entry(symbol.to_string())
                     .or_insert_with(|| name.to_string());
-                requested.insert(symbol.to_string(), Request::Forced(name.to_string()));
             } else {
+                submitted.insert(symbol.to_string(), SubmittedRequest::Off);
                 requested.insert(symbol.to_string(), Request::Off(name.to_string()));
             }
         }
@@ -291,6 +303,29 @@ fn verify_fragment_options(fragments: &[&Path], resolved: &Path) -> Result<()> {
              the pin would keep the symbol on and hide a vanished forcing chain:\n{}",
             pin_conflicts.join("\n")
         ));
+    }
+
+    let missing_off_requests: Vec<String> = forced
+        .iter()
+        .filter(|(symbol, _)| !matches!(submitted.get(*symbol), Some(SubmittedRequest::Off)))
+        .map(|(symbol, name)| {
+            format!("  - {name}: {symbol} asserted forced on without an effective off request")
+        })
+        .collect();
+    if !missing_off_requests.is_empty() {
+        return Err(anyhow!(
+            "forced-on assertions must be paired with a final `# CONFIG_X is not set` \
+             or `CONFIG_X=n` request; otherwise a default-y symbol can satisfy the \
+             assertion after its forcing chain disappears:\n{}",
+            missing_off_requests.join("\n")
+        ));
+    }
+
+    // Assertion metadata is orthogonal to fragment merge order. Once its
+    // effective off request is proven above, evaluate the symbol as Forced
+    // even when the marker appeared before that request.
+    for (symbol, name) in &forced {
+        requested.insert(symbol.clone(), Request::Forced(name.clone()));
     }
 
     let mut mismatches = Vec::new();
@@ -323,7 +358,7 @@ fn verify_fragment_options(fragments: &[&Path], resolved: &Path) -> Result<()> {
             (Request::Forced(name), None) => {
                 mismatches.push(format!(
                     "  - {name}: {symbol} asserted forced on, resolved off (forcing gone; \
-                     turn the assertion into `# {symbol} is not set` or drop it)"
+                     drop the assertion and keep the off request)"
                 ));
             }
         }
@@ -336,7 +371,7 @@ fn verify_fragment_options(fragments: &[&Path], resolved: &Path) -> Result<()> {
              .config (olddefconfig drops =y requests with unmet dependencies and \
              force-enables `is not set` requests for selected/promptless symbols):\n{}\n\
              Fix the fragment (add the missing dependency, or unset the selecting \
-             symbol / assert it with `# CONFIG_X is forced on`) and rebuild.",
+             symbol / pair its off request with `# CONFIG_X is forced on`) and rebuild.",
             mismatches.join("\n")
         ))
     }
@@ -518,26 +553,52 @@ mod tests {
     #[test]
     fn verify_fragment_options_checks_forced_assertions() {
         let d = TempDir::new().unwrap();
-        let frag = write(&d, "frag.config", "# CONFIG_A is forced on\n");
         let held = write(&d, "resolved", "CONFIG_A=y\n");
-        verify_fragment_options(&[frag.as_path()], &held).unwrap();
         let gone = write(&d, "resolved2", "CONFIG_B=y\n");
-        let err = verify_fragment_options(&[frag.as_path()], &gone)
-            .unwrap_err()
-            .to_string();
-        assert!(err.contains("frag.config: CONFIG_A asserted forced on, resolved off"));
         let clamped = write(&d, "resolved3", "CONFIG_A=m\n");
-        let err = verify_fragment_options(&[frag.as_path()], &clamped)
-            .unwrap_err()
-            .to_string();
-        assert!(err.contains("frag.config: CONFIG_A asserted forced on, got CONFIG_A=m"));
+
+        for content in [
+            "# CONFIG_A is not set\n# CONFIG_A is forced on\n",
+            "# CONFIG_A is forced on\n# CONFIG_A is not set\n",
+        ] {
+            let frag = write(&d, "frag.config", content);
+            verify_fragment_options(&[frag.as_path()], &held).unwrap();
+            let err = verify_fragment_options(&[frag.as_path()], &gone)
+                .unwrap_err()
+                .to_string();
+            assert!(err.contains("frag.config: CONFIG_A asserted forced on, resolved off"));
+            let err = verify_fragment_options(&[frag.as_path()], &clamped)
+                .unwrap_err()
+                .to_string();
+            assert!(err.contains("frag.config: CONFIG_A asserted forced on, got CONFIG_A=m"));
+        }
+    }
+
+    #[test]
+    fn verify_fragment_options_rejects_forced_assertion_without_effective_off_request() {
+        let d = TempDir::new().unwrap();
+        let resolved = write(&d, "resolved", "CONFIG_A=y\n");
+        for content in [
+            "# CONFIG_A is forced on\n",
+            "# CONFIG_A is not set\nCONFIG_A=42\n# CONFIG_A is forced on\n",
+        ] {
+            let frag = write(&d, "frag.config", content);
+            let err = verify_fragment_options(&[frag.as_path()], &resolved)
+                .unwrap_err()
+                .to_string();
+            assert!(err.contains("without an effective off request"));
+        }
     }
 
     #[test]
     fn verify_fragment_options_rejects_forced_assertion_with_pin_in_either_order() {
         let d = TempDir::new().unwrap();
         let pin = write(&d, "pin.config", "CONFIG_A=y\n");
-        let assertion = write(&d, "assert.config", "# CONFIG_A is forced on\n");
+        let assertion = write(
+            &d,
+            "assert.config",
+            "# CONFIG_A is not set\n# CONFIG_A is forced on\n",
+        );
         let resolved = write(&d, "resolved", "CONFIG_A=y\n");
 
         for fragments in [

--- a/src/kernel/config.rs
+++ b/src/kernel/config.rs
@@ -134,6 +134,12 @@ pub fn run_configure_phase(
 /// that sets `# CONFIG_X is not set` retracts an earlier `CONFIG_X=y`
 /// request (e.g. c8s.config disables hardening.config's RANDSTRUCT_FULL,
 /// which DEBUG_INFO_BTF is incompatible with) — and vice versa.
+///
+/// A fragment may also assert `# CONFIG_X is forced on` for a symbol it
+/// wants off but that the enabled stack select's anyway: the symbol must
+/// resolve `=y` without the fragment requesting it, so the assertion fails
+/// loudly when the forcing goes away (an actual `=y` pin would keep the
+/// symbol on silently).
 fn verify_fragment_options(fragments: &[&Path], resolved: &Path) -> Result<()> {
     /// Final request for a symbol after last-fragment-wins merging; On/Off
     /// carry the requesting fragment's name for the error message.
@@ -143,6 +149,11 @@ fn verify_fragment_options(fragments: &[&Path], resolved: &Path) -> Result<()> {
         /// `# is not set` or `=n`; must resolve off (not-set comment or
         /// absent).
         Off(String),
+        /// `# CONFIG_X is forced on`: a symbol wanted off that the enabled
+        /// stack select's anyway. Must resolve `=y` WITHOUT the fragment
+        /// requesting it, so the build fails if the forcing goes away
+        /// instead of the fragment silently keeping the symbol on.
+        Forced(String),
         /// Non-boolean value; not verified.
         Skip,
     }
@@ -177,12 +188,20 @@ fn verify_fragment_options(fragments: &[&Path], resolved: &Path) -> Result<()> {
                 .filter(|s| s.starts_with("CONFIG_"))
             {
                 requested.insert(symbol.to_string(), Request::Off(name.to_string()));
-            } else if line.starts_with("# CONFIG_") && line.contains(" is not set") {
+            } else if let Some(symbol) = line
+                .strip_prefix("# ")
+                .and_then(|r| r.strip_suffix(" is forced on"))
+                .filter(|s| s.starts_with("CONFIG_"))
+            {
+                requested.insert(symbol.to_string(), Request::Forced(name.to_string()));
+            } else if line.starts_with("# CONFIG_")
+                && (line.contains(" is not set") || line.contains(" is forced on"))
+            {
                 // kconfig only honors the exact line; with trailing text the
                 // request silently no-ops in merge AND escapes verification.
                 return Err(anyhow!(
-                    "{name}: ineffective off-request {line:?} (trailing text after \
-                     \"is not set\"); kconfig ignores the whole line"
+                    "{name}: ineffective request {line:?} (trailing text); \
+                     kconfig ignores the whole line"
                 ));
             }
         }
@@ -204,6 +223,18 @@ fn verify_fragment_options(fragments: &[&Path], resolved: &Path) -> Result<()> {
             (Request::Off(name), Some(v)) => {
                 mismatches.push(format!("  - {name}: {symbol} requested off, got {symbol}={v}"));
             }
+            (Request::Forced(_), Some(&"y")) => {}
+            (Request::Forced(name), Some(v)) => {
+                mismatches.push(format!(
+                    "  - {name}: {symbol} asserted forced on, got {symbol}={v}"
+                ));
+            }
+            (Request::Forced(name), None) => {
+                mismatches.push(format!(
+                    "  - {name}: {symbol} asserted forced on, resolved off (forcing gone; \
+                     turn the assertion into `# {symbol} is not set` or drop it)"
+                ));
+            }
         }
     }
     if mismatches.is_empty() {
@@ -214,7 +245,7 @@ fn verify_fragment_options(fragments: &[&Path], resolved: &Path) -> Result<()> {
              .config (olddefconfig drops =y requests with unmet dependencies and \
              force-enables `is not set` requests for selected/promptless symbols):\n{}\n\
              Fix the fragment (add the missing dependency, or unset the selecting \
-             symbol / pin the forced value so verify keeps tracking it) and rebuild.",
+             symbol / assert it with `# CONFIG_X is forced on`) and rebuild.",
             mismatches.join("\n")
         ))
     }
@@ -345,7 +376,7 @@ mod tests {
         let err = verify_fragment_options(&[frag.as_path()], &resolved)
             .unwrap_err()
             .to_string();
-        assert!(err.contains("ineffective off-request"));
+        assert!(err.contains("ineffective request"));
     }
 
     #[test]
@@ -380,6 +411,24 @@ mod tests {
             .unwrap_err()
             .to_string();
         assert!(err.contains("frag.config: CONFIG_A requested on, got CONFIG_A=m"));
+    }
+
+    #[test]
+    fn verify_fragment_options_checks_forced_assertions() {
+        let d = TempDir::new().unwrap();
+        let frag = write(&d, "frag.config", "# CONFIG_A is forced on\n");
+        let held = write(&d, "resolved", "CONFIG_A=y\n");
+        verify_fragment_options(&[frag.as_path()], &held).unwrap();
+        let gone = write(&d, "resolved2", "CONFIG_B=y\n");
+        let err = verify_fragment_options(&[frag.as_path()], &gone)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("frag.config: CONFIG_A asserted forced on, resolved off"));
+        let clamped = write(&d, "resolved3", "CONFIG_A=m\n");
+        let err = verify_fragment_options(&[frag.as_path()], &clamped)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("frag.config: CONFIG_A asserted forced on, got CONFIG_A=m"));
     }
 
     #[test]

--- a/src/kernel/config.rs
+++ b/src/kernel/config.rs
@@ -140,7 +140,8 @@ fn verify_fragment_options(fragments: &[&Path], resolved: &Path) -> Result<()> {
         /// `=y` (or `=m`: mod2yesconfig collapses it in this module-less
         /// build); must resolve `=y`.
         On(String),
-        /// `# is not set`; must resolve off (not-set comment or absent).
+        /// `# is not set` or `=n`; must resolve off (not-set comment or
+        /// absent).
         Off(String),
         /// Non-boolean value; not verified.
         Skip,
@@ -165,6 +166,8 @@ fn verify_fragment_options(fragments: &[&Path], resolved: &Path) -> Result<()> {
             {
                 let request = match value {
                     "y" | "m" => Request::On(name.to_string()),
+                    // kconfig treats `=n` exactly like `# is not set`.
+                    "n" => Request::Off(name.to_string()),
                     _ => Request::Skip,
                 };
                 requested.insert(symbol.to_string(), request);
@@ -318,6 +321,19 @@ mod tests {
             .unwrap_err()
             .to_string();
         assert!(err.contains("hardening.config: CONFIG_SERIO_I8042 requested off"));
+    }
+
+    #[test]
+    fn verify_fragment_options_treats_eq_n_as_off_request() {
+        let d = TempDir::new().unwrap();
+        let frag = write(&d, "frag.config", "CONFIG_A=n\n");
+        let forced = write(&d, "resolved", "CONFIG_A=y\n");
+        let err = verify_fragment_options(&[frag.as_path()], &forced)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("frag.config: CONFIG_A requested off"));
+        let off = write(&d, "resolved2", "CONFIG_B=y\n");
+        verify_fragment_options(&[frag.as_path()], &off).unwrap();
     }
 
     #[test]

--- a/src/kernel/config.rs
+++ b/src/kernel/config.rs
@@ -197,7 +197,7 @@ fn verify_fragment_options(fragments: &[&Path], resolved: &Path) -> Result<()> {
              .config (olddefconfig drops =y requests with unmet dependencies and \
              force-enables `is not set` requests for selected/promptless symbols):\n{}\n\
              Fix the fragment (add the missing dependency, or unset the selecting \
-             symbol / document the force-enable) and rebuild.",
+             symbol / pin the forced value so verify keeps tracking it) and rebuild.",
             mismatches.join("\n")
         ))
     }


### PR DESCRIPTION
Follow-up to #51's review: the fragment verifier only checked `=y` requests, so `# CONFIG_X is not set` requests that kconfig force-enables (promptless symbols, `select`s) passed silently — the config equivalent of a dropped `=y`, in the direction that weakens hardening.

## What

- **`verify_fragment_options` verifies both directions** (last-fragment-wins, as before): `=y`/`=m` must resolve `=y`; `is not set` must resolve off. Non-boolean values stay unverified.
- **Hardening off-requests that never worked, fixed at the root where possible** (validated by replaying the merge + `mod2yesconfig` + `olddefconfig` pipeline for all three lineages against 6.16.12):
  - `MOUSE_PS2` (=y in defconfig) selects `SERIO_I8042` → unset; the i8042 request now works and the PS/2 driver family drops out of the kernel.
  - `WLAN` (drivers/net/wireless) selects `WIRELESS` → unset, plus vestigial `RFKILL`; the wireless gate request now works.
  - `PCI_ATS`/`PCI_PRI`/`PCI_PASID`, `PCI_LABEL`, `IOMMU_SVA`, `ACPI_PROCESSOR`, `ACPI_HOTPLUG_CPU`: promptless/select'ed by the enabled IOMMU + cpufreq stacks — an off request can never win. Dead lines replaced with comments explaining why they stay `=y`.

## Notes

- **Measurements change for every lineage** on the next build (kernel loses PS/2, WLAN-gate, and rfkill code) — that's the point of the fix, but plan the bump accordingly.
- The committed `config-x86_64.snapshot` is stale: `891dbdc` was regenerated from a tree predating `30fb7b2`'s KSPP not-set lines (its own diff flips `# CONFIG_DEVMEM is not set` → `=y`; the honest merge keeps DEVMEM off). The next kernel build on a real builder rewrites it — review that diff when it lands.
- Verified via containerized kconfig replay (Apple-silicon fidelity caveat: GCC-plugin/pahole probe symbols can't be checked there; the existing `=y` verification already covers them in real builds).