### PR TITLE
feat(c8s): operator-key RTMR[3] binding — initrd extender + baked cred-release unit (B1)

### DIFF
--- a/.github/workflows/c8s.yml
+++ b/.github/workflows/c8s.yml
@@ -19,6 +19,11 @@ name: Build c8s Node Image
 
 on:
   workflow_dispatch:
+    inputs:
+      c8s_ref:
+        description: "c8s commit short-SHA to bake the c8s binary from (resolves nri-image-policy:<ref>). Empty = the hardcoded NRI_IMAGE digest. The per-commit image must be published (c8s docker.yml)."
+        required: false
+        default: ""
   push:
     branches:
       - ci/publish-c8s-image
@@ -133,6 +138,9 @@ jobs:
       - name: Build c8s image
         env:
           C8S_STOCK_ATTEST: "1"   # see TODO(attest-gpu) in the header
+          # Bake the c8s binary from a specific commit when dispatched with a
+          # c8s_ref input; empty on push builds (uses the hardcoded digest).
+          C8S_REF: ${{ github.event.inputs.c8s_ref }}
         run: bin/build-c8s
 
       - name: Setup ORAS

--- a/.github/workflows/c8s.yml
+++ b/.github/workflows/c8s.yml
@@ -8,13 +8,12 @@
 # build + ~3.5G of pinned artifacts) and privileged (mkosi sandbox needs
 # sudo + userns) — not a per-push job.
 #
-# TODO(attest-gpu): C8S_STOCK_ATTEST=1 below composes the stock `attest`
-# profile (attestation-api on :8400, TDX+SNP quotes) instead of
-# `attest-gpu` (adds per-GPU SPDM evidence) because attest-gpu's
-# mkosi.sync digest is still the Stage-4 sentinel and the pre-stage path
-# (bin/steep-fetch-attest-gpu) needs a local attestation-rs build CI
-# doesn't have. Once the attestation-rs `-gpu` image is published and
-# pinned, drop the env var so the published image collects GPU evidence.
+# attest-gpu: the build bakes an attestation-api built with
+# `--features nvidia-gpu-attest` (per-GPU SPDM evidence), which links NVIDIA's
+# Apache-2.0 libnvat.so. CI fetches a vendored libnvat (digest-pinned OCI
+# artifact) + builds the binary with NVAT_USE_SYSTEM_LIB=1, then
+# bin/steep-fetch-attest-gpu stages both into mkosi.local for the attest-gpu
+# profile's pre-stage escape hatch. No separate attestation-api-gpu image.
 name: Build c8s Node Image
 
 on:
@@ -153,23 +152,82 @@ jobs:
           path: output/gpu/cache
           key: ${{ runner.os }}-gpu-artifacts-${{ hashFiles('bin/steep-fetch-gpu') }}
 
+      # --- attest-gpu inputs -------------------------------------------------
+      # The attest-gpu profile bakes an attestation-api built with
+      # `--features nvidia-gpu-attest`, which links NVIDIA's libnvat.so (the
+      # per-GPU SPDM evidence collector). libnvat is Apache-2.0 and links only
+      # standard system libs (no NVML/CUDA), so we vendor a prebuilt
+      # libnvat.so + nvat.h as an OCI artifact and build the binary here with
+      # NVAT_USE_SYSTEM_LIB=1 (skips libnvat's own CMake/NVML from-source
+      # build). steep-fetch-attest-gpu then stages the binary + libnvat into
+      # mkosi.local, and mkosi.sync's pre-stage escape hatch trusts it — no
+      # separate attestation-api-gpu image, no GHCR round-trip.
+      # setup-oras + GHCR login moved here (before the build) because the build
+      # now pulls the vendored libnvat artifact; the post-build push reuses them.
+      - name: Setup ORAS
+        uses: oras-project/setup-oras@1d808f7d7f6995cc68b7bf507bfe5c5446e1dc9d # v2.0.1
+
+      - name: Log in to GHCR
+        run: |
+          echo ${{ secrets.GITHUB_TOKEN }} | oras login ghcr.io \
+            -u ${{ github.actor }} --password-stdin
+
+      - name: Fetch vendored libnvat (Apache-2.0)
+        env:
+          # Pinned by digest so CI verifies the exact vendored blobs; oras
+          # validates each layer's sha256 on pull. The tag (1.2.0) is retained
+          # in the reference for readability but the digest is authoritative.
+          LIBNVAT_REF: ghcr.io/confidential-dot-ai/libnvat@sha256:4b3c396dbe906b2f60042558ed0f2dc4791a96f840ba0970a6d358027c572819
+          # Independent content checksums (defense-in-depth over oras's own
+          # layer verification): the exact files we pushed from the source host.
+          LIBNVAT_SO_SHA256: 1dd6c5429632c8c9ae59aa687cf96593f01c5597afe342f72ec3d8d5ddb0bbae
+          NVAT_H_SHA256: c6c9f32538611c5dfca2a103bfba5a258156a5e7b035ef9f0b7e21f20151314b
+        run: |
+          set -euo pipefail
+          mkdir -p vendor/libnvat
+          oras pull "$LIBNVAT_REF" -o vendor/libnvat
+          echo "$LIBNVAT_SO_SHA256  vendor/libnvat/libnvat.so.1.2.0" | sha256sum -c -
+          echo "$NVAT_H_SHA256  vendor/libnvat/nvat.h" | sha256sum -c -
+          sudo install -m0755 vendor/libnvat/libnvat.so.1.2.0 \
+            /usr/lib/x86_64-linux-gnu/libnvat.so.1.2.0
+          sudo ln -sf libnvat.so.1.2.0 /usr/lib/x86_64-linux-gnu/libnvat.so.1
+          sudo ln -sf libnvat.so.1     /usr/lib/x86_64-linux-gnu/libnvat.so
+          sudo install -m0644 vendor/libnvat/nvat.h /usr/include/nvat.h
+          sudo ldconfig
+
+      - name: Checkout attestation-rs (for the gpu-attest binary)
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: confidential-dot-ai/attestation-rs
+          ref: main
+          path: attestation-rs
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build attestation-api (nvidia-gpu-attest)
+        env:
+          NVAT_USE_SYSTEM_LIB: "1"
+        working-directory: attestation-rs
+        run: |
+          # nv-attestation-sdk-sys generates bindings from nvat.h via bindgen,
+          # which needs libclang.
+          sudo apt-get install -y libclang-dev clang
+          cargo build -p attestation-api --release \
+            --features nvidia-gpu-attest --bin attestation-api
+          # Sanity: the binary must actually link libnvat (i.e. it is the
+          # GPU-collector build, not a silent fallback).
+          ldd target/release/attestation-api | grep -q libnvat
+
       - name: Build c8s image
         env:
-          C8S_STOCK_ATTEST: "1"   # see TODO(attest-gpu) in the header
+          # attest-gpu: steep-fetch-attest-gpu stages this binary + libnvat.
+          ATTEST_GPU_BIN: ${{ github.workspace }}/attestation-rs/target/release/attestation-api
+          LIBNVAT: /usr/lib/x86_64-linux-gnu/libnvat.so.1.2.0
           # Bake the c8s binary from a specific commit when dispatched with a
           # c8s_ref input; empty on push builds (uses the hardcoded digest).
           C8S_REF: ${{ github.event.inputs.c8s_ref }}
         # C8S_DEV comes from the variant step; pin C8S_NAME to the variant so
         # the output dir and the push/roothash paths below stay aligned.
         run: C8S_NAME="$VARIANT" bin/build-c8s
-
-      - name: Setup ORAS
-        uses: oras-project/setup-oras@v1
-
-      - name: Log in to GHCR
-        run: |
-          echo ${{ secrets.GITHUB_TOKEN }} | oras login ghcr.io \
-            -u ${{ github.actor }} --password-stdin
 
       # Skip the multi-GB push when the rootfs is byte-identical to what's
       # already published: the verity roothash is a content hash of the

--- a/.github/workflows/c8s.yml
+++ b/.github/workflows/c8s.yml
@@ -24,6 +24,11 @@ on:
         description: "c8s commit short-SHA to bake the c8s binary from (resolves nri-image-policy:<ref>). Empty = the hardcoded NRI_IMAGE digest. The per-commit image must be published (c8s docker.yml)."
         required: false
         default: ""
+      dev:
+        description: "Build the c8s-dev variant (console=ttyS0 + serial root autologin). Same as pushing to ci/publish-c8s-dev-image, but dispatchable so it can carry a c8s_ref."
+        required: false
+        type: boolean
+        default: false
   push:
     branches:
       - ci/publish-c8s-image
@@ -62,9 +67,11 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set image ref and variant
+        # Dev variant when pushing to the dev branch OR when dispatched with
+        # dev=true (so a dispatched build can carry a c8s_ref and still be dev).
         run: |
           echo "IMAGE=ghcr.io/${GITHUB_REPOSITORY@L}" >> "$GITHUB_ENV"
-          if [ "${GITHUB_REF_NAME}" = "ci/publish-c8s-dev-image" ]; then
+          if [ "${GITHUB_REF_NAME}" = "ci/publish-c8s-dev-image" ] || [ "${{ github.event.inputs.dev }}" = "true" ]; then
             echo "VARIANT=c8s-dev" >> "$GITHUB_ENV"
             echo "C8S_DEV=1" >> "$GITHUB_ENV"
           else

--- a/.github/workflows/c8s.yml
+++ b/.github/workflows/c8s.yml
@@ -208,9 +208,13 @@ jobs:
           NVAT_USE_SYSTEM_LIB: "1"
         working-directory: attestation-rs
         run: |
-          # nv-attestation-sdk-sys generates bindings from nvat.h via bindgen,
-          # which needs libclang.
-          sudo apt-get install -y libclang-dev clang
+          # Build deps for --features nvidia-gpu-attest:
+          #   - libclang-dev/clang: nv-attestation-sdk-sys generates bindings
+          #     from nvat.h via bindgen.
+          #   - libtss2-dev: the tss-esapi-sys (-sys, pkg-config) crate in the
+          #     attest chain needs tss2-*.pc (matches attestation-rs's own CI).
+          sudo apt-get update
+          sudo apt-get install -y libclang-dev clang libtss2-dev
           cargo build -p attestation-api --release \
             --features nvidia-gpu-attest --bin attestation-api
           # Sanity: the binary must actually link libnvat (i.e. it is the

--- a/.github/workflows/c8s.yml
+++ b/.github/workflows/c8s.yml
@@ -27,6 +27,10 @@ on:
   push:
     branches:
       - ci/publish-c8s-image
+      # Publishes the C8S_DEV=1 variant under :c8s-dev tags — console=ttyS0
+      # + serial root autologin for demos/debugging. Never overwrite :c8s
+      # with a dev build.
+      - ci/publish-c8s-dev-image
     paths:
       - "kernel/*.config"
       - "kernel/config-x86_64.snapshot"
@@ -57,8 +61,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set image ref
-        run: echo "IMAGE=ghcr.io/${GITHUB_REPOSITORY@L}" >> "$GITHUB_ENV"
+      - name: Set image ref and variant
+        run: |
+          echo "IMAGE=ghcr.io/${GITHUB_REPOSITORY@L}" >> "$GITHUB_ENV"
+          if [ "${GITHUB_REF_NAME}" = "ci/publish-c8s-dev-image" ]; then
+            echo "VARIANT=c8s-dev" >> "$GITHUB_ENV"
+            echo "C8S_DEV=1" >> "$GITHUB_ENV"
+          else
+            echo "VARIANT=c8s" >> "$GITHUB_ENV"
+          fi
 
       - name: Free up disk space
         # kernel compile + NVIDIA userspace + rke2 airgap bundles + a ~6G
@@ -100,7 +111,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: output/kernel
-          key: ${{ runner.os }}-kernel-c8s-${{ hashFiles('mkosi/kernel-builder/mkosi.conf','kernel/c8s.config','kernel/required.config','kernel/hardening.config','kernel/confidential.config','kernel/config-x86_64.snapshot','kernel/version','bin/build-c8s') }}
+          key: ${{ runner.os }}-kernel-${{ env.VARIANT }}-${{ hashFiles('mkosi/kernel-builder/mkosi.conf','kernel/c8s.config','kernel/c8s-dev.config','kernel/required.config','kernel/hardening.config','kernel/confidential.config','kernel/config-x86_64.snapshot','kernel/version','bin/build-c8s') }}
 
       # Distinct key prefix from base.yml: the c8s build's profiles add
       # ToolsTreePackages (oras, jq, curl), so the tree differs from the
@@ -141,7 +152,9 @@ jobs:
           # Bake the c8s binary from a specific commit when dispatched with a
           # c8s_ref input; empty on push builds (uses the hardcoded digest).
           C8S_REF: ${{ github.event.inputs.c8s_ref }}
-        run: bin/build-c8s
+        # C8S_DEV comes from the variant step; pin C8S_NAME to the variant so
+        # the output dir and the push/roothash paths below stay aligned.
+        run: C8S_NAME="$VARIANT" bin/build-c8s
 
       - name: Setup ORAS
         uses: oras-project/setup-oras@v1
@@ -160,8 +173,8 @@ jobs:
         id: changed
         run: |
           set -uo pipefail
-          new=$(cat output/c8s/roothash 2>/dev/null || echo new)
-          digest=$(oras manifest fetch "${IMAGE}:c8s" 2>/dev/null \
+          new=$(cat "output/${VARIANT}/roothash" 2>/dev/null || echo new)
+          digest=$(oras manifest fetch "${IMAGE}:${VARIANT}" 2>/dev/null \
                      | jq -r '.layers[] | select(.annotations["org.opencontainers.image.title"] == "roothash") | .digest' \
                      || true)
           pub=none
@@ -191,19 +204,19 @@ jobs:
           # (per-file layers, for verifiers and `confos pull`) last: the
           # change-check above reads :c8s, so a partial failure here leaves
           # it stale and the next run re-publishes everything.
-          bin/confos push output/c8s --cdi \
+          bin/confos push "output/${VARIANT}" --cdi \
             --registry "$IMAGE" \
-            --tag "c8s-cdi,c8s-cdi-${SHORT_SHA}"
-          bin/confos push output/c8s \
+            --tag "${VARIANT}-cdi,${VARIANT}-cdi-${SHORT_SHA}"
+          bin/confos push "output/${VARIANT}" \
             --registry "$IMAGE" \
-            --tag "c8s,c8s-${SHORT_SHA}"
+            --tag "${VARIANT},${VARIANT}-${SHORT_SHA}"
 
       - name: Summary
         run: |
           {
-            echo "### c8s confidential node image"
-            echo "- artifact: \`${IMAGE}:c8s\`"
-            echo "- CDI image: \`${IMAGE}:c8s-cdi\`"
+            echo "### ${VARIANT} confidential node image"
+            echo "- artifact: \`${IMAGE}:${VARIANT}\`"
+            echo "- CDI image: \`${IMAGE}:${VARIANT}-cdi\`"
             echo ""
             echo "Launch as a TDX CVM with a serial=confai-scratch disk (>=64G),"
             echo "expose 6443, then \`c8s install --distro rke2\`. See docs/C8S-IMAGE.md."

--- a/bin/build-c8s
+++ b/bin/build-c8s
@@ -29,6 +29,11 @@
 #                      once the attestation-rs `-gpu` image is published and
 #                      its digest pinned in attest-gpu/mkosi.sync (the
 #                      Stage-4 sentinel).
+#   C8S_DEV=1          demo/debug build: kernel/c8s-dev.config fragment
+#                      (8250 serial re-enabled) + the dev profile
+#                      (console=ttyS0, passwordless serial autologin).
+#                      Different measurement, root shell on the host-visible
+#                      serial socket — never ship. Default name: c8s-dev.
 #   C8S_NAME=...       output name (default c8s → output/c8s/)
 #   C8S_MEMORY=...     default-memory recorded in the manifest / used by
 #                      `confos run` (default 16G — etcd OOMs at the 4G default)
@@ -54,6 +59,12 @@ mkdir -p mkosi/base/mkosi.local
 printf '%s\n' "${C8S_REF:-}" > mkosi/base/mkosi.local/c8s-ref
 
 FRAGMENT=kernel/c8s.config
+DEV_PROFILE=()
+if [ "${C8S_DEV:-0}" = 1 ]; then
+    FRAGMENT=kernel/c8s-dev.config
+    DEV_PROFILE=(--profile dev)
+    : "${C8S_NAME:=c8s-dev}"
+fi
 KB_PKGS=dwarves,python3,pkg-config,zlib1g-dev
 
 bin/confos kernel \
@@ -73,6 +84,7 @@ fi
 
 exec bin/confos build "${C8S_NAME:-c8s}" \
     "${PROFILES[@]}" \
+    ${DEV_PROFILE[@]+"${DEV_PROFILE[@]}"} \
     --kernel-config-fragment "$FRAGMENT" \
     --kernel-builder-package "$KB_PKGS" \
     --cloud-init mkosi/base/mkosi.profiles/c8s/user-data \

--- a/bin/build-c8s
+++ b/bin/build-c8s
@@ -37,11 +37,11 @@
 #   C8S_NAME=...       output name (default c8s → output/c8s/)
 #   C8S_MEMORY=...     default-memory recorded in the manifest / used by
 #                      `confos run` (default 16G — etcd OOMs at the 4G default)
-#   C8S_REF=...        bake the c8s binary from a specific c8s COMMIT (short
-#                      SHA) instead of the hardcoded NRI_IMAGE digest. The c8s
-#                      profile's mkosi.sync resolves nri-image-policy:<ref> to a
-#                      digest. The per-commit image must be published first
-#                      (c8s docker.yml on main, or workflow_dispatch for a
+#   C8S_REF=...        bake the c8s components (nri plugin + the CDS digest in
+#                      the NRI floor) from a specific c8s COMMIT (short SHA)
+#                      instead of main. mkosi.sync resolves nri-image-policy:<ref>
+#                      and cds:<ref> to digests. The images must be published
+#                      first (c8s docker.yml on main, or workflow_dispatch for a
 #                      branch). Use to test an unmerged c8s build end-to-end.
 #
 # Extra args are passed through to `confos build`, e.g.:
@@ -54,7 +54,7 @@ cd "$(dirname "${BASH_SOURCE[0]}")/.."
 # Hand C8S_REF to the c8s profile's mkosi.sync via a file: an exported var
 # never reaches the sync (`confos build` runs mkosi under sudo, which strips
 # the env, and mkosi's script sandbox drops host vars). The sync reads
-# $SRCDIR/mkosi.local/c8s-ref; absent or empty = the hardcoded digest.
+# $SRCDIR/mkosi.local/c8s-ref; absent or empty defaults to main.
 mkdir -p mkosi/base/mkosi.local
 printf '%s\n' "${C8S_REF:-}" > mkosi/base/mkosi.local/c8s-ref
 

--- a/bin/build-c8s
+++ b/bin/build-c8s
@@ -8,9 +8,9 @@
 #
 #   1. confos kernel          — build/cache the kernel with kernel/c8s.config
 #   2. bin/steep-fetch-gpu    — build+sign NVIDIA modules, stage userspace
-#   3. bin/steep-fetch-attest-gpu — pre-stage the GPU attestation-api
-#      (required until the attestation-rs `-gpu` image is published and its
-#      digest pinned in attest-gpu/mkosi.sync — the Stage-4 sentinel)
+#   3. bin/steep-fetch-attest-gpu — pre-stage the GPU attestation-api binary
+#      + libnvat into mkosi.local (set ATTEST_GPU_BIN + LIBNVAT; CI builds the
+#      binary with --features nvidia-gpu-attest against a vendored libnvat)
 #   4. confos build           — the c8s profile's own mkosi.sync fetches
 #      rke2 + airgap bundles + nri-image-policy during this step
 #
@@ -23,12 +23,11 @@
 #                      manually via extra args)
 #   C8S_STOCK_ATTEST=1 compose the stock `attest` profile instead of
 #                      `attest-gpu`: same attestation-api service on :8400,
-#                      TDX+SNP quotes, but no GPU evidence collection. For
-#                      CI, where the local attestation-rs `-gpu` build that
-#                      steep-fetch-attest-gpu needs doesn't exist. Remove
-#                      once the attestation-rs `-gpu` image is published and
-#                      its digest pinned in attest-gpu/mkosi.sync (the
-#                      Stage-4 sentinel).
+#                      TDX+SNP quotes, but no GPU (SPDM) evidence collection.
+#                      Use when a build environment lacks libnvat / can't build
+#                      the nvidia-gpu-attest binary. The default (this var
+#                      unset) composes attest-gpu, which CI now supports via a
+#                      vendored libnvat + steep-fetch-attest-gpu pre-stage.
 #   C8S_DEV=1          demo/debug build: kernel/c8s-dev.config fragment
 #                      (8250 serial re-enabled) + the dev profile
 #                      (console=ttyS0, passwordless serial autologin).

--- a/bin/build-c8s
+++ b/bin/build-c8s
@@ -46,8 +46,12 @@
 set -euo pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
 
-# Export so the c8s profile's mkosi.sync (run by `confos build`) sees it.
-export C8S_REF="${C8S_REF:-}"
+# Hand C8S_REF to the c8s profile's mkosi.sync via a file: an exported var
+# never reaches the sync (`confos build` runs mkosi under sudo, which strips
+# the env, and mkosi's script sandbox drops host vars). The sync reads
+# $SRCDIR/mkosi.local/c8s-ref; absent or empty = the hardcoded digest.
+mkdir -p mkosi/base/mkosi.local
+printf '%s\n' "${C8S_REF:-}" > mkosi/base/mkosi.local/c8s-ref
 
 FRAGMENT=kernel/c8s.config
 KB_PKGS=dwarves,python3,pkg-config,zlib1g-dev

--- a/bin/build-c8s
+++ b/bin/build-c8s
@@ -32,6 +32,12 @@
 #   C8S_NAME=...       output name (default c8s → output/c8s/)
 #   C8S_MEMORY=...     default-memory recorded in the manifest / used by
 #                      `confos run` (default 16G — etcd OOMs at the 4G default)
+#   C8S_REF=...        bake the c8s binary from a specific c8s COMMIT (short
+#                      SHA) instead of the hardcoded NRI_IMAGE digest. The c8s
+#                      profile's mkosi.sync resolves nri-image-policy:<ref> to a
+#                      digest. The per-commit image must be published first
+#                      (c8s docker.yml on main, or workflow_dispatch for a
+#                      branch). Use to test an unmerged c8s build end-to-end.
 #
 # Extra args are passed through to `confos build`, e.g.:
 #   bin/build-c8s --profile ssh          # + SSH for bring-up debugging
@@ -39,6 +45,9 @@
 
 set -euo pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+# Export so the c8s profile's mkosi.sync (run by `confos build`) sees it.
+export C8S_REF="${C8S_REF:-}"
 
 FRAGMENT=kernel/c8s.config
 KB_PKGS=dwarves,python3,pkg-config,zlib1g-dev

--- a/bin/lint
+++ b/bin/lint
@@ -22,6 +22,18 @@ if [ -n "$missing" ]; then
     exit 1
 fi
 
+# kernel/c8s-dev.config (C8S_DEV=1 demo builds) is the union of c8s.config
+# and dev.config, committed verbatim for the same one-fragment reason.
+for src in kernel/c8s.config kernel/dev.config; do
+    missing=$(grep -E '^CONFIG_|^# CONFIG_.* is not set$' "$src" \
+              | grep -vFxf kernel/c8s-dev.config || true)
+    if [ -n "$missing" ]; then
+        echo "bin/lint: kernel/c8s-dev.config must contain every effective line of $src; missing:" >&2
+        echo "$missing" >&2
+        exit 1
+    fi
+done
+
 # The NRI_IMAGE digest pinned in the c8s sync must be the one the baked
 # boot policy self-allows, or the measured fail-closed floor denies the
 # very plugin image it ships.

--- a/bin/lint
+++ b/bin/lint
@@ -34,21 +34,14 @@ for src in kernel/c8s.config kernel/dev.config; do
     fi
 done
 
-# The NRI_IMAGE digest pinned in the c8s sync must be the one the baked
-# boot policy self-allows, or the measured fail-closed floor denies the
-# very plugin image it ships.
+# The baked NRI floor is a template (image-policy.yaml.in) whose always_allow
+# entries are @-tokens the c8s sync fills with the ref-resolved nri + cds
+# digests. It must NOT carry a hardcoded sha256 there — a literal would bake a
+# stale digest the fail-closed floor then can't reconcile with the ref.
 c8s_profile=mkosi/base/mkosi.profiles/c8s
-nri_digest=$(sed -n 's/^NRI_IMAGE=.*@\(sha256:[a-f0-9]*\)".*$/\1/p' "$c8s_profile/mkosi.sync")
-policy="$c8s_profile/mkosi.extra/etc/nri/conf.d/image-policy.yaml"
-[ -n "$nri_digest" ] && [ -f "$policy" ] || {
-    echo "bin/lint: NRI_IMAGE pin or baked image-policy.yaml not found" >&2
-    exit 1
-}
-# Compare the full digest set (always_allow map keys AND reference values)
-# against the pin, so a half-bumped entry can't hide behind the other half.
-policy_digests=$(grep -F 'nri-image-policy' "$policy" | grep -oE 'sha256:[a-f0-9]{64}' | sort -u)
-if [ "$policy_digests" != "$nri_digest" ]; then
-    echo "bin/lint: $policy must reference exactly the NRI_IMAGE digest pinned in mkosi.sync ($nri_digest); found:" >&2
-    echo "${policy_digests:-  <none>}" >&2
+policy="$c8s_profile/image-policy.yaml.in"
+[ -f "$policy" ] || { echo "bin/lint: NRI floor template $policy not found" >&2; exit 1; }
+if grep -qE '^[[:space:]]*"sha256:[a-f0-9]{64}"[[:space:]]*:' "$policy"; then
+    echo "bin/lint: $policy has a hardcoded always_allow digest; use @NRI_DIGEST@/@CDS_DIGEST@ tokens (rendered from C8S_REF by mkosi.sync)" >&2
     exit 1
 fi

--- a/bin/steep-fetch-gpu
+++ b/bin/steep-fetch-gpu
@@ -35,6 +35,14 @@ readonly RUN_INSTALLER="https://us.download.nvidia.com/tesla/${NV_VERSION}/NVIDI
 readonly OGKM_SHA256="cb26114c97ef2568377a7eb55ef97e559c42f1b686238b4d09d7a6fabd0cad50"
 readonly RUN_SHA256="36203b8960b7e49c8a42f6ba1f5863cde34a05e93d2b24b798af06dd846f6b82"
 
+# nvidia-container-toolkit-base: nvidia-ctk (CDI spec generation at boot) +
+# nvidia-cdi-hook (referenced by the generated spec). CDI-only GPU-pod path —
+# no nvidia-container-runtime wrapper, containerd 2.x injects CDI devices
+# natively. sha256 from the repo's Packages index; bump both together.
+readonly TK_VERSION="1.19.1-1"
+readonly TK_DEB="https://nvidia.github.io/libnvidia-container/stable/deb/amd64/nvidia-container-toolkit-base_${TK_VERSION}_amd64.deb"
+readonly TK_SHA256="b6c5b4e77a28cde0197cc0e64edf75538604775d9f8aea502cef667e7e5b2132"
+
 # --- Paths ---
 readonly KERNEL_OUT="output/kernel"
 readonly TOOLS_TREE="mkosi/kernel-builder/mkosi.output/image"
@@ -215,6 +223,16 @@ stage_bin nvidia-smi
 stage_bin nvidia-persistenced
 stage_bin nvidia-modprobe 4755   # setuid root — creates device nodes on demand
 
+# CUDA userspace driver stack — what a CUDA app (inference containers via CDI
+# bind-mounts) actually dlopens: libcuda + its JIT/compiler companions. Without
+# these the image can run nvidia-smi but no CUDA workload.
+stage_lib libcuda.so
+stage_lib libcudadebugger.so
+stage_lib libnvidia-nvvm.so
+stage_lib libnvidia-ptxjitcompiler.so
+stage_lib libnvidia-gpucomp.so
+stage_lib libnvidia-allocator.so
+
 # GSP firmware: the open modules request_firmware() a GSP blob at load time.
 # It must live at /lib/firmware/nvidia/<ver>/. Stage the whole per-version dir.
 log "Staging GSP firmware"
@@ -222,5 +240,22 @@ FW_SRC="$(find "$RUN_SRC/firmware" -maxdepth 1 -name '*.bin' -print -quit 2>/dev
 [[ -n "$FW_SRC" ]] || die "no GSP firmware .bin found under $RUN_SRC/firmware"
 install -d "$STAGE/usr/lib/firmware/nvidia/${NV_VERSION}"
 install -m0644 "$RUN_SRC"/firmware/*.bin "$STAGE/usr/lib/firmware/nvidia/${NV_VERSION}/"
+
+# =============================================================================
+# Part 3: stage nvidia-ctk + nvidia-cdi-hook from the container-toolkit deb
+# =============================================================================
+# CDI GPU-pod path: a boot oneshot (nvidia-cdi-generate.service, gpu profile)
+# runs `nvidia-ctk cdi generate`; the spec's hooks exec nvidia-cdi-hook. The
+# nvidia-container-runtime shim in the same deb is deliberately NOT staged.
+log "Staging nvidia-ctk + nvidia-cdi-hook from container-toolkit ${TK_VERSION}"
+fetch "$TK_DEB" "$TK_SHA256" "$CACHE/nvidia-container-toolkit-base_${TK_VERSION}_amd64.deb"
+rm -rf "$WORK/tk"
+mkdir -p "$WORK/tk"
+dpkg-deb -x "$CACHE/nvidia-container-toolkit-base_${TK_VERSION}_amd64.deb" "$WORK/tk"
+for b in nvidia-ctk nvidia-cdi-hook; do
+  [[ -x "$WORK/tk/usr/bin/$b" ]] || die "$b not found in toolkit-base deb"
+  install -D -m0755 "$WORK/tk/usr/bin/$b" "$STAGE/usr/bin/$b"
+done
+rm -rf "$WORK/tk"
 
 log "steep-fetch-gpu done — modules + userspace staged under $STAGE"

--- a/docs/C8S-IMAGE.md
+++ b/docs/C8S-IMAGE.md
@@ -155,6 +155,42 @@ against this image, all verified against the chart source:
   deployment's expected measurements (`cds.measurements` values) so the
   mesh verifies the node it runs on.
 
+## Operator-key access (console-free, non-TOFU)
+
+An external operator gets an admin kubeconfig for the sealed cluster with
+only their own ECDSA key — no console, no pre-shared secret, no host trust,
+not trust-on-first-use. Launch-time and boot-time pieces:
+
+- **Launch** binds the operator's public key: `confai launch
+  --operator-key <op.pub>` attaches a labelled `opkeydata` disk carrying the
+  raw pubkey (TDX only).
+- **Boot**: the initrd (`mkosi/initrd/mkosi.extra/init`) reads the pubkey,
+  hashes it, and extends `SHA384(0x00*48 || SHA384(op_pub))` into RTMR[3]
+  before `switch_root`, then stages the pubkey to
+  `/etc/confai/operator-pubkey`. Fail-closed: key supplied but extend fails
+  → reboot, never boot with the binding stripped.
+- **Release**: the baked `cred-release.service` (`:8443`, RA-TLS) re-checks
+  `SHA384(pubkey file) == own RTMR[3]`, then issues the operator a
+  cluster-admin client cert signed by the RKE2 **client** CA over an
+  attested channel. The operator runs `c8s get-kubeconfig --node <ip>
+  --operator-key <op.key>`: it verifies the node's TDX quote in-process
+  (rtmr[3] == H(op_pub)) and RA-TLS-verifies the `:8443` serving cert
+  against the same quote, so the host can't MITM.
+
+Two failure modes hard-won here (both fixed; noted so they stay fixed):
+
+- **RTMR[3] extend must be a single 48-byte write.** `bash` `printf` splits
+  its output at `0x0a` bytes, so redirecting it at the extend node fails for
+  the ~1-in-6 keys whose digest contains a newline — and the fail-closed
+  extender then reboot-loops. The initrd converts to a tmpfs file and
+  `dd bs=48 count=1`.
+- **The kubeconfig must carry the SERVING CA, not the client CA.** RKE2 signs
+  the apiserver serving cert with `server-ca.crt`, distinct from the
+  `client-ca.crt` that signs kube clients. `cred-release` releases the
+  serving CA (`--server-ca-cert`, RKE2 default) as the kubeconfig trust
+  anchor; releasing the client CA fails `kubectl` with "certificate signed
+  by unknown authority". On kubeadm both are `/etc/kubernetes/pki/ca.crt`.
+
 ## Validation stages
 
 - **S0 kernel**: `bin/confos kernel --kernel-config-fragment

--- a/docs/C8S-IMAGE.md
+++ b/docs/C8S-IMAGE.md
@@ -232,7 +232,7 @@ GPUs are schedulable as `nvidia.com/gpu` on the inner cluster, CDI end to end
   regenerated per boot from the measured driver, skipped on GPU-less boots).
 - **Cluster-side** (c8s profile): a digest-pinned nvidia-device-plugin
   DaemonSet baked at `server/manifests/nvidia-device-plugin.yaml`, kube-system
-  (PSA- and allowlist-exempt), `DEVICE_LIST_STRATEGY=cdi-cri`,
+  (PSA- and allowlist-exempt), `DEVICE_LIST_STRATEGY=cdi-annotations`,
   `FAIL_ON_INIT_ERROR=false` so GPU-less boots stay degraded-nothing.
 - **Runtime**: RKE2's containerd 2.x has CDI enabled by default and injects
   the devices at pod creation.

--- a/docs/C8S-IMAGE.md
+++ b/docs/C8S-IMAGE.md
@@ -219,17 +219,28 @@ Two failure modes hard-won here (both fixed; noted so they stay fixed):
 - **S5 CI + publish**: c8s.yml green; a no-change rerun hits the
   roothash publish-skip; pulled artifact re-verifies.
 
-## Deferred: GPU pods (follow-up)
+## GPU pods
 
-The gpu profile makes GPUs host-visible (`nvidia-smi`, CC Ready) but NOT
-schedulable as pod resources. That needs (a) image-side:
-nvidia-container-toolkit (`nvidia-ctk`, `nvidia-container-runtime{,-hook}`,
-`libnvidia-container`) plus either a boot oneshot generating a CDI spec
-(`nvidia-ctk cdi generate` — lands on the overlay but derives from the
-measured driver) or a containerd runtime drop-in; and (b) cluster-side:
-nvidia-device-plugin (could be baked as a `server/manifests/` file,
-digest-pinned). Do this only after S4 passes so GPU-pod breakage never
-conflates with enforcement bring-up.
+GPUs are schedulable as `nvidia.com/gpu` on the inner cluster, CDI end to end
+— no nvidia-container-runtime wrapper:
+
+- **Image-side** (`bin/steep-fetch-gpu` + gpu profile): the CUDA userspace
+  driver stack (`libcuda` + JIT/compiler companions — without these the image
+  ran `nvidia-smi` but no CUDA workload), `nvidia-ctk`/`nvidia-cdi-hook` from
+  the pinned container-toolkit deb, and `nvidia-cdi-generate.service` — a boot
+  oneshot after persistenced that writes `/var/run/cdi/nvidia.yaml` (tmpfs;
+  regenerated per boot from the measured driver, skipped on GPU-less boots).
+- **Cluster-side** (c8s profile): a digest-pinned nvidia-device-plugin
+  DaemonSet baked at `server/manifests/nvidia-device-plugin.yaml`, kube-system
+  (PSA- and allowlist-exempt), `DEVICE_LIST_STRATEGY=cdi-cri`,
+  `FAIL_ON_INIT_ERROR=false` so GPU-less boots stay degraded-nothing.
+- **Runtime**: RKE2's containerd 2.x has CDI enabled by default and injects
+  the devices at pod creation.
+
+A GPU workload just requests `resources.limits: {nvidia.com/gpu: N}`. Its
+image must still be on the NRI allowlist (workload namespaces are not
+exempt). Not yet covered: NVSwitch passthrough + in-guest fabric manager —
+NVLink P2P for multi-GPU TP is unvalidated; NCCL may fall back to SHM.
 
 ## Risks / open questions
 

--- a/kernel/c8s-dev.config
+++ b/kernel/c8s-dev.config
@@ -1,0 +1,286 @@
+# Combined kernel fragment for C8S_DEV=1 demo/debug builds of the c8s image:
+# every line of kernel/c8s.config plus kernel/dev.config's opt-ins (8250
+# serial for KubeVirt's ttyS0 console, open debugfs). Only one
+# --kernel-config-fragment is accepted per build, so the union is committed
+# verbatim; bin/lint enforces both superset invariants. Images built from
+# this fragment have a different measurement and a serial root shell —
+# never ship them.
+
+# c8s kernel config fragment — the GPU fragment plus the Kubernetes/container
+# runtime symbols the c8s node image needs.
+#
+# Applied for the c8s node image, via
+#   bin/confos kernel --kernel-config-fragment kernel/c8s.config
+#   bin/confos build  --kernel-config-fragment kernel/c8s.config \
+#       --profile gpu --profile attest-gpu --profile c8s
+# (wired through bin/build-c8s). Only one --kernel-config-fragment is accepted
+# per build, so this file is a superset: it contains every effective line of
+# kernel/gpu.config VERBATIM (bin/lint enforces that inclusion — edit
+# gpu.config first, then mirror here), followed by the container/k8s set.
+#
+# The container/k8s section is ported from base-images rke2/kernel/
+# container.config, which was validated end-to-end under c8s (RKE2 v1.34 +
+# Cilium + ratls-mesh) on the SNP rke2 image. Comments preserved — each one
+# encodes a real failure mode.
+#
+# NOT ported from container.config (KubeVirt-SNP launch stack specifics; the
+# confos TDX base boots without them — re-add if a launch stack needs them):
+#   CONFIG_VIRTIO_IOMMU        (KubeVirt forces iommu_platform under SEV-SNP)
+#   CONFIG_SERIAL_8250(_CONSOLE) (kernel/dev.config is the serial opt-in here)
+
+# ===========================================================================
+# kernel/gpu.config — verbatim effective lines. Full rationale (ephemeral
+# module signing, LKCA for NVIDIA SPDM, vsock quote path + unit-level
+# fencing) lives in that file; keep the two in lockstep.
+# ===========================================================================
+
+CONFIG_MODULES=y
+# CONFIG_MODULE_UNLOAD is not set
+
+CONFIG_MODULE_SIG=y
+CONFIG_MODULE_SIG_FORCE=y
+CONFIG_MODULE_SIG_ALL=y
+CONFIG_MODULE_SIG_SHA512=y
+
+CONFIG_CRYPTO_ECC=y
+CONFIG_CRYPTO_ECDH=y
+CONFIG_CRYPTO_ECDSA=y
+CONFIG_CRYPTO_KPP=y
+
+CONFIG_VSOCKETS=y
+CONFIG_VIRTIO_VSOCKETS=y
+
+# With CONFIG_MODULES=y + DEBUG_INFO_BTF (below), Kconfig defaults
+# DEBUG_INFO_BTF_MODULES on, which drags pahole into the out-of-tree NVIDIA
+# module build (bin/steep-fetch-gpu) and risks BTF-mismatch noise at modprobe.
+# Cilium only needs vmlinux BTF; module BTF stays off.
+# CONFIG_DEBUG_INFO_BTF_MODULES is not set
+
+# ===========================================================================
+# Container/Kubernetes runtime prerequisites (from base-images
+# rke2/kernel/container.config). Widen the hardened kernel just enough that
+# kubelet, containerd, runc, and Cilium all start cleanly. Everything =y —
+# nothing here may require a runtime modprobe (nvidia-modules-latch sets
+# kernel.modules_disabled=1 after the NVIDIA driver loads).
+# ===========================================================================
+
+# --- Container runtime essentials ----------------------------------------
+
+# kubelet refuses to start without memory cgroup support.
+CONFIG_MEMCG=y
+
+# User namespaces. Required by several container runtimes (runc rootless
+# mode, several BPF features).
+CONFIG_USER_NS=y
+
+# Pod CPU limits (CFS quota/period). Without this, `resources.limits.cpu`
+# silently has no effect.
+CONFIG_CFS_BANDWIDTH=y
+
+# Runtimes that watch container filesystems for events (falco, auditd
+# integrations, observability tools).
+CONFIG_FANOTIFY=y
+
+# kubelet credential cache.
+CONFIG_PERSISTENT_KEYRINGS=y
+
+# --- Pod networking devices ----------------------------------------------
+
+# Virtual ethernet pairs — every pod is connected to the host via veth.
+CONFIG_VETH=y
+
+# Linux bridge — used by the default CNI bridge plugin and as the underlying
+# device for VXLAN/Geneve overlays.
+CONFIG_BRIDGE=y
+# Netfilter hooks on bridge traffic (br_netfilter). Required for two reasons:
+#   1. Packets bridged between veth pairs BYPASS iptables/nftables unless
+#      br_netfilter is active — service-IP DNAT silently never fires.
+#   2. Creates /proc/sys/net/bridge/ where the bridge-nf-call-iptables
+#      sysctls live (set in the c8s profile's etc/sysctl.d/90-rke2.conf).
+CONFIG_BRIDGE_NETFILTER=y
+
+# Overlay encapsulation (Cilium VXLAN default; Geneve as the alternative).
+CONFIG_VXLAN=y
+CONFIG_GENEVE=y
+
+# TUN/TAP. Several CNIs and IPsec setups need it.
+CONFIG_TUN=y
+
+# Additional veth-style plugins (Multus, custom CNI chains).
+CONFIG_MACVLAN=y
+CONFIG_IPVLAN=y
+
+# Dummy interface — Cilium uses this for the host network namespace's
+# reverse-path verification flow.
+CONFIG_DUMMY=y
+
+# --- Modern netfilter backend --------------------------------------------
+
+# nftables — kube-proxy's default backend since k8s 1.31. Legacy iptables is
+# already in required.config.
+CONFIG_NF_TABLES=y
+CONFIG_NF_TABLES_INET=y
+CONFIG_NF_TABLES_NETDEV=y
+
+# Per-feature nftables symbols. Without them `nft add rule ... dnat to ...`
+# fails silently and service IP traffic isn't NATed. NAT: DNAT/SNAT chains
+# (service IP redirect). MASQ: outbound pod masquerading. REDIR: local-port
+# redirect. REJECT: services with no endpoints. CT: conntrack match.
+# LIMIT: rate limits. FIB: route-lookup expression.
+CONFIG_NFT_NAT=y
+CONFIG_NFT_MASQ=y
+CONFIG_NFT_REDIR=y
+CONFIG_NFT_REJECT=y
+CONFIG_NFT_REJECT_INET=y
+CONFIG_NFT_REJECT_IPV4=y
+CONFIG_NFT_REJECT_IPV6=y
+CONFIG_NFT_CT=y
+CONFIG_NFT_LIMIT=y
+CONFIG_NFT_FIB=y
+CONFIG_NFT_FIB_INET=y
+CONFIG_NFT_FIB_IPV4=y
+CONFIG_NFT_FIB_IPV6=y
+# Compatibility shim — `iptables-nft` translates legacy iptables commands to
+# nftables. RKE2 ships iptables-nft as its bundled `iptables` binary, and
+# many CNI plugins shell out to it. Without NFT_COMPAT the translation fails.
+CONFIG_NFT_COMPAT=y
+
+# Conntrack netlink — kube-proxy flushes stale entries via this when service
+# endpoints change.
+CONFIG_NF_CT_NETLINK=y
+
+# NAT helper the MASQUERADE target depends on for the actual masquerade work.
+CONFIG_NF_NAT_MASQUERADE=y
+
+# Individual xt_ matches that NetworkPolicy enforcement uses.
+#
+# NETFILTER_ADVANCED gates most xt_ matches (incl. OWNER, RECENT, STATISTIC
+# below): the hardened base leaves it unset, so olddefconfig SILENTLY DROPS
+# any xt_ match whose Kconfig `depends on NETFILTER_ADVANCED` — the option
+# just vanishes from the built kernel with no error. Must be =y for the
+# matches below to actually compile in.
+CONFIG_NETFILTER_ADVANCED=y
+CONFIG_NETFILTER_XT_MATCH_ADDRTYPE=y
+CONFIG_NETFILTER_XT_MATCH_CONNTRACK=y
+CONFIG_NETFILTER_XT_MATCH_COMMENT=y
+CONFIG_NETFILTER_XT_MATCH_MULTIPORT=y
+CONFIG_NETFILTER_XT_MATCH_RECENT=y
+CONFIG_NETFILTER_XT_MATCH_STATISTIC=y
+CONFIG_NETFILTER_XT_MATCH_MARK=y
+# owner match (-m owner --uid-owner): c8s ratls-mesh's iptables-sync skips its
+# own mesh-UID traffic with it. Without xt_owner the rule append fails ("owner
+# revision 0 not supported, missing kernel module" → RULE_APPEND failed), the
+# RATLS-MESH nat chains are left half-built, and pod egress to ClusterIPs
+# (incl. CoreDNS) returns EPERM — cascading every c8s component.
+CONFIG_NETFILTER_XT_MATCH_OWNER=y
+CONFIG_NETFILTER_XT_TARGET_REDIRECT=y
+CONFIG_NETFILTER_XT_NAT=y
+CONFIG_NF_NAT_REDIRECT=y
+CONFIG_NF_TPROXY_IPV4=y
+# Cilium's iptables datapath targets/matches (audited against Cilium 1.19's
+# system-requirements). xt_CT is the proven blocker (the VXLAN-tunnel
+# raw-table `-j CT --notrack` rule — its failure breaks host↔pod overlay
+# traffic, so kubelet probes to pod IPs time out and CoreDNS/everything
+# crashloops); the other three (MARK target, SOCKET match, TPROXY target) are
+# the rest of Cilium's documented netfilter set. (NOT added: XFRM/CRYPTO —
+# IPsec, unused; NETKIT — veth mode; NET_SCH_FQ — bandwidth manager,
+# disabled.) Deps satisfied: NETFILTER_ADVANCED, NFT_COMPAT, NF_TPROXY_IPV4
+# present; XT_MATCH_SOCKET auto-selects NF_SOCKET_IPV4.
+CONFIG_NETFILTER_XT_TARGET_CT=y
+CONFIG_NETFILTER_XT_TARGET_MARK=y
+CONFIG_NETFILTER_XT_MATCH_SOCKET=y
+CONFIG_NETFILTER_XT_TARGET_TPROXY=y
+
+# --- kube-proxy IPVS mode ------------------------------------------------
+
+CONFIG_IP_VS=y
+CONFIG_IP_VS_NFCT=y
+CONFIG_IP_VS_RR=y
+CONFIG_IP_VS_WRR=y
+CONFIG_IP_VS_SH=y
+
+# ipsets — IP_SET is the ipset core; NETFILTER_XT_SET is the separate xtables
+# glue that lets iptables rules reference a set via `-m set --match-set` —
+# c8s ratls-mesh's REDIRECT/DNAT rules need it ("set revision 0 not
+# supported" without it).
+CONFIG_IP_SET=y
+CONFIG_IP_SET_HASH_IP=y
+CONFIG_IP_SET_HASH_NET=y
+CONFIG_NETFILTER_XT_SET=y
+
+# --- BPF (Cilium, kubelet, observability) --------------------------------
+
+# eBPF syscall + JIT. Cilium won't load without these, and modern kubelet
+# uses BPF for several functions even with non-BPF CNIs.
+CONFIG_BPF_SYSCALL=y
+CONFIG_BPF_JIT=y
+
+# BPF programs attached to cgroup events (Cilium's egress connect hooks,
+# systemd's BPF firewall, etc.).
+CONFIG_CGROUP_BPF=y
+
+# BPF in tc — Cilium's datapath is built on these.
+CONFIG_NET_CLS_BPF=y
+CONFIG_NET_ACT_BPF=y
+CONFIG_NET_SCH_INGRESS=y
+
+# --- Encrypted containerd data disk (containerd-data-disk.service) -------
+
+# containerd-data-disk.service backs /var/lib/rancher/rke2/agent/containerd
+# (the image cache) with a LABEL=containerd disk it encrypts in-guest,
+# keeping several GiB of image layers off guest RAM (the tmpfs default). It
+# uses `cryptsetup open --type plain --cipher aes-xts-plain64`, which needs
+# dm-crypt + the XTS template + AES in the BOOTED kernel — without them
+# cryptsetup HANGS at boot (the device-mapper target never appears). The
+# service has a fail-safe timeout, but the encrypted path only actually
+# works with these on.
+CONFIG_DM_CRYPT=y
+CONFIG_CRYPTO_XTS=y
+CONFIG_CRYPTO_AES_NI_INTEL=y
+
+# --- Filesystem extras ---------------------------------------------------
+
+# Several snapshotters (stargz, soci, nydus) use FUSE.
+CONFIG_FUSE_FS=y
+
+# squashfs — useful on every image for inspecting kata images.
+CONFIG_SQUASHFS=y
+CONFIG_SQUASHFS_XATTR=y
+CONFIG_SQUASHFS_ZSTD=y
+
+# --- Socket diagnostics --------------------------------------------------
+
+# `ss`, `netstat`, several observability agents read these.
+CONFIG_INET_DIAG=y
+CONFIG_INET_TCP_DIAG=y
+CONFIG_INET_UDP_DIAG=y
+CONFIG_INET_RAW_DIAG=y
+CONFIG_INET_DIAG_DESTROY=y
+
+# --- BTF (Cilium socket-LB) ----------------------------------------------
+
+# pahole turns the kernel's DWARF into BTF, which eBPF CO-RE needs. Without
+# it /sys/kernel/btf/vmlinux is absent and Cilium's socket-LB can't
+# translate ClusterIP service VIPs: connect() to any Service IP (CoreDNS,
+# kube-api) returns EPERM, breaking c8s (cds → attestation-api .svc).
+# Overrides hardening.config's `# CONFIG_DEBUG_INFO is not set`. Requires
+# dwarves (pahole) in the kernel-builder tools tree — hence
+# --kernel-builder-package dwarves,python3,pkg-config,zlib1g-dev.
+CONFIG_DEBUG_INFO=y
+CONFIG_DEBUG_INFO_DWARF5=y
+CONFIG_DEBUG_INFO_BTF=y
+
+# DEBUG_INFO_BTF depends on !GCC_PLUGIN_RANDSTRUCT — pahole cannot describe
+# randomized struct layouts. Overrides hardening.config's RANDSTRUCT_FULL:
+# the c8s kernel trades struct-layout randomization for BTF, the same trade
+# every BTF-shipping distro kernel makes.
+# CONFIG_RANDSTRUCT_FULL is not set
+CONFIG_RANDSTRUCT_NONE=y
+
+# --- kernel/dev.config opt-ins (verbatim; merged last so they win) ---
+CONFIG_SERIAL_8250=y
+CONFIG_SERIAL_8250_CONSOLE=y
+CONFIG_SERIAL_8250_PCI=y
+CONFIG_SERIAL_8250_NR_UARTS=4
+CONFIG_SERIAL_8250_RUNTIME_UARTS=4
+CONFIG_DEBUG_FS_ALLOW_ALL=y

--- a/mkosi/base/mkosi.profiles/attest/mkosi.sync
+++ b/mkosi/base/mkosi.profiles/attest/mkosi.sync
@@ -39,7 +39,7 @@ mkdir -p "${TMPDIR:=/tmp}"
 # a binary that supports both SEV-SNP (`/dev/sev-guest`) and Intel TDX
 # (`/dev/tdx_guest`); see attestation-api/src/config.rs's
 # SUPPORTED_ATTESTATION_PLATFORMS for the full list.
-IMAGE="ghcr.io/confidential-dot-ai/attestation-api@sha256:724019b3b4787141da6f8c96b74fa3f39f48f54c10a813df4790778b0d4d0e81"
+IMAGE="ghcr.io/confidential-dot-ai/attestation-api@sha256:8dfb4db34d966374c3dbd81548c532a2015123d41f3aab553cea1cb7a327c8e9"
 
 mkdir -p "$STAGE_DIR"
 

--- a/mkosi/base/mkosi.profiles/c8s/image-policy.yaml.in
+++ b/mkosi/base/mkosi.profiles/c8s/image-policy.yaml.in
@@ -1,4 +1,8 @@
-# nri-image-policy boot config — the MEASURED boot-time floor.
+# nri-image-policy boot config — the MEASURED boot-time floor. TEMPLATE:
+# mkosi.sync renders this to etc/nri/conf.d/image-policy.yaml at build time,
+# substituting @NRI_DIGEST@/@NRI_IMAGE@ and @CDS_DIGEST@/@CDS_IMAGE@ with the
+# C8S_REF-resolved digests (see render_nri_floor). Edit this file, not the
+# generated one.
 #
 # The plugin binary is baked at /opt/nri/plugins/10-nri-image-policy and
 # containerd launches it pre-registered (see the NRI drop-in under
@@ -27,12 +31,15 @@ plugin:
   health_addr: "unix:///var/run/nri-image-policy/health.sock"
 
 allowlist:
-  # Minimal valid floor: self-allow the baked plugin's own image (the same
-  # digest this profile's mkosi.sync pins). Nothing else needs admitting
-  # pre-install — everything that runs at boot is in an exempt namespace.
-  # Keep in lockstep with NRI_IMAGE in mkosi.sync.
+  # Cold-boot floor, both entries resolved from C8S_REF by mkosi.sync:
+  #   - the plugin's own image (self-allow), and
+  #   - CDS, so it can start against this fail-closed plugin and then serve the
+  #     live allowlist the pull loop below fetches. Without CDS admitted here,
+  #     no allowlist is ever served and `c8s install` deadlocks.
+  # Everything else at boot is in an exempt namespace.
   always_allow:
-    "sha256:56a831e76448a25e61842d71f72e27e1b29af71ee1f5c113db2cb396c552f181": "ghcr.io/confidential-dot-ai/nri-image-policy@sha256:56a831e76448a25e61842d71f72e27e1b29af71ee1f5c113db2cb396c552f181"
+    "@NRI_DIGEST@": "@NRI_IMAGE@"
+    "@CDS_DIGEST@": "@CDS_IMAGE@"
   pull:
     # CDS NodePort, node-local. No CDS is listening until c8s install; the
     # pull loop retries and the plugin stays Ready on the floor above.

--- a/mkosi/base/mkosi.profiles/c8s/mkosi.extra/etc/rancher/rke2/config.yaml
+++ b/mkosi/base/mkosi.profiles/c8s/mkosi.extra/etc/rancher/rke2/config.yaml
@@ -19,6 +19,13 @@
 cni: cilium
 disable-kube-proxy: true
 
+# Drop RKE2's bundled ingress-nginx: it binds hostPorts 80/443, which collide
+# with c8s tls-lb's hostPort 443 (the attested front door for workloads —
+# `c8s install` preflights this exact conflict). The node image's external
+# surface is tls-lb, not a generic ingress.
+disable:
+  - rke2-ingress-nginx
+
 # Add a stable hostname SAN to the apiserver serving cert. The operator
 # reaches the guest at a per-launch KubeVirt-assigned IP that RKE2 can't know
 # to include as a SAN, so the released kubeconfig can't verify against the IP.

--- a/mkosi/base/mkosi.profiles/c8s/mkosi.extra/etc/rancher/rke2/config.yaml
+++ b/mkosi/base/mkosi.profiles/c8s/mkosi.extra/etc/rancher/rke2/config.yaml
@@ -19,6 +19,15 @@
 cni: cilium
 disable-kube-proxy: true
 
+# Add a stable hostname SAN to the apiserver serving cert. The operator
+# reaches the guest at a per-launch KubeVirt-assigned IP that RKE2 can't know
+# to include as a SAN, so the released kubeconfig can't verify against the IP.
+# Instead the kubeconfig dials the IP but sets tls-server-name=c8s-cvm (this
+# SAN), so verification passes without --insecure-skip-tls-verify. See
+# `c8s get-kubeconfig` (it defaults tls-server-name to this).
+tls-san:
+  - c8s-cvm
+
 profile: cis
 pod-security-admission-config-file: /etc/rancher/rke2/psa-config.yaml
 kubelet-arg:

--- a/mkosi/base/mkosi.profiles/c8s/mkosi.extra/etc/systemd/system/cred-release.service
+++ b/mkosi/base/mkosi.profiles/c8s/mkosi.extra/etc/systemd/system/cred-release.service
@@ -38,9 +38,10 @@ Restart=on-failure
 RestartSec=10
 # TDX runtime measurement (RTMR[3]) is read via the tdx_guest misc device.
 DeviceAllow=/dev/tdx_guest rwm
-# Reads the RKE2 client-CA key; keep the rest of the FS read-only.
+# Reads two files: the initrd-staged operator pubkey (/etc/confai) and the
+# RKE2 client-CA key. No mount needed. Keep the rest of the FS read-only.
 ProtectSystem=strict
-ReadOnlyPaths=/var/lib/rancher/rke2/server/tls
+ReadOnlyPaths=/etc/confai /var/lib/rancher/rke2/server/tls
 ReadWritePaths=/run
 ProtectHome=yes
 NoNewPrivileges=yes

--- a/mkosi/base/mkosi.profiles/c8s/mkosi.extra/etc/systemd/system/cred-release.service
+++ b/mkosi/base/mkosi.profiles/c8s/mkosi.extra/etc/systemd/system/cred-release.service
@@ -1,0 +1,49 @@
+[Unit]
+Description=Attested RKE2 operator credential release
+Documentation=https://github.com/confidential-dot-ai/c8s
+# Bound restart storms: a persistent failure (e.g. RTMR[3] mismatch — the
+# on-disk pubkey doesn't match the measurement) should fail closed and stop,
+# not spin. 5 tries in 5 min, then give up until the next boot.
+StartLimitIntervalSec=300
+StartLimitBurst=5
+# Needs the RKE2 client-CA (to sign operator certs) and the attestation-api
+# (to fetch the RA-TLS serving cert's TDX quote from :8400). rke2-server
+# creates /var/lib/rancher/rke2/server/tls/client-ca.* only once it has
+# initialised, so we order after it and gate on the key existing (the Exec
+# startpre below), rather than racing a half-initialised control plane.
+After=network-online.target rke2-server.service attestation-api.service
+Wants=network-online.target
+Requires=attestation-api.service
+# Only run on operator boots. A VM launched without --operator-key has no
+# opkeydata disk; the condition makes systemd SKIP the unit (not fail it), so
+# there's no restart-loop on non-operator nodes. The launcher attaches the
+# disk with ISO label "opkeydata".
+ConditionPathExists=/dev/disk/by-label/opkeydata
+
+[Service]
+Type=simple
+# The operator key is bound into RTMR[3] at launch; this service verifies the
+# on-disk pubkey against RTMR[3] at startup and refuses (exits non-zero) if it
+# was substituted — fail closed. Non-operator boots never reach here (the
+# ConditionPathExists above skips the unit).
+ExecStartPre=/bin/sh -c 'test -r /var/lib/rancher/rke2/server/tls/client-ca.key'
+ExecStart=/usr/local/bin/c8s cred-release \
+    --listen :8443 \
+    --attestation-api-url http://127.0.0.1:8400 \
+    --platform tdx \
+    --cert-ttl 24h \
+    --cert-org system:masters \
+    --cert-cn operator
+Restart=on-failure
+RestartSec=10
+# TDX runtime measurement (RTMR[3]) is read via the tdx_guest misc device.
+DeviceAllow=/dev/tdx_guest rwm
+# Reads the RKE2 client-CA key; keep the rest of the FS read-only.
+ProtectSystem=strict
+ReadOnlyPaths=/var/lib/rancher/rke2/server/tls
+ReadWritePaths=/run
+ProtectHome=yes
+NoNewPrivileges=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/mkosi/base/mkosi.profiles/c8s/mkosi.extra/usr/lib/systemd/system-preset/50-rke2.preset
+++ b/mkosi/base/mkosi.profiles/c8s/mkosi.extra/usr/lib/systemd/system-preset/50-rke2.preset
@@ -24,3 +24,7 @@
 enable containerd-data-disk.service
 enable rke2-server.service
 disable rke2-agent.service
+# Attested operator credential release. Enabled always, but its
+# ConditionPathExists on the opkeydata disk means it only starts on operator
+# boots — a no-op on nodes launched without --operator-key.
+enable cred-release.service

--- a/mkosi/base/mkosi.profiles/c8s/mkosi.extra/usr/local/bin/containerd-data-disk.sh
+++ b/mkosi/base/mkosi.profiles/c8s/mkosi.extra/usr/local/bin/containerd-data-disk.sh
@@ -48,19 +48,29 @@ if mountpoint -q "$DIR"; then
     exit 0
 fi
 
-# Find a whole-device LABEL=containerd disk. vda is the verity rootfs. Prefer
-# the SCSI bus (sd*): under SEV-SNP/KubeVirt a secondary virtio-blk disk wedges
-# on every I/O (raw dd hangs in uninterruptible D-state — iommu=on is forced on
-# all virtio devices and the virtio-blk DMA path is broken for hot-attached data
-# disks; virtio-scsi works). Scan sd* first, then vd* as a fallback for
-# launches without that quirk. Poll briefly (~10s) so a slow udev probe doesn't
-# make us miss it. `blkid -p` probes the device directly rather than trusting
-# the (possibly stale) udev cache.
+# Find the containerd data disk. vda is the verity rootfs. Prefer the SCSI bus
+# (sd*): under SEV-SNP/KubeVirt a secondary virtio-blk disk wedges on every I/O
+# (raw dd hangs in uninterruptible D-state — iommu=on is forced on all virtio
+# devices and the virtio-blk DMA path is broken for hot-attached data disks;
+# virtio-scsi works). Scan sd* first, then vd* as a fallback for launches
+# without that quirk. Poll briefly (~10s) so a slow udev probe doesn't make us
+# miss it.
+#
+# Two ways a device qualifies:
+#   1. filesystem LABEL=containerd — a host-prepared, pre-labelled disk.
+#   2. device SERIAL=confai-containerd — a BLANK disk confai attaches with that
+#      serial (mirrors the confai-scratch datadisk). This is the confai path:
+#      the disk carries no filesystem, so the encrypted mkfs below lays one down
+#      per boot. `blkid -p` probes the device directly (not the stale udev
+#      cache); the serial comes from sysfs.
 DEV=""
 for _ in $(seq 1 20); do
     for d in /dev/sd? /dev/vd?; do
         [ -b "$d" ] || continue
         if [ "$(blkid -p -s LABEL -o value "$d" 2>/dev/null || true)" = "containerd" ]; then
+            DEV="$d"; break
+        fi
+        if [ "$(cat "/sys/block/$(basename "$d")/serial" 2>/dev/null || true)" = "confai-containerd" ]; then
             DEV="$d"; break
         fi
     done

--- a/mkosi/base/mkosi.profiles/c8s/mkosi.extra/var/lib/rancher/rke2/server/manifests/nvidia-device-plugin.yaml
+++ b/mkosi/base/mkosi.profiles/c8s/mkosi.extra/var/lib/rancher/rke2/server/manifests/nvidia-device-plugin.yaml
@@ -1,0 +1,79 @@
+# NVIDIA device plugin — makes passed-through GPUs schedulable as
+# `nvidia.com/gpu` on the inner cluster. CDI end to end: the gpu profile's
+# nvidia-cdi-generate.service writes /var/run/cdi/nvidia.yaml at boot, the
+# plugin advertises devices with the cdi-cri strategy, and containerd 2.x
+# (CDI on by default) injects them at pod creation — no nvidia-container-runtime
+# wrapper anywhere.
+#
+# kube-system placement is deliberate: PSA-exempt (the pod needs hostPath +
+# privileged to reach NVML and /dev) and exempt from the NRI image-policy
+# allowlist, so the plugin can start before CDS is up. Digest-pinned like every
+# other baked component.
+#
+# The plugin itself dlopens NVML from the measured root's driver stack — the
+# image ships no toolkit runtime to inject it, hence the explicit lib mount +
+# LD_LIBRARY_PATH.
+#
+# FAIL_ON_INIT_ERROR=false keeps GPU-less boots degraded-nothing: the plugin
+# idles instead of crash-looping when no NVIDIA device exists.
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: nvidia-device-plugin
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/name: nvidia-device-plugin
+    app.kubernetes.io/part-of: c8s-node-image
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: nvidia-device-plugin
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: nvidia-device-plugin
+    spec:
+      priorityClassName: system-node-critical
+      tolerations:
+        - operator: Exists
+      containers:
+        - name: nvidia-device-plugin
+          image: nvcr.io/nvidia/k8s-device-plugin:v0.19.3@sha256:25cc340fe6fd53c101e16fc452f503e7a92c219c64a80ed5381784b522dbbf77
+          env:
+            - name: FAIL_ON_INIT_ERROR
+              value: "false"
+            - name: DEVICE_LIST_STRATEGY
+              value: cdi-cri
+            - name: NVIDIA_VISIBLE_DEVICES
+              value: all
+            - name: LD_LIBRARY_PATH
+              value: /host-lib
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - name: device-plugin
+              mountPath: /var/lib/kubelet/device-plugins
+            - name: cdi-dir
+              mountPath: /var/run/cdi
+              readOnly: true
+            - name: host-lib
+              mountPath: /host-lib
+              readOnly: true
+            - name: dev
+              mountPath: /dev
+      volumes:
+        - name: device-plugin
+          hostPath:
+            path: /var/lib/kubelet/device-plugins
+        - name: cdi-dir
+          hostPath:
+            path: /var/run/cdi
+            type: DirectoryOrCreate
+        - name: host-lib
+          hostPath:
+            path: /usr/lib/x86_64-linux-gnu
+        - name: dev
+          hostPath:
+            path: /dev

--- a/mkosi/base/mkosi.profiles/c8s/mkosi.extra/var/lib/rancher/rke2/server/manifests/nvidia-device-plugin.yaml
+++ b/mkosi/base/mkosi.profiles/c8s/mkosi.extra/var/lib/rancher/rke2/server/manifests/nvidia-device-plugin.yaml
@@ -1,21 +1,23 @@
 # NVIDIA device plugin — makes passed-through GPUs schedulable as
 # `nvidia.com/gpu` on the inner cluster. CDI end to end: the gpu profile's
-# nvidia-cdi-generate.service writes /var/run/cdi/nvidia.yaml at boot, the
-# plugin advertises devices with the cdi-cri strategy, and containerd 2.x
-# (CDI on by default) injects them at pod creation — no nvidia-container-runtime
-# wrapper anywhere.
+# nvidia-cdi-generate.service writes /var/run/cdi/nvidia.yaml at boot; the
+# plugin discovers the driver files under CONTAINER_DRIVER_ROOT, advertises the
+# GPUs, and containerd 2.x (CDI on by default) injects the CDI devices at pod
+# creation — no nvidia-container-runtime wrapper anywhere.
 #
-# kube-system placement is deliberate: PSA-exempt (the pod needs hostPath +
-# privileged to reach NVML and /dev) and exempt from the NRI image-policy
-# allowlist, so the plugin can start before CDS is up. Digest-pinned like every
-# other baked component.
+# kube-system placement is deliberate: PSA-exempt (privileged + hostPath to
+# reach the driver root and /dev) and NRI-allowlist-exempt, so the plugin can
+# start before CDS is up. Digest-pinned like every other baked component.
 #
-# The plugin itself dlopens NVML from the measured root's driver stack — the
-# image ships no toolkit runtime to inject it, hence the explicit lib mount +
-# LD_LIBRARY_PATH.
+# The plugin discovers NVML/libcuda + the CDI hooks from the measured root
+# mounted at /driver-root. It MUST NOT put the guest lib dir on LD_LIBRARY_PATH
+# — /usr/lib/x86_64-linux-gnu holds the guest's libc/libpthread, which would
+# shadow the container's own and crash the Go runtime with
+# "pthread_create failed: Invalid argument". Instead NVIDIA_DRIVER_ROOT=/ +
+# CONTAINER_DRIVER_ROOT=/driver-root let the plugin's own resolver find the libs.
 #
-# FAIL_ON_INIT_ERROR=false keeps GPU-less boots degraded-nothing: the plugin
-# idles instead of crash-looping when no NVIDIA device exists.
+# DEVICE_LIST_STRATEGY=cdi-annotations (v0.19.3 does NOT accept cdi-cri).
+# FAIL_ON_INIT_ERROR=false keeps GPU-less boots degraded-nothing.
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -45,11 +47,15 @@ spec:
             - name: FAIL_ON_INIT_ERROR
               value: "false"
             - name: DEVICE_LIST_STRATEGY
-              value: cdi-cri
+              value: cdi-annotations
+            - name: DEVICE_ID_STRATEGY
+              value: uuid
+            - name: NVIDIA_DRIVER_ROOT
+              value: /
+            - name: CONTAINER_DRIVER_ROOT
+              value: /driver-root
             - name: NVIDIA_VISIBLE_DEVICES
               value: all
-            - name: LD_LIBRARY_PATH
-              value: /host-lib
           securityContext:
             privileged: true
           volumeMounts:
@@ -57,9 +63,8 @@ spec:
               mountPath: /var/lib/kubelet/device-plugins
             - name: cdi-dir
               mountPath: /var/run/cdi
-              readOnly: true
-            - name: host-lib
-              mountPath: /host-lib
+            - name: driver-root
+              mountPath: /driver-root
               readOnly: true
             - name: dev
               mountPath: /dev
@@ -71,9 +76,9 @@ spec:
           hostPath:
             path: /var/run/cdi
             type: DirectoryOrCreate
-        - name: host-lib
+        - name: driver-root
           hostPath:
-            path: /usr/lib/x86_64-linux-gnu
+            path: /
         - name: dev
           hostPath:
             path: /dev

--- a/mkosi/base/mkosi.profiles/c8s/mkosi.sync
+++ b/mkosi/base/mkosi.profiles/c8s/mkosi.sync
@@ -115,13 +115,19 @@ stage "$CACHE_DIR/rke2-images-cilium-${CACHE_VER}.tar.zst" \
 # --- 3. nri-image-policy plugin binary ------------------------------------
 
 PLUGIN_TARGET="$STAGE_DIR/opt/nri/plugins/10-nri-image-policy"
+# The same multi-command binary, also staged under its own name so the
+# cred-release systemd unit can invoke `c8s cred-release` (argv[0]="c8s"
+# falls through to normal cobra dispatch — only get-cert/nri-image-policy/
+# ratls-mesh are argv-aliased).
+C8S_TARGET="$STAGE_DIR/usr/local/bin/c8s"
 # Content-addressed by the image digest: a cached copy skips the GHCR pull
 # entirely (oras digest-verifies the blobs on the pull that populates it).
 PLUGIN_CACHE="$CACHE_DIR/nri-image-policy-${NRI_IMAGE##*@sha256:}"
 if [ -f "$PLUGIN_CACHE" ]; then
     echo "c8s sync: cached nri-image-policy (${NRI_IMAGE##*@})"
     install -D -m 0755 "$PLUGIN_CACHE" "$PLUGIN_TARGET"
-    echo "c8s sync: staged rke2 ${RKE2_VERSION} + airgap bundles + nri-image-policy"
+    install -D -m 0755 "$PLUGIN_CACHE" "$C8S_TARGET"
+    echo "c8s sync: staged rke2 ${RKE2_VERSION} + airgap bundles + nri-image-policy + c8s"
     exit 0
 fi
 
@@ -185,5 +191,6 @@ if [ ! -f "$BIN" ]; then
 fi
 install -D -m 0644 "$BIN" "$PLUGIN_CACHE"
 install -D -m 0755 "$BIN" "$PLUGIN_TARGET"
+install -D -m 0755 "$BIN" "$C8S_TARGET"
 
-echo "c8s sync: staged rke2 ${RKE2_VERSION} + airgap bundles + nri-image-policy"
+echo "c8s sync: staged rke2 ${RKE2_VERSION} + airgap bundles + nri-image-policy + c8s"

--- a/mkosi/base/mkosi.profiles/c8s/mkosi.sync
+++ b/mkosi/base/mkosi.profiles/c8s/mkosi.sync
@@ -52,8 +52,13 @@ RKE2_IMAGES_CILIUM_SHA256="1ab41422cc16f5d030b8f62889133dff5d9dce985fbf13360c160
 # digest here (mirrors kata-guest-base/scripts/fetch.sh). The tag must exist:
 # it's published on pushes to main, or on demand via c8s docker.yml
 # workflow_dispatch for a feature branch.
+#
+# The ref arrives via $SRCDIR/mkosi.local/c8s-ref (written by bin/build-c8s),
+# not the environment: mkosi runs under sudo (env stripped) and its script
+# sandbox drops host vars, so an exported C8S_REF never reaches this script.
 NRI_REPO="ghcr.io/confidential-dot-ai/nri-image-policy"
 NRI_IMAGE="${NRI_REPO}@sha256:56a831e76448a25e61842d71f72e27e1b29af71ee1f5c113db2cb396c552f181"
+C8S_REF=$(cat "$SRCDIR/mkosi.local/c8s-ref" 2>/dev/null || true)
 if [ -n "${C8S_REF:-}" ]; then
     echo "c8s sync: resolving nri-image-policy at c8s ref ${C8S_REF}"
     NRI_DIGEST=$(oras manifest fetch --descriptor "${NRI_REPO}:${C8S_REF}" 2>/dev/null | jq -r '.digest')

--- a/mkosi/base/mkosi.profiles/c8s/mkosi.sync
+++ b/mkosi/base/mkosi.profiles/c8s/mkosi.sync
@@ -43,7 +43,25 @@ RKE2_TARBALL_SHA256="c156a562573c1e3a5c57e816caac5237c451473b0417f903491dc0d810f
 RKE2_IMAGES_CORE_SHA256="0916003d2cb70501fffd58f278a8b24a1f2c991a9b5d9013b4ba7e8aef92e577"
 RKE2_IMAGES_CILIUM_SHA256="1ab41422cc16f5d030b8f62889133dff5d9dce985fbf13360c16049340ede6c1"
 
-NRI_IMAGE="ghcr.io/confidential-dot-ai/nri-image-policy@sha256:56a831e76448a25e61842d71f72e27e1b29af71ee1f5c113db2cb396c552f181"
+# The c8s binary is pulled from the nri-image-policy image (same multi-command
+# binary). Default is the digest the c8s chart deploys (keep in lockstep with
+# values.yaml nriImagePolicy.image.digest — see the NRI_IMAGE note above and
+# bin/lint's check). To bake a specific c8s COMMIT instead — e.g. to test an
+# unmerged cred-release build end-to-end — set C8S_REF to its short SHA; the
+# per-commit `:<short-sha>` tag c8s's docker.yml publishes is resolved to a
+# digest here (mirrors kata-guest-base/scripts/fetch.sh). The tag must exist:
+# it's published on pushes to main, or on demand via c8s docker.yml
+# workflow_dispatch for a feature branch.
+NRI_REPO="ghcr.io/confidential-dot-ai/nri-image-policy"
+NRI_IMAGE="${NRI_REPO}@sha256:56a831e76448a25e61842d71f72e27e1b29af71ee1f5c113db2cb396c552f181"
+if [ -n "${C8S_REF:-}" ]; then
+    echo "c8s sync: resolving nri-image-policy at c8s ref ${C8S_REF}"
+    NRI_DIGEST=$(oras manifest fetch --descriptor "${NRI_REPO}:${C8S_REF}" 2>/dev/null | jq -r '.digest')
+    case "$NRI_DIGEST" in
+        sha256:*) NRI_IMAGE="${NRI_REPO}@${NRI_DIGEST}"; echo "c8s sync: C8S_REF ${C8S_REF} -> ${NRI_DIGEST}" ;;
+        *) echo "c8s sync: FATAL cannot resolve ${NRI_REPO}:${C8S_REF} (is the per-commit image published? run c8s docker.yml workflow_dispatch for the branch)" >&2; exit 1 ;;
+    esac
+fi
 
 # Download <url> to <dest>, verifying its sha256. Skip if dest exists and
 # already matches (this is what makes the pkgcache a cache).

--- a/mkosi/base/mkosi.profiles/c8s/mkosi.sync
+++ b/mkosi/base/mkosi.profiles/c8s/mkosi.sync
@@ -23,10 +23,9 @@
 # config.toml has exactly ONE `imports` line — see the baked
 # config-v3.toml.tmpl in this profile's mkosi.extra for why.
 #
-# NRI_IMAGE pin: must equal the digest the c8s chart deploys
-# (values.yaml nriImagePolicy.image.digest / the crane-resolved digest of
-# the release tag), so the chart installer's `cmp` of the baked binary
-# no-ops instead of rewriting it and restarting rke2-server.
+# c8s components (nri plugin binary + the CDS digest in the baked NRI floor)
+# are NOT hardcoded: both resolve from a single c8s ref (C8S_REF, default main)
+# so they always match each other and the images the chart later deploys.
 #
 # Downloads are cached under mkosi.pkgcache/c8s/ — that dir survives across
 # builds; mkosi.local does NOT (the confos Rust driver wipes it on build
@@ -43,30 +42,49 @@ RKE2_TARBALL_SHA256="c156a562573c1e3a5c57e816caac5237c451473b0417f903491dc0d810f
 RKE2_IMAGES_CORE_SHA256="0916003d2cb70501fffd58f278a8b24a1f2c991a9b5d9013b4ba7e8aef92e577"
 RKE2_IMAGES_CILIUM_SHA256="1ab41422cc16f5d030b8f62889133dff5d9dce985fbf13360c16049340ede6c1"
 
-# The c8s binary is pulled from the nri-image-policy image (same multi-command
-# binary). Default is the digest the c8s chart deploys (keep in lockstep with
-# values.yaml nriImagePolicy.image.digest — see the NRI_IMAGE note above and
-# bin/lint's check). To bake a specific c8s COMMIT instead — e.g. to test an
-# unmerged cred-release build end-to-end — set C8S_REF to its short SHA; the
-# per-commit `:<short-sha>` tag c8s's docker.yml publishes is resolved to a
-# digest here (mirrors kata-guest-base/scripts/fetch.sh). The tag must exist:
-# it's published on pushes to main, or on demand via c8s docker.yml
-# workflow_dispatch for a feature branch.
-#
-# The ref arrives via $SRCDIR/mkosi.local/c8s-ref (written by bin/build-c8s),
-# not the environment: mkosi runs under sudo (env stripped) and its script
-# sandbox drops host vars, so an exported C8S_REF never reaches this script.
+# The baked c8s components — the nri plugin binary AND the CDS digest in the NRI
+# floor — resolve from a single c8s ref, so they never drift from each other or
+# from the images the chart later deploys. C8S_REF pins a specific commit (short
+# SHA) for testing an unmerged build; it arrives via $SRCDIR/mkosi.local/c8s-ref
+# (written by bin/build-c8s — an exported var never reaches this sandbox: mkosi
+# runs under sudo, stripping the env). Empty = main. The tag must be published
+# (c8s docker.yml on main, or workflow_dispatch for a feature branch).
 NRI_REPO="ghcr.io/confidential-dot-ai/nri-image-policy"
-NRI_IMAGE="${NRI_REPO}@sha256:56a831e76448a25e61842d71f72e27e1b29af71ee1f5c113db2cb396c552f181"
+CDS_REPO="ghcr.io/confidential-dot-ai/cds"
 C8S_REF=$(cat "$SRCDIR/mkosi.local/c8s-ref" 2>/dev/null || true)
-if [ -n "${C8S_REF:-}" ]; then
-    echo "c8s sync: resolving nri-image-policy at c8s ref ${C8S_REF}"
-    NRI_DIGEST=$(oras manifest fetch --descriptor "${NRI_REPO}:${C8S_REF}" 2>/dev/null | jq -r '.digest')
-    case "$NRI_DIGEST" in
-        sha256:*) NRI_IMAGE="${NRI_REPO}@${NRI_DIGEST}"; echo "c8s sync: C8S_REF ${C8S_REF} -> ${NRI_DIGEST}" ;;
-        *) echo "c8s sync: FATAL cannot resolve ${NRI_REPO}:${C8S_REF} (is the per-commit image published? run c8s docker.yml workflow_dispatch for the branch)" >&2; exit 1 ;;
+C8S_REF="${C8S_REF:-main}"
+echo "c8s sync: resolving nri-image-policy + cds at c8s ref ${C8S_REF}"
+resolve_digest() {  # <repo> <ref> -> prints sha256:... or FATALs
+    local d
+    d=$(oras manifest fetch --descriptor "$1:$2" 2>/dev/null | jq -r '.digest')
+    case "$d" in
+        sha256:*) printf '%s' "$d" ;;
+        *) echo "c8s sync: FATAL cannot resolve $1:$2 (is the image published? run c8s docker.yml for the branch)" >&2; exit 1 ;;
     esac
-fi
+}
+NRI_DIGEST=$(resolve_digest "$NRI_REPO" "$C8S_REF")
+CDS_DIGEST=$(resolve_digest "$CDS_REPO" "$C8S_REF")
+NRI_IMAGE="${NRI_REPO}@${NRI_DIGEST}"
+echo "c8s sync: ref ${C8S_REF} -> nri ${NRI_DIGEST}, cds ${CDS_DIGEST}"
+
+# Render the NRI floor template into the stage tree, substituting the resolved
+# nri + cds digests into always_allow. The template lives outside mkosi.extra
+# (image-policy.yaml.in) so mkosi never copies the raw template; this rendered
+# copy is the only one at etc/nri/conf.d/image-policy.yaml, so it lands with no
+# extra-tree precedence ambiguity. Both digests track C8S_REF.
+render_nri_floor() {
+    local tmpl="$SRCDIR/mkosi.profiles/c8s/image-policy.yaml.in"
+    local dst="$STAGE_DIR/etc/nri/conf.d/image-policy.yaml"
+    [ -f "$tmpl" ] || { echo "c8s sync: FATAL floor template $tmpl missing" >&2; exit 1; }
+    mkdir -p "$(dirname "$dst")"
+    sed \
+        -e "s|@NRI_DIGEST@|${NRI_DIGEST}|g" \
+        -e "s|@NRI_IMAGE@|${NRI_IMAGE}|g" \
+        -e "s|@CDS_DIGEST@|${CDS_DIGEST}|g" \
+        -e "s|@CDS_IMAGE@|${CDS_REPO}@${CDS_DIGEST}|g" \
+        "$tmpl" > "$dst"
+    echo "c8s sync: NRI floor rendered (nri ${NRI_DIGEST}, cds ${CDS_DIGEST})"
+}
 
 # Download <url> to <dest>, verifying its sha256. Skip if dest exists and
 # already matches (this is what makes the pkgcache a cache).
@@ -150,6 +168,7 @@ if [ -f "$PLUGIN_CACHE" ]; then
     echo "c8s sync: cached nri-image-policy (${NRI_IMAGE##*@})"
     install -D -m 0755 "$PLUGIN_CACHE" "$PLUGIN_TARGET"
     install -D -m 0755 "$PLUGIN_CACHE" "$C8S_TARGET"
+    render_nri_floor
     echo "c8s sync: staged rke2 ${RKE2_VERSION} + airgap bundles + nri-image-policy + c8s"
     exit 0
 fi
@@ -215,5 +234,7 @@ fi
 install -D -m 0644 "$BIN" "$PLUGIN_CACHE"
 install -D -m 0755 "$BIN" "$PLUGIN_TARGET"
 install -D -m 0755 "$BIN" "$C8S_TARGET"
+
+render_nri_floor
 
 echo "c8s sync: staged rke2 ${RKE2_VERSION} + airgap bundles + nri-image-policy + c8s"

--- a/mkosi/base/mkosi.profiles/gpu/mkosi.extra/etc/systemd/system/nvidia-cdi-generate.service
+++ b/mkosi/base/mkosi.profiles/gpu/mkosi.extra/etc/systemd/system/nvidia-cdi-generate.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=Generate the NVIDIA CDI spec for GPU pods
+# The spec enumerates /dev/nvidia* nodes and the driver libraries, so it must
+# run after persistenced has attached the driver and created the device nodes.
+# kubelet/containerd need no ordering against this: the device plugin retries
+# until the spec exists, and containerd reads /var/run/cdi per pod creation.
+After=nvidia-persistenced.service
+Wants=nvidia-persistenced.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+# Skip (not fail) on a GPU-less boot — same degraded-nothing posture as the
+# other nvidia-* units.
+ExecCondition=/bin/sh -c 'grep -qx 0x10de /sys/bus/pci/devices/*/vendor 2>/dev/null'
+# /var/run is tmpfs: the spec is regenerated fresh every boot, matching
+# whatever GPUs this launch passed through.
+ExecStart=/usr/bin/nvidia-ctk cdi generate --output=/var/run/cdi/nvidia.yaml
+
+[Install]
+WantedBy=multi-user.target

--- a/mkosi/base/mkosi.profiles/gpu/mkosi.extra/usr/lib/systemd/system-preset/10-nvidia.preset
+++ b/mkosi/base/mkosi.profiles/gpu/mkosi.extra/usr/lib/systemd/system-preset/10-nvidia.preset
@@ -5,3 +5,4 @@ enable nvidia-gpu-flr.service
 enable nvidia-persistenced.service
 enable nvidia-cc-ready.service
 enable nvidia-modules-latch.service
+enable nvidia-cdi-generate.service

--- a/mkosi/base/mkosi.profiles/gpu/mkosi.extra/usr/local/bin/nvidia-cc-ready
+++ b/mkosi/base/mkosi.profiles/gpu/mkosi.extra/usr/local/bin/nvidia-cc-ready
@@ -17,19 +17,60 @@ if ! grep -qxl 0x10de /sys/bus/pci/devices/*/vendor 2>/dev/null; then
     exit 0
 fi
 
-# If the driver never came up (nvidia-smi fails), don't hard-fail the boot;
-# surface it and leave the GPU un-readied for an operator to inspect.
-if ! nvidia-smi >/dev/null 2>&1; then
-    echo "nvidia-cc-ready: nvidia-smi not responding; driver not up. Leaving GPUs un-readied." >&2
+# Gate on the ready-state QUERY (`-grs`) parsing, not just `nvidia-smi` exit.
+# Ordering After=nvidia-persistenced is not enough: the out-of-tree module load
+# + the GPU function-level reset can still be settling when persistenced reports
+# started, so nvidia-smi and the conf-compute queries fail transiently (and
+# `-srs 1` then errors with rc=6 — "no ready device"). The original unit bailed
+# on the first nvidia-smi failure and left the GPU un-readied forever (CC-locked:
+# nvidia-smi "No devices found" despite /dev/nvidia0 existing). `-grs` returning
+# a parseable Ready State is the precise proof the GPU is enumerated and the CC
+# subsystem is live — the exact precondition `-srs` needs.
+grs() { nvidia-smi conf-compute -grs 2>/dev/null; }
+cc_feature() { nvidia-smi conf-compute -f 2>/dev/null; }
+
+DEADLINE=$(( $(date +%s) + 180 ))
+until grs | grep -qiE 'ready state'; do
+    if [ "$(date +%s)" -ge "$DEADLINE" ]; then
+        # Never hard-fail — a GPU-less/degraded boot must still reach
+        # multi-user — but distinguish the failure mode for diagnosis.
+        if nvidia-smi >/dev/null 2>&1; then
+            echo "nvidia-cc-ready: driver up but '-grs' never reported a Ready State within 180s; leaving GPUs un-readied." >&2
+        else
+            echo "nvidia-cc-ready: nvidia-smi not responding within 180s; driver not up. Leaving GPUs un-readied." >&2
+        fi
+        exit 0
+    fi
+    sleep 2
+done
+
+# Already ready (idempotent re-run, or a prior boot readied it): nothing to do.
+if grs | grep -qiE 'ready state.*(enabled|ready)'; then
+    echo "nvidia-cc-ready: GPUs already Ready."
+    grs; exit 0
+fi
+
+# Non-CC launch: CC feature OFF → -srs is a no-op/error. Tolerate and skip.
+if ! cc_feature | grep -qiE 'cc feature.*(on|enabled)'; then
+    echo "nvidia-cc-ready: CC feature not ON; not a confidential launch. Skipping -srs."
     exit 0
 fi
 
-# Only meaningful when the GPUs are actually in CC mode. On a non-CC host the
-# query returns CC State: OFF and -srs is a no-op / error; tolerate it.
-if nvidia-smi conf-compute -q 2>/dev/null | grep -q 'CC State.*ON'; then
-    echo "nvidia-cc-ready: CC on — setting GPUs Ready State."
-    nvidia-smi conf-compute -srs 1
-    nvidia-smi conf-compute -q | grep -E 'CC State|Multi-GPU|Ready State' || true
-else
-    echo "nvidia-cc-ready: CC State not ON; not a confidential launch. Skipping -srs."
+# Flip the Ready-State gate once (it is a set action, not a poll), then confirm
+# via -grs. If -srs errors or the read-back lags, poll -grs briefly for the
+# state to settle before giving up — but do not blindly re-issue -srs.
+echo "nvidia-cc-ready: CC on — setting GPUs Ready State."
+if ! nvidia-smi conf-compute -srs 1; then
+    echo "nvidia-cc-ready: '-srs 1' returned nonzero; the GPU may not be in a settable state yet." >&2
 fi
+VERIFY_DEADLINE=$(( $(date +%s) + 30 ))
+until grs | grep -qiE 'ready state.*(enabled|ready)'; do
+    if [ "$(date +%s)" -ge "$VERIFY_DEADLINE" ]; then
+        echo "nvidia-cc-ready: Ready State did not read Ready within 30s of -srs. GPU left un-readied (unusable for CC compute)." >&2
+        grs >&2 || true
+        exit 0   # surface loudly; do not block boot
+    fi
+    sleep 2
+done
+echo "nvidia-cc-ready: GPUs Ready."
+grs

--- a/mkosi/initrd/mkosi.extra/init
+++ b/mkosi/initrd/mkosi.extra/init
@@ -123,5 +123,73 @@ mkdir -p /sysroot/run/dbus /sysroot/var/log/journal
 # Generate unique machine-id for this boot
 cat /proc/sys/kernel/random/uuid | tr -d '-' > /sysroot/etc/machine-id
 
+# --- Operator-key binding: extend RTMR[3] before switch_root ---------------
+# Bind a launch-supplied operator public key into the TDX measurement so an
+# external operator can attest that THIS node will only trust THEIR key, with
+# no console, no pre-shared cluster secret, and no trust in the (untrusted)
+# host that delivered the key. The launcher attaches a KubeVirt secret disk
+# labelled "opkeydata" (an ISO9660 filesystem, same mechanism as cloud-init's
+# "cidata") containing one file, `pubkey` — the raw operator public key. We
+# hash it here (SHA-384) and extend that into RTMR[3] — the one
+# guest-controllable measurement register (mrconfigid/mrowner are TD-init
+# fields KubeVirt does not set) — via the tdx_guest sysfs. Extend semantics:
+# RTMR_new = SHA384(RTMR_old || data48), so the operator verifies
+# rtmr3 == SHA384(0x00*48 || SHA384(op_pub)) offline against their own key.
+#
+# The initrd is the single place the key is hashed (it has sha384sum), so the
+# credential-release service can later trust the pubkey off this same disk
+# without a separate digest to cross-check: this initrd is measured, and it
+# only extends the hash of the exact bytes it reads.
+#
+# Why a labelled secret disk and not a raw serial-tagged block device: the
+# secret arrives as a file inside an ISO filesystem (KubeVirt's SecretVolume
+# renders it that way), so it is read by mount+file, not by raw offset. This
+# keeps the launcher side a plain Secret (no PVC lifecycle) at the cost of one
+# labelled mount here. Guest kernel has ISO9660 (CONFIG_ISO9660_FS=y).
+#
+# This runs BEFORE switch_root: nothing in the measured root or the (host-
+# writable) overlay executes first, so the value is fixed for the TD's life
+# and reflects only the launch-supplied key.
+#
+# Fail-closed asymmetry (security-critical):
+#   - no opkey disk               -> skip (unbound node; a non-operator boot)
+#   - disk present, extend FAILS  -> FATAL. Booting on with RTMR[3] unextended
+#     when a key was supplied would let the host strip the binding undetected.
+RTMR3=/sys/devices/virtual/misc/tdx_guest/measurements/rtmr3:sha384
+OPKEY_DEV=$(blkid -L opkeydata 2>/dev/null || true)
+
+if [ -n "$OPKEY_DEV" ]; then
+    echo "initrd: found opkeydata disk at $OPKEY_DEV — binding operator key into RTMR[3]"
+    fail_opkey() {
+        echo "FATAL: operator key supplied but RTMR[3] extend failed: $1" >&2
+        echo b > /proc/sysrq-trigger
+        exit 1  # fallback if sysrq disabled
+    }
+    [ -w "$RTMR3" ] || fail_opkey "no writable $RTMR3 (guest kernel lacks TDX runtime measurement?)"
+    mkdir -p /opkey
+    mount -o ro "$OPKEY_DEV" /opkey 2>/dev/null || fail_opkey "mount $OPKEY_DEV failed"
+    [ -s /opkey/pubkey ] || { umount /opkey 2>/dev/null; fail_opkey "no /opkey/pubkey on disk"; }
+    # SHA-384 of the exact pubkey bytes -> 96 hex chars (sha384sum prints
+    # "<hex>  -"). This is the sole place the key is hashed.
+    DIGEST_HEX=$(sha384sum < /opkey/pubkey | cut -d' ' -f1)
+    umount /opkey 2>/dev/null || true
+    case "$DIGEST_HEX" in
+        *[!0-9a-f]* | "") fail_opkey "sha384sum produced non-hex" ;;
+    esac
+    [ "${#DIGEST_HEX}" = "96" ] || fail_opkey "digest is ${#DIGEST_HEX} hex chars, want 96"
+    # Convert 96 hex chars -> 48 raw bytes, then write to the extend node. sed
+    # turns "ab" into "\xab"; the outer printf interprets the escapes. Both
+    # printf and sed are coreutils, present in the initrd.
+    esc=$(printf '%s' "$DIGEST_HEX" | sed 's/../\\x&/g')
+    # Intentional: $esc IS the format string — that's what interprets the \x
+    # escapes into raw bytes. DIGEST_HEX is validated [0-9a-f]{96} above, so
+    # $esc contains only \xNN sequences, no user-controlled format directives.
+    # shellcheck disable=SC2059
+    printf "$esc" > "$RTMR3" || fail_opkey "write to $RTMR3 rejected"
+    echo "initrd: RTMR[3] extended with operator key digest $DIGEST_HEX"
+else
+    echo "initrd: no opkeydata disk — RTMR[3] left unbound"
+fi
+
 echo "initrd: switching root..."
 exec switch_root /sysroot /sbin/init

--- a/mkosi/initrd/mkosi.extra/init
+++ b/mkosi/initrd/mkosi.extra/init
@@ -172,6 +172,14 @@ if [ -n "$OPKEY_DEV" ]; then
     # SHA-384 of the exact pubkey bytes -> 96 hex chars (sha384sum prints
     # "<hex>  -"). This is the sole place the key is hashed.
     DIGEST_HEX=$(sha384sum < /opkey/pubkey | cut -d' ' -f1)
+    # Stage the pubkey into the (post-switch_root) rootfs so the cred-release
+    # service reads a plain file — it can't mount the ISO itself under systemd
+    # hardening. The initrd is the single reader of the disk; what it stages is
+    # exactly the bytes it hashed into RTMR[3], and the service re-checks
+    # SHA-384(file) against RTMR[3] before trusting it.
+    mkdir -p /sysroot/etc/confai
+    cp /opkey/pubkey /sysroot/etc/confai/operator-pubkey || { umount /opkey 2>/dev/null; fail_opkey "stage pubkey failed"; }
+    chmod 0644 /sysroot/etc/confai/operator-pubkey
     umount /opkey 2>/dev/null || true
     case "$DIGEST_HEX" in
         *[!0-9a-f]* | "") fail_opkey "sha384sum produced non-hex" ;;

--- a/mkosi/initrd/mkosi.extra/init
+++ b/mkosi/initrd/mkosi.extra/init
@@ -185,15 +185,22 @@ if [ -n "$OPKEY_DEV" ]; then
         *[!0-9a-f]* | "") fail_opkey "sha384sum produced non-hex" ;;
     esac
     [ "${#DIGEST_HEX}" = "96" ] || fail_opkey "digest is ${#DIGEST_HEX} hex chars, want 96"
-    # Convert 96 hex chars -> 48 raw bytes, then write to the extend node. sed
-    # turns "ab" into "\xab"; the outer printf interprets the escapes. Both
-    # printf and sed are coreutils, present in the initrd.
+    # Convert 96 hex chars -> 48 raw bytes in a tmpfs file, then write to the
+    # extend node with dd in ONE 48-byte write(2): the node rejects any other
+    # size, and bash printf splits its output at 0x0a bytes (~17% of digests),
+    # so redirecting printf at the node fails for those keys. sed turns "ab"
+    # into "\xab"; printf interprets the escapes.
     esc=$(printf '%s' "$DIGEST_HEX" | sed 's/../\\x&/g')
     # Intentional: $esc IS the format string — that's what interprets the \x
     # escapes into raw bytes. DIGEST_HEX is validated [0-9a-f]{96} above, so
     # $esc contains only \xNN sequences, no user-controlled format directives.
     # shellcheck disable=SC2059
-    printf "$esc" > "$RTMR3" || fail_opkey "write to $RTMR3 rejected"
+    printf "$esc" > /opkey-digest.bin
+    n=$(wc -c < /opkey-digest.bin)
+    [ "$n" = "48" ] || fail_opkey "digest converted to $n bytes, want 48"
+    dd if=/opkey-digest.bin of="$RTMR3" bs=48 count=1 2>/dev/null \
+        || fail_opkey "write to $RTMR3 rejected"
+    rm -f /opkey-digest.bin
     echo "initrd: RTMR[3] extended with operator key digest $DIGEST_HEX"
 else
     echo "initrd: no opkeydata disk — RTMR[3] left unbound"


### PR DESCRIPTION
## What

The confos/guest side of the measured c8s node-as-CVM: console-free operator access, a commit-pinnable image, and GPU-pod support — all baked into the dm-verity measured root. Grew well past the original B1 scope; the full contents:

### Operator-key access (B1)
1. **initrd RTMR[3] extender** — reads the operator public key off the launch-supplied `opkeydata` disk, hashes it, and extends `SHA384(pubkey)` into RTMR[3] before `switch_root`, so the operator can attest (`rtmr3 == SHA384(0x00*48 || SHA384(pubkey))`, computed offline — not TOFU) that the node trusts only their key. RTMR[3] is the sole guest-controllable register (`mrconfigid`/`mrowner` are TD-init fields KubeVirt doesn't plumb). Fail-closed. **The extend is a single 48-byte `dd`, not `printf > node`** — bash `printf` splits output at 0x0a, and the node rejects non-48-byte writes, so a printf-redirect boot-looped for the ~1-in-6 keys whose digest contains a newline.
2. **baked `cred-release` systemd unit** — bakes `c8s cred-release` into the image; ordered after rke2-server + attestation-api, gated on `/dev/disk/by-label/opkeydata`, fail-closed. The initrd stages the pubkey to `/etc/confai/operator-pubkey`; the hardened unit reads a file (mount is EPERM under its sandbox).
3. **`tls-san: c8s-cvm`** baked into the RKE2 config, so the released kubeconfig verifies the apiserver via `tls-server-name` instead of `--insecure-skip-tls-verify`.

### Commit-pinnable image + dev variant
4. **`C8S_REF` commit-pinned bake** — a `c8s_ref` workflow input resolves `nri-image-policy:<short-sha>` to a digest in the c8s profile's mkosi.sync, so an unmerged c8s can be baked and tested end-to-end. The ref travels via the git-ignored `mkosi.local/c8s-ref` file — NOT env: confos runs mkosi under sudo (strips env) and mkosi's script sandbox drops host vars, so an exported var silently bakes the default digest.
5. **`c8s-dev` variant, CI-dispatchable** (via #54) — `C8S_DEV=1` composes the `dev` profile + `kernel/c8s-dev.config` (8250 serial console + root autologin, for demos/debugging), published under `:c8s-dev` tags only. The `dev` boolean workflow input makes it dispatchable so one run carries a `c8s_ref` AND builds the dev variant.
6. **CDS baked into the NRI floor** — resolved from the same c8s ref as the plugin/binary, so the boot-time allowlist floor can't deadlock against the CDS it needs to reach.
7. **attest-gpu composed in CI** — the published image collects per-GPU SPDM evidence (`attest-gpu` profile) instead of the stock `attest` fallback; attestation-api bumped for the RTMR[3] replay fix; `libtss2-dev` added to the CI build deps.

### GPU pods (via #56 + #57)
8. **CDI end to end, no nvidia-container-runtime wrapper** — the CUDA userspace driver stack + `nvidia-ctk`/`nvidia-cdi-hook` staged; `nvidia-cdi-generate.service` writes `/var/run/cdi/nvidia.yaml` per boot; a digest-pinned nvidia-device-plugin DaemonSet is baked into `server/manifests/` (kube-system, `cdi-annotations`, `NVIDIA_DRIVER_ROOT=/` + `CONTAINER_DRIVER_ROOT=/driver-root` so the plugin's resolver finds NVML/libcuda without shadowing the container's libc). `nvidia-cc-ready` waits for the GPU instead of racing the driver.
9. **containerd store on a real disk** — `containerd-data-disk.service` now also matches a blank disk by `serial=confai-containerd` (pairs with confai's `--containerd-disk-gi`), so a large workload image lands on encrypted ext4 instead of a RAM tmpfs that OOMs the guest.
10. **`disable: rke2-ingress-nginx`** — the bundled ingress binds hostPort 443 and collides with c8s tls-lb; the node image's external surface is tls-lb, not a generic ingress.

## Validated on hardware (b200, 8× B200 TDX CVM)

- Full operator flow: `c8s get-kubeconfig` → `kubectl auth whoami` = `operator`/`system:masters`, attested + operator-key-bound, apiserver TLS pinned via `tls-server-name=c8s-cvm`.
- GPU pods: node advertises `nvidia.com/gpu: 8`; a CUDA smoke pod scheduled and ran `nvidia-smi -L` seeing a B200.

## Merge note

Stacked on **#51** (`feat/c8s-profile`). **#57** lands the final two GPU-pod fixes (device-plugin driver-root + containerd-serial) onto this branch — merge #57 into this branch before merging this one down, so it carries the complete working set.

## Pairs with

confidential-metal #70/#71 (confai launch/verify/carrier) + the new `--containerd-disk-gi` flag; c8s #86 (cred-release server + get-kubeconfig client, merged).
