### PR TITLE
fix(gpu): working containerd-disk match (by-id) + IMEX channel + tdx self-label + NTP

### DIFF
--- a/mkosi/base/mkosi.profiles/c8s/mkosi.conf
+++ b/mkosi/base/mkosi.profiles/c8s/mkosi.conf
@@ -42,6 +42,11 @@ Packages=
     procps
     # On-node debugging of rke2/NRI state (kubectl -o json plumbing etc.).
     jq
+    # NTP: the guest clock free-runs off the TDX TSC and drifts ~60-70s behind
+    # the operator's, which trips cred-release's JWT clock-skew check
+    # ("token used before issued") on get-kubeconfig. timesyncd (enabled via
+    # the preset below) syncs it over the CVM's masquerade egress.
+    systemd-timesyncd
 
 [Build]
 # oras + jq: mkosi.sync pulls the nri-image-policy OCI image by digest and

--- a/mkosi/base/mkosi.profiles/c8s/mkosi.extra/etc/rancher/rke2/config.yaml
+++ b/mkosi/base/mkosi.profiles/c8s/mkosi.extra/etc/rancher/rke2/config.yaml
@@ -37,6 +37,11 @@ tls-san:
 
 profile: cis
 pod-security-admission-config-file: /etc/rancher/rke2/psa-config.yaml
+# Self-label as a TDX confidential node so `c8s install --hardware-platform tdx`
+# finds a target without a manual `kubectl label`. This image is TDX-only
+# (RTMR[3] operator binding, TDX quotes); the label is always correct here.
+node-label:
+  - confidential.ai/tdx=true
 kubelet-arg:
   - max-pods=200
 kube-apiserver-arg:

--- a/mkosi/base/mkosi.profiles/c8s/mkosi.extra/usr/lib/systemd/system-preset/50-rke2.preset
+++ b/mkosi/base/mkosi.profiles/c8s/mkosi.extra/usr/lib/systemd/system-preset/50-rke2.preset
@@ -24,6 +24,10 @@
 enable containerd-data-disk.service
 enable rke2-server.service
 disable rke2-agent.service
+# NTP: sync the free-running TDX guest clock so it doesn't drift behind the
+# operator and trip cred-release's JWT clock-skew check. Egress is via the
+# CVM's masquerade NAT.
+enable systemd-timesyncd.service
 # Attested operator credential release. Enabled always, but its
 # ConditionPathExists on the opkeydata disk means it only starts on operator
 # boots — a no-op on nodes launched without --operator-key.

--- a/mkosi/base/mkosi.profiles/c8s/mkosi.extra/usr/local/bin/containerd-data-disk.sh
+++ b/mkosi/base/mkosi.profiles/c8s/mkosi.extra/usr/local/bin/containerd-data-disk.sh
@@ -65,11 +65,22 @@ fi
 #      cache); the serial comes from sysfs.
 DEV=""
 for _ in $(seq 1 20); do
+    # by-id first: virtio-scsi (KubeVirt Bus: scsi) surfaces the serial ONLY in
+    # /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_<serial>, NOT in
+    # /sys/block/<dev>/serial (empty on SCSI). This is the confai path
+    # (--containerd-disk-gi attaches a scsi disk serial=confai-containerd).
+    for l in /dev/disk/by-id/*confai-containerd*; do
+        [ -e "$l" ] || continue
+        DEV="$(readlink -f "$l")"; break
+    done
+    [ -n "$DEV" ] && break
     for d in /dev/sd? /dev/vd?; do
         [ -b "$d" ] || continue
+        # host-prepared disk with a real filesystem LABEL
         if [ "$(blkid -p -s LABEL -o value "$d" 2>/dev/null || true)" = "containerd" ]; then
             DEV="$d"; break
         fi
+        # virtio-blk surfaces the serial in sysfs (SCSI does not — see above)
         if [ "$(cat "/sys/block/$(basename "$d")/serial" 2>/dev/null || true)" = "confai-containerd" ]; then
             DEV="$d"; break
         fi

--- a/mkosi/base/mkosi.profiles/gpu/mkosi.extra/etc/systemd/system/nvidia-cdi-generate.service
+++ b/mkosi/base/mkosi.profiles/gpu/mkosi.extra/etc/systemd/system/nvidia-cdi-generate.service
@@ -2,9 +2,11 @@
 Description=Generate the NVIDIA CDI spec for GPU pods
 # The spec enumerates /dev/nvidia* nodes and the driver libraries, so it must
 # run after persistenced has attached the driver and created the device nodes.
+# It also runs after nvidia-imex-channel so the IMEX channel node exists before
+# we fold it into every device (B200/NVSwitch needs it or CUDA errors 802).
 # kubelet/containerd need no ordering against this: the device plugin retries
 # until the spec exists, and containerd reads /var/run/cdi per pod creation.
-After=nvidia-persistenced.service
+After=nvidia-persistenced.service nvidia-imex-channel.service
 Wants=nvidia-persistenced.service
 
 [Service]
@@ -15,7 +17,17 @@ RemainAfterExit=yes
 ExecCondition=/bin/sh -c 'grep -qx 0x10de /sys/bus/pci/devices/*/vendor 2>/dev/null'
 # /var/run is tmpfs: the spec is regenerated fresh every boot, matching
 # whatever GPUs this launch passed through.
-ExecStart=/usr/bin/nvidia-ctk cdi generate --output=/var/run/cdi/nvidia.yaml
+#
+# nvml mode gives the full spec (device nodes + driver libraries) but omits the
+# IMEX channel; imex mode carries the channel but not the libraries. Neither
+# alone is complete for B200. Generate the nvml spec, then fold the IMEX channel
+# deviceNode into every device's containerEdits (one awk pass: after each
+# `deviceNodes:` line, insert the channel at matching indent, major read from
+# /proc/devices) so a pod requesting nvidia.com/gpu gets the fabric channel
+# alongside the GPUs — no separate resource request. No-op when the channel
+# node is absent (non-NVSwitch host).
+ExecStart=/usr/bin/nvidia-ctk cdi generate --mode=nvml --output=/var/run/cdi/nvidia.yaml
+ExecStart=/bin/sh /usr/local/bin/nvidia-cdi-add-imex.sh /var/run/cdi/nvidia.yaml
 
 [Install]
 WantedBy=multi-user.target

--- a/mkosi/base/mkosi.profiles/gpu/mkosi.extra/etc/systemd/system/nvidia-imex-channel.service
+++ b/mkosi/base/mkosi.profiles/gpu/mkosi.extra/etc/systemd/system/nvidia-imex-channel.service
@@ -1,0 +1,31 @@
+[Unit]
+Description=Create the NVIDIA IMEX channel device node
+# B200/NVSwitch GPUs need an IMEX (Internode Memory Exchange) channel to
+# initialize the multi-GPU fabric — without /dev/nvidia-caps-imex-channels/channel0
+# CUDA fails with "error 802: system not yet initialized" (cudaGetDeviceCount),
+# even for single-node multi-GPU. On bare metal nvidia-imex/fabric-manager
+# creates it; in the CVM we create channel 0 explicitly. Must run after the
+# driver is attached and BEFORE nvidia-cdi-generate so the CDI spec can pick it
+# up (and before kubelet so GPU pods see it).
+After=nvidia-persistenced.service
+Wants=nvidia-persistenced.service
+Before=nvidia-cdi-generate.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+# Skip on a GPU-less boot — same degraded-nothing posture as the other nvidia units.
+ExecCondition=/bin/sh -c 'grep -qx 0x10de /sys/bus/pci/devices/*/vendor 2>/dev/null'
+# nvidia-modprobe -c 0 registers the nvidia-caps-imex-channels chardev (its major
+# lands in /proc/devices, dynamically allocated); then mknod channel 0 at that
+# major. Idempotent: skip the mknod if the node already exists.
+ExecStart=/usr/bin/nvidia-modprobe -c 0
+ExecStart=/bin/sh -c 'test -e /dev/nvidia-caps-imex-channels/channel0 || { \
+    maj=$(awk "/nvidia-caps-imex-channels/ {print \$1}" /proc/devices); \
+    test -n "$maj" || { echo "nvidia-imex-channel: no imex major in /proc/devices" >&2; exit 1; }; \
+    mkdir -p /dev/nvidia-caps-imex-channels; \
+    mknod /dev/nvidia-caps-imex-channels/channel0 c "$maj" 0; \
+    chmod 0666 /dev/nvidia-caps-imex-channels/channel0; }'
+
+[Install]
+WantedBy=multi-user.target

--- a/mkosi/base/mkosi.profiles/gpu/mkosi.extra/usr/lib/systemd/system-preset/10-nvidia.preset
+++ b/mkosi/base/mkosi.profiles/gpu/mkosi.extra/usr/lib/systemd/system-preset/10-nvidia.preset
@@ -5,4 +5,5 @@ enable nvidia-gpu-flr.service
 enable nvidia-persistenced.service
 enable nvidia-cc-ready.service
 enable nvidia-modules-latch.service
+enable nvidia-imex-channel.service
 enable nvidia-cdi-generate.service

--- a/mkosi/base/mkosi.profiles/gpu/mkosi.extra/usr/local/bin/nvidia-cdi-add-imex.sh
+++ b/mkosi/base/mkosi.profiles/gpu/mkosi.extra/usr/local/bin/nvidia-cdi-add-imex.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+# Fold the NVIDIA IMEX channel deviceNode into every device of a CDI spec.
+#
+# nvidia-ctk cdi generate --mode=nvml omits the IMEX channel that B200/NVSwitch
+# needs (without /dev/nvidia-caps-imex-channels/channel0 CUDA errors 802 "system
+# not yet initialized"). Insert it into each device's containerEdits.deviceNodes
+# so a pod requesting nvidia.com/gpu gets the channel with no extra resource.
+# Idempotent; no-op on non-NVSwitch hosts (channel absent).
+set -eu
+
+SPEC="$1"
+CHANNEL=/dev/nvidia-caps-imex-channels/channel0
+
+[ -e "$CHANNEL" ] || exit 0                       # not an NVSwitch box
+grep -q "$CHANNEL" "$SPEC" && exit 0              # already folded in
+
+MAJOR=$(awk '/nvidia-caps-imex-channels/ {print $1}' /proc/devices)
+[ -n "$MAJOR" ] || { echo "nvidia-cdi-add-imex: no imex major in /proc/devices" >&2; exit 1; }
+
+# After each `deviceNodes:` line, emit the channel entry at the list-item indent
+# (the key's indent + 4 spaces, matching nvidia-ctk's own layout).
+awk -v ch="$CHANNEL" -v maj="$MAJOR" '
+  { print }
+  /^[[:space:]]*deviceNodes:[[:space:]]*$/ {
+    match($0, /^[[:space:]]*/); ind = substr($0, 1, RLENGTH) "    "
+    printf "%s- path: %s\n", ind, ch
+    printf "%s  major: %s\n", ind, maj
+    printf "%s  fileMode: 438\n", ind
+    printf "%s  permissions: rwm\n", ind
+  }
+' "$SPEC" > "$SPEC.tmp"
+mv "$SPEC.tmp" "$SPEC"


### PR DESCRIPTION
## What

Four hardware-validated fixes that land on top of what already merged into #51 via #53/#56/#57. Two of them **fix bugs in code already in #51** (the containerd-disk match and the earlier device-plugin work).

1. **containerd disk matched by-id** (`9c54aa2`) — the serial match already in #51 (`7d88b1f`) checks `/sys/block/<dev>/serial`, which is **empty for virtio-scsi**; the disk's serial only surfaces at `/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_confai-containerd`. So the `--containerd-disk-gi` disk was never matched and the image still fell back to a RAM tmpfs. Now match by-id first. **Without this, #51's containerd-disk support silently no-ops.**
2. **TDX node self-label** (`9c54aa2`) — bake `node-label: confidential.ai/tdx=true` in the rke2 config so `c8s install --hardware-platform tdx` needs no manual `kubectl label`.
3. **NTP** (`9c54aa2`) — enable `systemd-timesyncd`; the free-running TDX guest clock drifts ~60–70s behind the operator and trips cred-release's JWT clock-skew check on `get-kubeconfig`.
4. **IMEX channel for B200** (`7f47c47`) — `nvidia-imex-channel.service` creates `/dev/nvidia-caps-imex-channels/channel0` at boot; `nvidia-cdi-generate` folds the channel into the boot CDI spec (awk, no new deps). **Post-merge correction:** this was shipped as the fix for CUDA `error 802`, and it is not — the channel turned out to be unrelated to the failure. The real causes (both fixed directly on the base branch, `c986d53`): `nvidia-cc-ready`'s "already Ready" regex matched the substring `ready` inside `not-ready` and never ran `-srs 1` (→ 802), and `libnvidia-pkcs11{,-openssl3}` were missing from the staged driver libs, which libcuda needs for the CC secure session (→ 801 after readying). The channel unit stays as harmless NVLE plumbing.

## Validated (b200, 8× B200 TDX CVM, image c8s-dev-cdi-9c54aa2 — clean hands-off launch)

- containerd store on `/dev/mapper/containerd` ext4 393.7G (not tmpfs)
- `get-kubeconfig` succeeds first try (skew 0s); node self-labels `tdx=true`; device plugin advertises `nvidia.com/gpu: 8`
- `c8s install --hardware-platform tdx` → all c8s pods Running incl. `c8s-tls-lb 2/2`; SGLang scheduled + admitted
- ~~IMEX fix (`7f47c47`): torch.cuda sees 8 GPUs with the channel mounted~~ **retracted — false positive**: `torch.cuda.device_count()` comes from NVML and returns 8 even when CUDA init fails; `is_available()` was False. CUDA on CC GPUs is fixed by `c986d53` on the base branch (pkcs11 libs + cc-ready), validated live with real allocs/matmul on all 8.

## Note

These build on #53/#56/#57 (already merged into this base). This closes the loop so #51 carries the *working* containerd match, not the sysfs-only one.
