### PR TITLE
feat(gpu): GPU pods via CDI — CUDA userspace + nvidia-ctk + baked device plugin

### DIFF
--- a/bin/steep-fetch-gpu
+++ b/bin/steep-fetch-gpu
@@ -35,6 +35,14 @@ readonly RUN_INSTALLER="https://us.download.nvidia.com/tesla/${NV_VERSION}/NVIDI
 readonly OGKM_SHA256="cb26114c97ef2568377a7eb55ef97e559c42f1b686238b4d09d7a6fabd0cad50"
 readonly RUN_SHA256="36203b8960b7e49c8a42f6ba1f5863cde34a05e93d2b24b798af06dd846f6b82"
 
+# nvidia-container-toolkit-base: nvidia-ctk (CDI spec generation at boot) +
+# nvidia-cdi-hook (referenced by the generated spec). CDI-only GPU-pod path —
+# no nvidia-container-runtime wrapper, containerd 2.x injects CDI devices
+# natively. sha256 from the repo's Packages index; bump both together.
+readonly TK_VERSION="1.19.1-1"
+readonly TK_DEB="https://nvidia.github.io/libnvidia-container/stable/deb/amd64/nvidia-container-toolkit-base_${TK_VERSION}_amd64.deb"
+readonly TK_SHA256="b6c5b4e77a28cde0197cc0e64edf75538604775d9f8aea502cef667e7e5b2132"
+
 # --- Paths ---
 readonly KERNEL_OUT="output/kernel"
 readonly TOOLS_TREE="mkosi/kernel-builder/mkosi.output/image"
@@ -215,6 +223,16 @@ stage_bin nvidia-smi
 stage_bin nvidia-persistenced
 stage_bin nvidia-modprobe 4755   # setuid root — creates device nodes on demand
 
+# CUDA userspace driver stack — what a CUDA app (inference containers via CDI
+# bind-mounts) actually dlopens: libcuda + its JIT/compiler companions. Without
+# these the image can run nvidia-smi but no CUDA workload.
+stage_lib libcuda.so
+stage_lib libcudadebugger.so
+stage_lib libnvidia-nvvm.so
+stage_lib libnvidia-ptxjitcompiler.so
+stage_lib libnvidia-gpucomp.so
+stage_lib libnvidia-allocator.so
+
 # GSP firmware: the open modules request_firmware() a GSP blob at load time.
 # It must live at /lib/firmware/nvidia/<ver>/. Stage the whole per-version dir.
 log "Staging GSP firmware"
@@ -222,5 +240,22 @@ FW_SRC="$(find "$RUN_SRC/firmware" -maxdepth 1 -name '*.bin' -print -quit 2>/dev
 [[ -n "$FW_SRC" ]] || die "no GSP firmware .bin found under $RUN_SRC/firmware"
 install -d "$STAGE/usr/lib/firmware/nvidia/${NV_VERSION}"
 install -m0644 "$RUN_SRC"/firmware/*.bin "$STAGE/usr/lib/firmware/nvidia/${NV_VERSION}/"
+
+# =============================================================================
+# Part 3: stage nvidia-ctk + nvidia-cdi-hook from the container-toolkit deb
+# =============================================================================
+# CDI GPU-pod path: a boot oneshot (nvidia-cdi-generate.service, gpu profile)
+# runs `nvidia-ctk cdi generate`; the spec's hooks exec nvidia-cdi-hook. The
+# nvidia-container-runtime shim in the same deb is deliberately NOT staged.
+log "Staging nvidia-ctk + nvidia-cdi-hook from container-toolkit ${TK_VERSION}"
+fetch "$TK_DEB" "$TK_SHA256" "$CACHE/nvidia-container-toolkit-base_${TK_VERSION}_amd64.deb"
+rm -rf "$WORK/tk"
+mkdir -p "$WORK/tk"
+dpkg-deb -x "$CACHE/nvidia-container-toolkit-base_${TK_VERSION}_amd64.deb" "$WORK/tk"
+for b in nvidia-ctk nvidia-cdi-hook; do
+  [[ -x "$WORK/tk/usr/bin/$b" ]] || die "$b not found in toolkit-base deb"
+  install -D -m0755 "$WORK/tk/usr/bin/$b" "$STAGE/usr/bin/$b"
+done
+rm -rf "$WORK/tk"
 
 log "steep-fetch-gpu done — modules + userspace staged under $STAGE"

--- a/docs/C8S-IMAGE.md
+++ b/docs/C8S-IMAGE.md
@@ -219,17 +219,28 @@ Two failure modes hard-won here (both fixed; noted so they stay fixed):
 - **S5 CI + publish**: c8s.yml green; a no-change rerun hits the
   roothash publish-skip; pulled artifact re-verifies.
 
-## Deferred: GPU pods (follow-up)
+## GPU pods
 
-The gpu profile makes GPUs host-visible (`nvidia-smi`, CC Ready) but NOT
-schedulable as pod resources. That needs (a) image-side:
-nvidia-container-toolkit (`nvidia-ctk`, `nvidia-container-runtime{,-hook}`,
-`libnvidia-container`) plus either a boot oneshot generating a CDI spec
-(`nvidia-ctk cdi generate` — lands on the overlay but derives from the
-measured driver) or a containerd runtime drop-in; and (b) cluster-side:
-nvidia-device-plugin (could be baked as a `server/manifests/` file,
-digest-pinned). Do this only after S4 passes so GPU-pod breakage never
-conflates with enforcement bring-up.
+GPUs are schedulable as `nvidia.com/gpu` on the inner cluster, CDI end to end
+— no nvidia-container-runtime wrapper:
+
+- **Image-side** (`bin/steep-fetch-gpu` + gpu profile): the CUDA userspace
+  driver stack (`libcuda` + JIT/compiler companions — without these the image
+  ran `nvidia-smi` but no CUDA workload), `nvidia-ctk`/`nvidia-cdi-hook` from
+  the pinned container-toolkit deb, and `nvidia-cdi-generate.service` — a boot
+  oneshot after persistenced that writes `/var/run/cdi/nvidia.yaml` (tmpfs;
+  regenerated per boot from the measured driver, skipped on GPU-less boots).
+- **Cluster-side** (c8s profile): a digest-pinned nvidia-device-plugin
+  DaemonSet baked at `server/manifests/nvidia-device-plugin.yaml`, kube-system
+  (PSA- and allowlist-exempt), `DEVICE_LIST_STRATEGY=cdi-cri`,
+  `FAIL_ON_INIT_ERROR=false` so GPU-less boots stay degraded-nothing.
+- **Runtime**: RKE2's containerd 2.x has CDI enabled by default and injects
+  the devices at pod creation.
+
+A GPU workload just requests `resources.limits: {nvidia.com/gpu: N}`. Its
+image must still be on the NRI allowlist (workload namespaces are not
+exempt). Not yet covered: NVSwitch passthrough + in-guest fabric manager —
+NVLink P2P for multi-GPU TP is unvalidated; NCCL may fall back to SHM.
 
 ## Risks / open questions
 

--- a/mkosi/base/mkosi.profiles/c8s/mkosi.extra/var/lib/rancher/rke2/server/manifests/nvidia-device-plugin.yaml
+++ b/mkosi/base/mkosi.profiles/c8s/mkosi.extra/var/lib/rancher/rke2/server/manifests/nvidia-device-plugin.yaml
@@ -1,0 +1,79 @@
+# NVIDIA device plugin — makes passed-through GPUs schedulable as
+# `nvidia.com/gpu` on the inner cluster. CDI end to end: the gpu profile's
+# nvidia-cdi-generate.service writes /var/run/cdi/nvidia.yaml at boot, the
+# plugin advertises devices with the cdi-cri strategy, and containerd 2.x
+# (CDI on by default) injects them at pod creation — no nvidia-container-runtime
+# wrapper anywhere.
+#
+# kube-system placement is deliberate: PSA-exempt (the pod needs hostPath +
+# privileged to reach NVML and /dev) and exempt from the NRI image-policy
+# allowlist, so the plugin can start before CDS is up. Digest-pinned like every
+# other baked component.
+#
+# The plugin itself dlopens NVML from the measured root's driver stack — the
+# image ships no toolkit runtime to inject it, hence the explicit lib mount +
+# LD_LIBRARY_PATH.
+#
+# FAIL_ON_INIT_ERROR=false keeps GPU-less boots degraded-nothing: the plugin
+# idles instead of crash-looping when no NVIDIA device exists.
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: nvidia-device-plugin
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/name: nvidia-device-plugin
+    app.kubernetes.io/part-of: c8s-node-image
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: nvidia-device-plugin
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: nvidia-device-plugin
+    spec:
+      priorityClassName: system-node-critical
+      tolerations:
+        - operator: Exists
+      containers:
+        - name: nvidia-device-plugin
+          image: nvcr.io/nvidia/k8s-device-plugin:v0.19.3@sha256:25cc340fe6fd53c101e16fc452f503e7a92c219c64a80ed5381784b522dbbf77
+          env:
+            - name: FAIL_ON_INIT_ERROR
+              value: "false"
+            - name: DEVICE_LIST_STRATEGY
+              value: cdi-cri
+            - name: NVIDIA_VISIBLE_DEVICES
+              value: all
+            - name: LD_LIBRARY_PATH
+              value: /host-lib
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - name: device-plugin
+              mountPath: /var/lib/kubelet/device-plugins
+            - name: cdi-dir
+              mountPath: /var/run/cdi
+              readOnly: true
+            - name: host-lib
+              mountPath: /host-lib
+              readOnly: true
+            - name: dev
+              mountPath: /dev
+      volumes:
+        - name: device-plugin
+          hostPath:
+            path: /var/lib/kubelet/device-plugins
+        - name: cdi-dir
+          hostPath:
+            path: /var/run/cdi
+            type: DirectoryOrCreate
+        - name: host-lib
+          hostPath:
+            path: /usr/lib/x86_64-linux-gnu
+        - name: dev
+          hostPath:
+            path: /dev

--- a/mkosi/base/mkosi.profiles/gpu/mkosi.extra/etc/systemd/system/nvidia-cdi-generate.service
+++ b/mkosi/base/mkosi.profiles/gpu/mkosi.extra/etc/systemd/system/nvidia-cdi-generate.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=Generate the NVIDIA CDI spec for GPU pods
+# The spec enumerates /dev/nvidia* nodes and the driver libraries, so it must
+# run after persistenced has attached the driver and created the device nodes.
+# kubelet/containerd need no ordering against this: the device plugin retries
+# until the spec exists, and containerd reads /var/run/cdi per pod creation.
+After=nvidia-persistenced.service
+Wants=nvidia-persistenced.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+# Skip (not fail) on a GPU-less boot — same degraded-nothing posture as the
+# other nvidia-* units.
+ExecCondition=/bin/sh -c 'grep -qx 0x10de /sys/bus/pci/devices/*/vendor 2>/dev/null'
+# /var/run is tmpfs: the spec is regenerated fresh every boot, matching
+# whatever GPUs this launch passed through.
+ExecStart=/usr/bin/nvidia-ctk cdi generate --output=/var/run/cdi/nvidia.yaml
+
+[Install]
+WantedBy=multi-user.target

--- a/mkosi/base/mkosi.profiles/gpu/mkosi.extra/usr/lib/systemd/system-preset/10-nvidia.preset
+++ b/mkosi/base/mkosi.profiles/gpu/mkosi.extra/usr/lib/systemd/system-preset/10-nvidia.preset
@@ -5,3 +5,4 @@ enable nvidia-gpu-flr.service
 enable nvidia-persistenced.service
 enable nvidia-cc-ready.service
 enable nvidia-modules-latch.service
+enable nvidia-cdi-generate.service


### PR DESCRIPTION
## What

Makes passed-through GPUs schedulable as `nvidia.com/gpu` on the inner cluster — the C8S-IMAGE.md "Deferred: GPU pods" plan, CDI end to end with no nvidia-container-runtime wrapper:

1. **CUDA userspace driver stack staged** (`bin/steep-fetch-gpu`): `libcuda`, `libcudadebugger`, `libnvidia-nvvm`, `libnvidia-ptxjitcompiler`, `libnvidia-gpucomp`, `libnvidia-allocator` — previously only NVML/cfg were staged, so the image could run `nvidia-smi` but no CUDA workload.
2. **`nvidia-ctk` + `nvidia-cdi-hook`** from the sha256-pinned `nvidia-container-toolkit-base` 1.19.1 deb (the `nvidia-container-runtime` shim in the same deb is deliberately not shipped).
3. **`nvidia-cdi-generate.service`** (gpu profile): boot oneshot after persistenced writing `/var/run/cdi/nvidia.yaml` — tmpfs, regenerated per launch from the measured driver; `ExecCondition` skips GPU-less boots (same degraded-nothing posture as the other nvidia-* units).
4. **Baked nvidia-device-plugin DaemonSet** (c8s profile `server/manifests/`): digest-pinned `v0.19.3`, kube-system (PSA- and NRI-allowlist-exempt), `DEVICE_LIST_STRATEGY=cdi-cri`, `FAIL_ON_INIT_ERROR=false`. RKE2's containerd 2.x injects the CDI devices natively.

## Why now

The inference deployment (SGLang, TP=8 on the 8× B200 node) needs `resources.limits: {nvidia.com/gpu: 8}` to work the product way. The b200 GPUs are currently held by a separate experiment, so this readies the image for when they free up; GPU-less boots are unaffected (all new pieces skip/idle cleanly).

## Not covered (known follow-ups)

- NVSwitch passthrough + in-guest fabric manager: NVLink P2P for multi-GPU TP is unvalidated; NCCL may fall back to SHM transport.
- Workload images still need NRI allowlisting (workload namespaces are not exempt) — the standard `--workload-ref`/`c8s allowlist add` flow.

## Validation

- `bash -n` + repo lint green; manifest YAML-parses.
- Full validation needs a CI image build + a GPU launch once the B200s free up: `nvidia-cdi-generate` active, plugin advertises 8× `nvidia.com/gpu`, a CUDA pod schedules and runs.

## Stacked on

confos #53 (`feat/rtmr3-operator-key`).