### PR TITLE
ci(c8s): dispatchable c8s-dev variant carrying a commit-pinned c8s (C8S_DEV + dev + c8s_ref)

### DIFF
--- a/.github/workflows/c8s.yml
+++ b/.github/workflows/c8s.yml
@@ -24,6 +24,11 @@ on:
         description: "c8s commit short-SHA to bake the c8s binary from (resolves nri-image-policy:<ref>). Empty = the hardcoded NRI_IMAGE digest. The per-commit image must be published (c8s docker.yml)."
         required: false
         default: ""
+      dev:
+        description: "Build the c8s-dev variant (console=ttyS0 + serial root autologin). Same as pushing to ci/publish-c8s-dev-image, but dispatchable so it can carry a c8s_ref."
+        required: false
+        type: boolean
+        default: false
   push:
     branches:
       - ci/publish-c8s-image
@@ -62,9 +67,11 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set image ref and variant
+        # Dev variant when pushing to the dev branch OR when dispatched with
+        # dev=true (so a dispatched build can carry a c8s_ref and still be dev).
         run: |
           echo "IMAGE=ghcr.io/${GITHUB_REPOSITORY@L}" >> "$GITHUB_ENV"
-          if [ "${GITHUB_REF_NAME}" = "ci/publish-c8s-dev-image" ]; then
+          if [ "${GITHUB_REF_NAME}" = "ci/publish-c8s-dev-image" ] || [ "${{ github.event.inputs.dev }}" = "true" ]; then
             echo "VARIANT=c8s-dev" >> "$GITHUB_ENV"
             echo "C8S_DEV=1" >> "$GITHUB_ENV"
           else

--- a/.github/workflows/c8s.yml
+++ b/.github/workflows/c8s.yml
@@ -27,6 +27,10 @@ on:
   push:
     branches:
       - ci/publish-c8s-image
+      # Publishes the C8S_DEV=1 variant under :c8s-dev tags — console=ttyS0
+      # + serial root autologin for demos/debugging. Never overwrite :c8s
+      # with a dev build.
+      - ci/publish-c8s-dev-image
     paths:
       - "kernel/*.config"
       - "kernel/config-x86_64.snapshot"
@@ -57,8 +61,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set image ref
-        run: echo "IMAGE=ghcr.io/${GITHUB_REPOSITORY@L}" >> "$GITHUB_ENV"
+      - name: Set image ref and variant
+        run: |
+          echo "IMAGE=ghcr.io/${GITHUB_REPOSITORY@L}" >> "$GITHUB_ENV"
+          if [ "${GITHUB_REF_NAME}" = "ci/publish-c8s-dev-image" ]; then
+            echo "VARIANT=c8s-dev" >> "$GITHUB_ENV"
+            echo "C8S_DEV=1" >> "$GITHUB_ENV"
+          else
+            echo "VARIANT=c8s" >> "$GITHUB_ENV"
+          fi
 
       - name: Free up disk space
         # kernel compile + NVIDIA userspace + rke2 airgap bundles + a ~6G
@@ -100,7 +111,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: output/kernel
-          key: ${{ runner.os }}-kernel-c8s-${{ hashFiles('mkosi/kernel-builder/mkosi.conf','kernel/c8s.config','kernel/required.config','kernel/hardening.config','kernel/confidential.config','kernel/config-x86_64.snapshot','kernel/version','bin/build-c8s') }}
+          key: ${{ runner.os }}-kernel-${{ env.VARIANT }}-${{ hashFiles('mkosi/kernel-builder/mkosi.conf','kernel/c8s.config','kernel/c8s-dev.config','kernel/required.config','kernel/hardening.config','kernel/confidential.config','kernel/config-x86_64.snapshot','kernel/version','bin/build-c8s') }}
 
       # Distinct key prefix from base.yml: the c8s build's profiles add
       # ToolsTreePackages (oras, jq, curl), so the tree differs from the
@@ -141,7 +152,9 @@ jobs:
           # Bake the c8s binary from a specific commit when dispatched with a
           # c8s_ref input; empty on push builds (uses the hardcoded digest).
           C8S_REF: ${{ github.event.inputs.c8s_ref }}
-        run: bin/build-c8s
+        # C8S_DEV comes from the variant step; pin C8S_NAME to the variant so
+        # the output dir and the push/roothash paths below stay aligned.
+        run: C8S_NAME="$VARIANT" bin/build-c8s
 
       - name: Setup ORAS
         uses: oras-project/setup-oras@v1
@@ -160,8 +173,8 @@ jobs:
         id: changed
         run: |
           set -uo pipefail
-          new=$(cat output/c8s/roothash 2>/dev/null || echo new)
-          digest=$(oras manifest fetch "${IMAGE}:c8s" 2>/dev/null \
+          new=$(cat "output/${VARIANT}/roothash" 2>/dev/null || echo new)
+          digest=$(oras manifest fetch "${IMAGE}:${VARIANT}" 2>/dev/null \
                      | jq -r '.layers[] | select(.annotations["org.opencontainers.image.title"] == "roothash") | .digest' \
                      || true)
           pub=none
@@ -191,19 +204,19 @@ jobs:
           # (per-file layers, for verifiers and `confos pull`) last: the
           # change-check above reads :c8s, so a partial failure here leaves
           # it stale and the next run re-publishes everything.
-          bin/confos push output/c8s --cdi \
+          bin/confos push "output/${VARIANT}" --cdi \
             --registry "$IMAGE" \
-            --tag "c8s-cdi,c8s-cdi-${SHORT_SHA}"
-          bin/confos push output/c8s \
+            --tag "${VARIANT}-cdi,${VARIANT}-cdi-${SHORT_SHA}"
+          bin/confos push "output/${VARIANT}" \
             --registry "$IMAGE" \
-            --tag "c8s,c8s-${SHORT_SHA}"
+            --tag "${VARIANT},${VARIANT}-${SHORT_SHA}"
 
       - name: Summary
         run: |
           {
-            echo "### c8s confidential node image"
-            echo "- artifact: \`${IMAGE}:c8s\`"
-            echo "- CDI image: \`${IMAGE}:c8s-cdi\`"
+            echo "### ${VARIANT} confidential node image"
+            echo "- artifact: \`${IMAGE}:${VARIANT}\`"
+            echo "- CDI image: \`${IMAGE}:${VARIANT}-cdi\`"
             echo ""
             echo "Launch as a TDX CVM with a serial=confai-scratch disk (>=64G),"
             echo "expose 6443, then \`c8s install --distro rke2\`. See docs/C8S-IMAGE.md."

--- a/bin/build-c8s
+++ b/bin/build-c8s
@@ -29,6 +29,11 @@
 #                      once the attestation-rs `-gpu` image is published and
 #                      its digest pinned in attest-gpu/mkosi.sync (the
 #                      Stage-4 sentinel).
+#   C8S_DEV=1          demo/debug build: kernel/c8s-dev.config fragment
+#                      (8250 serial re-enabled) + the dev profile
+#                      (console=ttyS0, passwordless serial autologin).
+#                      Different measurement, root shell on the host-visible
+#                      serial socket — never ship. Default name: c8s-dev.
 #   C8S_NAME=...       output name (default c8s → output/c8s/)
 #   C8S_MEMORY=...     default-memory recorded in the manifest / used by
 #                      `confos run` (default 16G — etcd OOMs at the 4G default)
@@ -54,6 +59,12 @@ mkdir -p mkosi/base/mkosi.local
 printf '%s\n' "${C8S_REF:-}" > mkosi/base/mkosi.local/c8s-ref
 
 FRAGMENT=kernel/c8s.config
+DEV_PROFILE=()
+if [ "${C8S_DEV:-0}" = 1 ]; then
+    FRAGMENT=kernel/c8s-dev.config
+    DEV_PROFILE=(--profile dev)
+    : "${C8S_NAME:=c8s-dev}"
+fi
 KB_PKGS=dwarves,python3,pkg-config,zlib1g-dev
 
 bin/confos kernel \
@@ -73,6 +84,7 @@ fi
 
 exec bin/confos build "${C8S_NAME:-c8s}" \
     "${PROFILES[@]}" \
+    ${DEV_PROFILE[@]+"${DEV_PROFILE[@]}"} \
     --kernel-config-fragment "$FRAGMENT" \
     --kernel-builder-package "$KB_PKGS" \
     --cloud-init mkosi/base/mkosi.profiles/c8s/user-data \

--- a/bin/lint
+++ b/bin/lint
@@ -22,6 +22,18 @@ if [ -n "$missing" ]; then
     exit 1
 fi
 
+# kernel/c8s-dev.config (C8S_DEV=1 demo builds) is the union of c8s.config
+# and dev.config, committed verbatim for the same one-fragment reason.
+for src in kernel/c8s.config kernel/dev.config; do
+    missing=$(grep -E '^CONFIG_|^# CONFIG_.* is not set$' "$src" \
+              | grep -vFxf kernel/c8s-dev.config || true)
+    if [ -n "$missing" ]; then
+        echo "bin/lint: kernel/c8s-dev.config must contain every effective line of $src; missing:" >&2
+        echo "$missing" >&2
+        exit 1
+    fi
+done
+
 # The NRI_IMAGE digest pinned in the c8s sync must be the one the baked
 # boot policy self-allows, or the measured fail-closed floor denies the
 # very plugin image it ships.

--- a/kernel/c8s-dev.config
+++ b/kernel/c8s-dev.config
@@ -1,0 +1,286 @@
+# Combined kernel fragment for C8S_DEV=1 demo/debug builds of the c8s image:
+# every line of kernel/c8s.config plus kernel/dev.config's opt-ins (8250
+# serial for KubeVirt's ttyS0 console, open debugfs). Only one
+# --kernel-config-fragment is accepted per build, so the union is committed
+# verbatim; bin/lint enforces both superset invariants. Images built from
+# this fragment have a different measurement and a serial root shell —
+# never ship them.
+
+# c8s kernel config fragment — the GPU fragment plus the Kubernetes/container
+# runtime symbols the c8s node image needs.
+#
+# Applied for the c8s node image, via
+#   bin/confos kernel --kernel-config-fragment kernel/c8s.config
+#   bin/confos build  --kernel-config-fragment kernel/c8s.config \
+#       --profile gpu --profile attest-gpu --profile c8s
+# (wired through bin/build-c8s). Only one --kernel-config-fragment is accepted
+# per build, so this file is a superset: it contains every effective line of
+# kernel/gpu.config VERBATIM (bin/lint enforces that inclusion — edit
+# gpu.config first, then mirror here), followed by the container/k8s set.
+#
+# The container/k8s section is ported from base-images rke2/kernel/
+# container.config, which was validated end-to-end under c8s (RKE2 v1.34 +
+# Cilium + ratls-mesh) on the SNP rke2 image. Comments preserved — each one
+# encodes a real failure mode.
+#
+# NOT ported from container.config (KubeVirt-SNP launch stack specifics; the
+# confos TDX base boots without them — re-add if a launch stack needs them):
+#   CONFIG_VIRTIO_IOMMU        (KubeVirt forces iommu_platform under SEV-SNP)
+#   CONFIG_SERIAL_8250(_CONSOLE) (kernel/dev.config is the serial opt-in here)
+
+# ===========================================================================
+# kernel/gpu.config — verbatim effective lines. Full rationale (ephemeral
+# module signing, LKCA for NVIDIA SPDM, vsock quote path + unit-level
+# fencing) lives in that file; keep the two in lockstep.
+# ===========================================================================
+
+CONFIG_MODULES=y
+# CONFIG_MODULE_UNLOAD is not set
+
+CONFIG_MODULE_SIG=y
+CONFIG_MODULE_SIG_FORCE=y
+CONFIG_MODULE_SIG_ALL=y
+CONFIG_MODULE_SIG_SHA512=y
+
+CONFIG_CRYPTO_ECC=y
+CONFIG_CRYPTO_ECDH=y
+CONFIG_CRYPTO_ECDSA=y
+CONFIG_CRYPTO_KPP=y
+
+CONFIG_VSOCKETS=y
+CONFIG_VIRTIO_VSOCKETS=y
+
+# With CONFIG_MODULES=y + DEBUG_INFO_BTF (below), Kconfig defaults
+# DEBUG_INFO_BTF_MODULES on, which drags pahole into the out-of-tree NVIDIA
+# module build (bin/steep-fetch-gpu) and risks BTF-mismatch noise at modprobe.
+# Cilium only needs vmlinux BTF; module BTF stays off.
+# CONFIG_DEBUG_INFO_BTF_MODULES is not set
+
+# ===========================================================================
+# Container/Kubernetes runtime prerequisites (from base-images
+# rke2/kernel/container.config). Widen the hardened kernel just enough that
+# kubelet, containerd, runc, and Cilium all start cleanly. Everything =y —
+# nothing here may require a runtime modprobe (nvidia-modules-latch sets
+# kernel.modules_disabled=1 after the NVIDIA driver loads).
+# ===========================================================================
+
+# --- Container runtime essentials ----------------------------------------
+
+# kubelet refuses to start without memory cgroup support.
+CONFIG_MEMCG=y
+
+# User namespaces. Required by several container runtimes (runc rootless
+# mode, several BPF features).
+CONFIG_USER_NS=y
+
+# Pod CPU limits (CFS quota/period). Without this, `resources.limits.cpu`
+# silently has no effect.
+CONFIG_CFS_BANDWIDTH=y
+
+# Runtimes that watch container filesystems for events (falco, auditd
+# integrations, observability tools).
+CONFIG_FANOTIFY=y
+
+# kubelet credential cache.
+CONFIG_PERSISTENT_KEYRINGS=y
+
+# --- Pod networking devices ----------------------------------------------
+
+# Virtual ethernet pairs — every pod is connected to the host via veth.
+CONFIG_VETH=y
+
+# Linux bridge — used by the default CNI bridge plugin and as the underlying
+# device for VXLAN/Geneve overlays.
+CONFIG_BRIDGE=y
+# Netfilter hooks on bridge traffic (br_netfilter). Required for two reasons:
+#   1. Packets bridged between veth pairs BYPASS iptables/nftables unless
+#      br_netfilter is active — service-IP DNAT silently never fires.
+#   2. Creates /proc/sys/net/bridge/ where the bridge-nf-call-iptables
+#      sysctls live (set in the c8s profile's etc/sysctl.d/90-rke2.conf).
+CONFIG_BRIDGE_NETFILTER=y
+
+# Overlay encapsulation (Cilium VXLAN default; Geneve as the alternative).
+CONFIG_VXLAN=y
+CONFIG_GENEVE=y
+
+# TUN/TAP. Several CNIs and IPsec setups need it.
+CONFIG_TUN=y
+
+# Additional veth-style plugins (Multus, custom CNI chains).
+CONFIG_MACVLAN=y
+CONFIG_IPVLAN=y
+
+# Dummy interface — Cilium uses this for the host network namespace's
+# reverse-path verification flow.
+CONFIG_DUMMY=y
+
+# --- Modern netfilter backend --------------------------------------------
+
+# nftables — kube-proxy's default backend since k8s 1.31. Legacy iptables is
+# already in required.config.
+CONFIG_NF_TABLES=y
+CONFIG_NF_TABLES_INET=y
+CONFIG_NF_TABLES_NETDEV=y
+
+# Per-feature nftables symbols. Without them `nft add rule ... dnat to ...`
+# fails silently and service IP traffic isn't NATed. NAT: DNAT/SNAT chains
+# (service IP redirect). MASQ: outbound pod masquerading. REDIR: local-port
+# redirect. REJECT: services with no endpoints. CT: conntrack match.
+# LIMIT: rate limits. FIB: route-lookup expression.
+CONFIG_NFT_NAT=y
+CONFIG_NFT_MASQ=y
+CONFIG_NFT_REDIR=y
+CONFIG_NFT_REJECT=y
+CONFIG_NFT_REJECT_INET=y
+CONFIG_NFT_REJECT_IPV4=y
+CONFIG_NFT_REJECT_IPV6=y
+CONFIG_NFT_CT=y
+CONFIG_NFT_LIMIT=y
+CONFIG_NFT_FIB=y
+CONFIG_NFT_FIB_INET=y
+CONFIG_NFT_FIB_IPV4=y
+CONFIG_NFT_FIB_IPV6=y
+# Compatibility shim — `iptables-nft` translates legacy iptables commands to
+# nftables. RKE2 ships iptables-nft as its bundled `iptables` binary, and
+# many CNI plugins shell out to it. Without NFT_COMPAT the translation fails.
+CONFIG_NFT_COMPAT=y
+
+# Conntrack netlink — kube-proxy flushes stale entries via this when service
+# endpoints change.
+CONFIG_NF_CT_NETLINK=y
+
+# NAT helper the MASQUERADE target depends on for the actual masquerade work.
+CONFIG_NF_NAT_MASQUERADE=y
+
+# Individual xt_ matches that NetworkPolicy enforcement uses.
+#
+# NETFILTER_ADVANCED gates most xt_ matches (incl. OWNER, RECENT, STATISTIC
+# below): the hardened base leaves it unset, so olddefconfig SILENTLY DROPS
+# any xt_ match whose Kconfig `depends on NETFILTER_ADVANCED` — the option
+# just vanishes from the built kernel with no error. Must be =y for the
+# matches below to actually compile in.
+CONFIG_NETFILTER_ADVANCED=y
+CONFIG_NETFILTER_XT_MATCH_ADDRTYPE=y
+CONFIG_NETFILTER_XT_MATCH_CONNTRACK=y
+CONFIG_NETFILTER_XT_MATCH_COMMENT=y
+CONFIG_NETFILTER_XT_MATCH_MULTIPORT=y
+CONFIG_NETFILTER_XT_MATCH_RECENT=y
+CONFIG_NETFILTER_XT_MATCH_STATISTIC=y
+CONFIG_NETFILTER_XT_MATCH_MARK=y
+# owner match (-m owner --uid-owner): c8s ratls-mesh's iptables-sync skips its
+# own mesh-UID traffic with it. Without xt_owner the rule append fails ("owner
+# revision 0 not supported, missing kernel module" → RULE_APPEND failed), the
+# RATLS-MESH nat chains are left half-built, and pod egress to ClusterIPs
+# (incl. CoreDNS) returns EPERM — cascading every c8s component.
+CONFIG_NETFILTER_XT_MATCH_OWNER=y
+CONFIG_NETFILTER_XT_TARGET_REDIRECT=y
+CONFIG_NETFILTER_XT_NAT=y
+CONFIG_NF_NAT_REDIRECT=y
+CONFIG_NF_TPROXY_IPV4=y
+# Cilium's iptables datapath targets/matches (audited against Cilium 1.19's
+# system-requirements). xt_CT is the proven blocker (the VXLAN-tunnel
+# raw-table `-j CT --notrack` rule — its failure breaks host↔pod overlay
+# traffic, so kubelet probes to pod IPs time out and CoreDNS/everything
+# crashloops); the other three (MARK target, SOCKET match, TPROXY target) are
+# the rest of Cilium's documented netfilter set. (NOT added: XFRM/CRYPTO —
+# IPsec, unused; NETKIT — veth mode; NET_SCH_FQ — bandwidth manager,
+# disabled.) Deps satisfied: NETFILTER_ADVANCED, NFT_COMPAT, NF_TPROXY_IPV4
+# present; XT_MATCH_SOCKET auto-selects NF_SOCKET_IPV4.
+CONFIG_NETFILTER_XT_TARGET_CT=y
+CONFIG_NETFILTER_XT_TARGET_MARK=y
+CONFIG_NETFILTER_XT_MATCH_SOCKET=y
+CONFIG_NETFILTER_XT_TARGET_TPROXY=y
+
+# --- kube-proxy IPVS mode ------------------------------------------------
+
+CONFIG_IP_VS=y
+CONFIG_IP_VS_NFCT=y
+CONFIG_IP_VS_RR=y
+CONFIG_IP_VS_WRR=y
+CONFIG_IP_VS_SH=y
+
+# ipsets — IP_SET is the ipset core; NETFILTER_XT_SET is the separate xtables
+# glue that lets iptables rules reference a set via `-m set --match-set` —
+# c8s ratls-mesh's REDIRECT/DNAT rules need it ("set revision 0 not
+# supported" without it).
+CONFIG_IP_SET=y
+CONFIG_IP_SET_HASH_IP=y
+CONFIG_IP_SET_HASH_NET=y
+CONFIG_NETFILTER_XT_SET=y
+
+# --- BPF (Cilium, kubelet, observability) --------------------------------
+
+# eBPF syscall + JIT. Cilium won't load without these, and modern kubelet
+# uses BPF for several functions even with non-BPF CNIs.
+CONFIG_BPF_SYSCALL=y
+CONFIG_BPF_JIT=y
+
+# BPF programs attached to cgroup events (Cilium's egress connect hooks,
+# systemd's BPF firewall, etc.).
+CONFIG_CGROUP_BPF=y
+
+# BPF in tc — Cilium's datapath is built on these.
+CONFIG_NET_CLS_BPF=y
+CONFIG_NET_ACT_BPF=y
+CONFIG_NET_SCH_INGRESS=y
+
+# --- Encrypted containerd data disk (containerd-data-disk.service) -------
+
+# containerd-data-disk.service backs /var/lib/rancher/rke2/agent/containerd
+# (the image cache) with a LABEL=containerd disk it encrypts in-guest,
+# keeping several GiB of image layers off guest RAM (the tmpfs default). It
+# uses `cryptsetup open --type plain --cipher aes-xts-plain64`, which needs
+# dm-crypt + the XTS template + AES in the BOOTED kernel — without them
+# cryptsetup HANGS at boot (the device-mapper target never appears). The
+# service has a fail-safe timeout, but the encrypted path only actually
+# works with these on.
+CONFIG_DM_CRYPT=y
+CONFIG_CRYPTO_XTS=y
+CONFIG_CRYPTO_AES_NI_INTEL=y
+
+# --- Filesystem extras ---------------------------------------------------
+
+# Several snapshotters (stargz, soci, nydus) use FUSE.
+CONFIG_FUSE_FS=y
+
+# squashfs — useful on every image for inspecting kata images.
+CONFIG_SQUASHFS=y
+CONFIG_SQUASHFS_XATTR=y
+CONFIG_SQUASHFS_ZSTD=y
+
+# --- Socket diagnostics --------------------------------------------------
+
+# `ss`, `netstat`, several observability agents read these.
+CONFIG_INET_DIAG=y
+CONFIG_INET_TCP_DIAG=y
+CONFIG_INET_UDP_DIAG=y
+CONFIG_INET_RAW_DIAG=y
+CONFIG_INET_DIAG_DESTROY=y
+
+# --- BTF (Cilium socket-LB) ----------------------------------------------
+
+# pahole turns the kernel's DWARF into BTF, which eBPF CO-RE needs. Without
+# it /sys/kernel/btf/vmlinux is absent and Cilium's socket-LB can't
+# translate ClusterIP service VIPs: connect() to any Service IP (CoreDNS,
+# kube-api) returns EPERM, breaking c8s (cds → attestation-api .svc).
+# Overrides hardening.config's `# CONFIG_DEBUG_INFO is not set`. Requires
+# dwarves (pahole) in the kernel-builder tools tree — hence
+# --kernel-builder-package dwarves,python3,pkg-config,zlib1g-dev.
+CONFIG_DEBUG_INFO=y
+CONFIG_DEBUG_INFO_DWARF5=y
+CONFIG_DEBUG_INFO_BTF=y
+
+# DEBUG_INFO_BTF depends on !GCC_PLUGIN_RANDSTRUCT — pahole cannot describe
+# randomized struct layouts. Overrides hardening.config's RANDSTRUCT_FULL:
+# the c8s kernel trades struct-layout randomization for BTF, the same trade
+# every BTF-shipping distro kernel makes.
+# CONFIG_RANDSTRUCT_FULL is not set
+CONFIG_RANDSTRUCT_NONE=y
+
+# --- kernel/dev.config opt-ins (verbatim; merged last so they win) ---
+CONFIG_SERIAL_8250=y
+CONFIG_SERIAL_8250_CONSOLE=y
+CONFIG_SERIAL_8250_PCI=y
+CONFIG_SERIAL_8250_NR_UARTS=4
+CONFIG_SERIAL_8250_RUNTIME_UARTS=4
+CONFIG_DEBUG_FS_ALLOW_ALL=y


### PR DESCRIPTION
## What

Makes the demo/debug **c8s-dev image variant** buildable from CI with a commit-pinned c8s binary:

1. **`C8S_DEV=1` build knob** — composes the `dev` profile and swaps the kernel fragment to `kernel/c8s-dev.config` (adds 8250 serial: `console=ttyS0` + root autologin on serial for demos/debugging). Publishes under `:c8s-dev` tags — never overwrites `:c8s`.
2. **`dev` workflow_dispatch input** — same effect as pushing to `ci/publish-c8s-dev-image`, but dispatchable so a single run can carry a `c8s_ref` AND be the dev variant. The variant step pins `C8S_NAME` so output/push/roothash paths stay aligned.

## Why dispatchable

Testing an unmerged c8s (e.g. cred-release) end-to-end needs one CI run that both bakes `nri-image-policy:<short-sha>` (via `c8s_ref`, from the base PR) and produces a console-accessible dev image. The push-branch trigger can't carry inputs.

## Stacked on

confos #53 (`feat/rtmr3-operator-key`) — uses its `c8s_ref` input + `mkosi.local/c8s-ref` plumbing.

Validated: run 29567082884 built this change (dev=true, c8s_ref=b8cb37d; same content, pre-rebase SHAs).
