### PR TITLE
fix(gpu): device-plugin driver-root + containerd serial disk (validated on b200)

### DIFF
--- a/docs/C8S-IMAGE.md
+++ b/docs/C8S-IMAGE.md
@@ -232,7 +232,7 @@ GPUs are schedulable as `nvidia.com/gpu` on the inner cluster, CDI end to end
   regenerated per boot from the measured driver, skipped on GPU-less boots).
 - **Cluster-side** (c8s profile): a digest-pinned nvidia-device-plugin
   DaemonSet baked at `server/manifests/nvidia-device-plugin.yaml`, kube-system
-  (PSA- and allowlist-exempt), `DEVICE_LIST_STRATEGY=cdi-cri`,
+  (PSA- and allowlist-exempt), `DEVICE_LIST_STRATEGY=cdi-annotations`,
   `FAIL_ON_INIT_ERROR=false` so GPU-less boots stay degraded-nothing.
 - **Runtime**: RKE2's containerd 2.x has CDI enabled by default and injects
   the devices at pod creation.

--- a/mkosi/base/mkosi.profiles/c8s/mkosi.extra/usr/local/bin/containerd-data-disk.sh
+++ b/mkosi/base/mkosi.profiles/c8s/mkosi.extra/usr/local/bin/containerd-data-disk.sh
@@ -48,19 +48,29 @@ if mountpoint -q "$DIR"; then
     exit 0
 fi
 
-# Find a whole-device LABEL=containerd disk. vda is the verity rootfs. Prefer
-# the SCSI bus (sd*): under SEV-SNP/KubeVirt a secondary virtio-blk disk wedges
-# on every I/O (raw dd hangs in uninterruptible D-state — iommu=on is forced on
-# all virtio devices and the virtio-blk DMA path is broken for hot-attached data
-# disks; virtio-scsi works). Scan sd* first, then vd* as a fallback for
-# launches without that quirk. Poll briefly (~10s) so a slow udev probe doesn't
-# make us miss it. `blkid -p` probes the device directly rather than trusting
-# the (possibly stale) udev cache.
+# Find the containerd data disk. vda is the verity rootfs. Prefer the SCSI bus
+# (sd*): under SEV-SNP/KubeVirt a secondary virtio-blk disk wedges on every I/O
+# (raw dd hangs in uninterruptible D-state — iommu=on is forced on all virtio
+# devices and the virtio-blk DMA path is broken for hot-attached data disks;
+# virtio-scsi works). Scan sd* first, then vd* as a fallback for launches
+# without that quirk. Poll briefly (~10s) so a slow udev probe doesn't make us
+# miss it.
+#
+# Two ways a device qualifies:
+#   1. filesystem LABEL=containerd — a host-prepared, pre-labelled disk.
+#   2. device SERIAL=confai-containerd — a BLANK disk confai attaches with that
+#      serial (mirrors the confai-scratch datadisk). This is the confai path:
+#      the disk carries no filesystem, so the encrypted mkfs below lays one down
+#      per boot. `blkid -p` probes the device directly (not the stale udev
+#      cache); the serial comes from sysfs.
 DEV=""
 for _ in $(seq 1 20); do
     for d in /dev/sd? /dev/vd?; do
         [ -b "$d" ] || continue
         if [ "$(blkid -p -s LABEL -o value "$d" 2>/dev/null || true)" = "containerd" ]; then
+            DEV="$d"; break
+        fi
+        if [ "$(cat "/sys/block/$(basename "$d")/serial" 2>/dev/null || true)" = "confai-containerd" ]; then
             DEV="$d"; break
         fi
     done

--- a/mkosi/base/mkosi.profiles/c8s/mkosi.extra/var/lib/rancher/rke2/server/manifests/nvidia-device-plugin.yaml
+++ b/mkosi/base/mkosi.profiles/c8s/mkosi.extra/var/lib/rancher/rke2/server/manifests/nvidia-device-plugin.yaml
@@ -1,21 +1,23 @@
 # NVIDIA device plugin — makes passed-through GPUs schedulable as
 # `nvidia.com/gpu` on the inner cluster. CDI end to end: the gpu profile's
-# nvidia-cdi-generate.service writes /var/run/cdi/nvidia.yaml at boot, the
-# plugin advertises devices with the cdi-cri strategy, and containerd 2.x
-# (CDI on by default) injects them at pod creation — no nvidia-container-runtime
-# wrapper anywhere.
+# nvidia-cdi-generate.service writes /var/run/cdi/nvidia.yaml at boot; the
+# plugin discovers the driver files under CONTAINER_DRIVER_ROOT, advertises the
+# GPUs, and containerd 2.x (CDI on by default) injects the CDI devices at pod
+# creation — no nvidia-container-runtime wrapper anywhere.
 #
-# kube-system placement is deliberate: PSA-exempt (the pod needs hostPath +
-# privileged to reach NVML and /dev) and exempt from the NRI image-policy
-# allowlist, so the plugin can start before CDS is up. Digest-pinned like every
-# other baked component.
+# kube-system placement is deliberate: PSA-exempt (privileged + hostPath to
+# reach the driver root and /dev) and NRI-allowlist-exempt, so the plugin can
+# start before CDS is up. Digest-pinned like every other baked component.
 #
-# The plugin itself dlopens NVML from the measured root's driver stack — the
-# image ships no toolkit runtime to inject it, hence the explicit lib mount +
-# LD_LIBRARY_PATH.
+# The plugin discovers NVML/libcuda + the CDI hooks from the measured root
+# mounted at /driver-root. It MUST NOT put the guest lib dir on LD_LIBRARY_PATH
+# — /usr/lib/x86_64-linux-gnu holds the guest's libc/libpthread, which would
+# shadow the container's own and crash the Go runtime with
+# "pthread_create failed: Invalid argument". Instead NVIDIA_DRIVER_ROOT=/ +
+# CONTAINER_DRIVER_ROOT=/driver-root let the plugin's own resolver find the libs.
 #
-# FAIL_ON_INIT_ERROR=false keeps GPU-less boots degraded-nothing: the plugin
-# idles instead of crash-looping when no NVIDIA device exists.
+# DEVICE_LIST_STRATEGY=cdi-annotations (v0.19.3 does NOT accept cdi-cri).
+# FAIL_ON_INIT_ERROR=false keeps GPU-less boots degraded-nothing.
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -45,11 +47,15 @@ spec:
             - name: FAIL_ON_INIT_ERROR
               value: "false"
             - name: DEVICE_LIST_STRATEGY
-              value: cdi-cri
+              value: cdi-annotations
+            - name: DEVICE_ID_STRATEGY
+              value: uuid
+            - name: NVIDIA_DRIVER_ROOT
+              value: /
+            - name: CONTAINER_DRIVER_ROOT
+              value: /driver-root
             - name: NVIDIA_VISIBLE_DEVICES
               value: all
-            - name: LD_LIBRARY_PATH
-              value: /host-lib
           securityContext:
             privileged: true
           volumeMounts:
@@ -57,9 +63,8 @@ spec:
               mountPath: /var/lib/kubelet/device-plugins
             - name: cdi-dir
               mountPath: /var/run/cdi
-              readOnly: true
-            - name: host-lib
-              mountPath: /host-lib
+            - name: driver-root
+              mountPath: /driver-root
               readOnly: true
             - name: dev
               mountPath: /dev
@@ -71,9 +76,9 @@ spec:
           hostPath:
             path: /var/run/cdi
             type: DirectoryOrCreate
-        - name: host-lib
+        - name: driver-root
           hostPath:
-            path: /usr/lib/x86_64-linux-gnu
+            path: /
         - name: dev
           hostPath:
             path: /dev


### PR DESCRIPTION
## What

Two hardware-validated fixes on top of #56 (which merged before these were found while bringing SGLang up on the 8×B200 CVM). Without them the GPU-pods path is broken:

1. **device-plugin driver-root discovery** (`f2e8884`) — the baked nvidia-device-plugin crash-looped with `runtime/cgo: pthread_create failed: Invalid argument`: mounting the guest `/usr/lib/x86_64-linux-gnu` as `/host-lib` on `LD_LIBRARY_PATH` shadowed the container's own libc/libpthread. Also `DEVICE_LIST_STRATEGY=cdi-cri` is invalid for device-plugin v0.19.3. Fix: mount host `/` at `/driver-root` (`NVIDIA_DRIVER_ROOT=/` + `CONTAINER_DRIVER_ROOT=/driver-root`), `DEVICE_LIST_STRATEGY=cdi-annotations`. **Validated**: node advertises `nvidia.com/gpu: 8`, a CUDA pod scheduled and ran `nvidia-smi`.

2. **containerd disk matched by serial** (`7d88b1f`) — confai attaches a blank disk with `serial=confai-containerd` (no filesystem label), so `LABEL=containerd` matching never found it and the image cached containers in a 32G RAM tmpfs; a large workload image (SGLang) then exhausted guest RAM → node disk-pressure eviction. Also match by `/sys/block/<dev>/serial`. Pairs with confai's new `--containerd-disk-gi` flag.

## Why a follow-up PR

#56 was merged into `feat/rtmr3-operator-key` at `8b62874` before these fixes existed; they were pushed to the same branch afterward. This PR lands them on #53's branch so #53 carries the complete, working GPU-pods set before it merges down.

## Validation

On b200 (8×B200 CVM): device plugin Running 1/1, `nvidia.com/gpu: 8` advertised, CUDA smoke pod Succeeded. Containerd-serial fix is in the in-flight image rebuild.