### PR TITLE
feat(c8s): read-only weights disk mounted at /var/lib/models

### DIFF
--- a/docs/C8S-IMAGE.md
+++ b/docs/C8S-IMAGE.md
@@ -43,6 +43,7 @@ CI's mode until the attestation-rs `-gpu` image digest is pinned),
 | Plugin boot config (measured floor) | profile mkosi.extra | `/etc/nri/conf.d/image-policy.yaml` |
 | RKE2 config: Cilium CNI, kube-proxy off, CIS, PSA, audit | ported from base-images rke2 (validated e2e under c8s) | `/etc/rancher/rke2/` + `server/manifests/` |
 | containerd-data-disk service | ported from base-images rke2 | encrypted `LABEL=containerd` backing for the image cache |
+| models-disk service | this profile | read-only mount of a pre-populated weights disk (serial `confai-models`) at `/var/lib/models` |
 | attestation-api | **attest-gpu profile** (or `attest` under `C8S_STOCK_ATTEST=1`), not this one | host service on `0.0.0.0:8400` |
 | NVIDIA driver stack | **gpu profile** | see docs/GPU-IMAGE-PLAN.md |
 
@@ -88,6 +89,11 @@ BTF-shipping distro kernel makes; the base/gpu images keep RANDSTRUCT.
   re-encrypts over it per boot). Keeps the multi-GiB image cache off guest
   RAM. Prefer virtio-scsi — the script scans `sd*` first; secondary
   virtio-blk disks have wedged under SEV-SNP/KubeVirt before.
+- **Optional: a pre-populated weights disk with serial `confai-models`**
+  (virtio-scsi). `models-disk.service` mounts it read-only at `/var/lib/models`
+  so a large HF cache survives relaunches instead of re-downloading. Not
+  encrypted / not mkfs'd — weights are public (integrity, not secrecy). Absent
+  → no-op. Attach via `confai launch --models-pvc <name>`.
 - Guest memory ≥16G (etcd OOMs at small sizes). TDX measurement is
   topology-invariant, so memory/SMP can vary per launch without changing
   the reference values.

--- a/mkosi/base/mkosi.profiles/c8s/mkosi.extra/etc/systemd/system/models-disk.service
+++ b/mkosi/base/mkosi.profiles/c8s/mkosi.extra/etc/systemd/system/models-disk.service
@@ -1,0 +1,33 @@
+# Mount a pre-populated read-only weights disk (serial=confai-models) at
+# /var/lib/models before rke2 starts, so large model weights persist across CVM
+# relaunches instead of re-downloading. See models-disk.sh for the why.
+#
+# The disk is public (weights), so unlike containerd-data-disk.service there is
+# no encryption and no per-boot mkfs — the filesystem is mounted read-only as-is.
+# Absent disk → clean no-op (GPU-less / no-weights boots).
+#
+# A oneshot (not a .mount unit) because the device is matched by serial at
+# runtime, which a static .mount cannot express. RemainAfterExit ties the mount
+# lifecycle to the unit. Ordered Before rke2 so /var/lib/models is ready when
+# pods start.
+[Unit]
+Description=Mount the read-only weights disk (serial=confai-models) at /var/lib/models
+DefaultDependencies=no
+Conflicts=umount.target
+Before=rke2-server.service rke2-agent.service
+After=systemd-udevd.service
+# Order After=systemd-udevd so udevd has started before we resolve /dev/disk/by-id.
+# NOT a hard Require, and no udev-settle: a dep on the by-id device unit would hang
+# when no disk is attached, breaking the no-op path. The script polls for the serial.
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/local/bin/models-disk.sh
+# Non-fatal to boot: the script wraps the mount in `timeout` and always exits 0
+# (a missing/failed disk just means a cold cache). Cap total runtime as a backstop.
+TimeoutStartSec=60
+ExecStop=-/bin/sh -c 'umount /var/lib/models 2>/dev/null; true'
+
+[Install]
+WantedBy=local-fs.target

--- a/mkosi/base/mkosi.profiles/c8s/mkosi.extra/usr/lib/systemd/system-preset/50-rke2.preset
+++ b/mkosi/base/mkosi.profiles/c8s/mkosi.extra/usr/lib/systemd/system-preset/50-rke2.preset
@@ -22,6 +22,9 @@
 # flip the last two lines (disable server, enable agent) and add a
 # `server: https://<server-ip>:9345` + `token:` to config.yaml.
 enable containerd-data-disk.service
+# Read-only weights disk (serial=confai-models). Enabled always; a no-op boot
+# when the disk isn't attached (GPU-less / no-weights launches).
+enable models-disk.service
 enable rke2-server.service
 disable rke2-agent.service
 # NTP: sync the free-running TDX guest clock so it doesn't drift behind the

--- a/mkosi/base/mkosi.profiles/c8s/mkosi.extra/usr/local/bin/models-disk.sh
+++ b/mkosi/base/mkosi.profiles/c8s/mkosi.extra/usr/local/bin/models-disk.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+# Mount a pre-populated, read-only weights disk at /var/lib/models before rke2
+# starts, so large model weights (an HF cache of hundreds of GiB) survive a CVM
+# relaunch instead of re-downloading. Run by models-disk.service.
+#
+# Unlike containerd-data-disk.sh this disk is NOT encrypted and NOT mkfs'd: it
+# already carries an ext4 filesystem with the cache. Weights are public — the
+# guarantee wanted is integrity, not secrecy, and integrity rests on the
+# workload verifying model digests, not on dm-crypt. The host (L0) can read the
+# disk; that is fine because the content is public.
+#
+# Absent disk → no-op (GPU-less / no-weights boots): the workload just downloads
+# to its own store. No tmpfs fallback — a cold cache is acceptable, wasting guest
+# RAM on it is not.
+#
+# Ordered Before rke2 so the mount exists when pods start. Read-only, nodev,
+# nosuid: the guest never writes it and it holds no executables it should run.
+set -u
+
+DIR=/var/lib/models
+# Per mount step. A wedged device must not block boot past the unit's
+# TimeoutStartSec (60s); mirrors containerd-data-disk.sh's step bound.
+STEP_TIMEOUT=30
+
+mkdir -p "$DIR"
+
+# Already mounted (service re-run / RemainAfterExit) → nothing to do.
+if mountpoint -q "$DIR"; then
+    echo "models-disk: $DIR already mounted"
+    exit 0
+fi
+
+# Find the models disk by serial=confai-models. virtio-scsi (KubeVirt Bus:
+# scsi) surfaces the serial ONLY in /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_
+# <serial>, NOT in /sys/block/<dev>/serial (empty on SCSI) — same matching as
+# containerd-data-disk.sh. Poll briefly (~10s) so a slow udev probe doesn't make
+# us miss it. virtio-blk is scanned as a fallback via its sysfs serial.
+DEV=""
+for _ in $(seq 1 20); do
+    for l in /dev/disk/by-id/*confai-models*; do
+        [ -e "$l" ] || continue
+        DEV="$(readlink -f "$l")"; break
+    done
+    [ -n "$DEV" ] && break
+    for d in /dev/sd? /dev/vd?; do
+        [ -b "$d" ] || continue
+        if [ "$(cat "/sys/block/$(basename "$d")/serial" 2>/dev/null || true)" = "confai-models" ]; then
+            DEV="$d"; break
+        fi
+    done
+    [ -n "$DEV" ] && break
+    sleep 0.5
+done
+
+if [ -z "$DEV" ]; then
+    echo "models-disk: no serial=confai-models disk — skipping (workload will download weights)"
+    exit 0
+fi
+
+echo "models-disk: found weights disk at $DEV — mounting read-only at $DIR"
+if timeout "$STEP_TIMEOUT" mount -o ro,nodev,nosuid "$DEV" "$DIR"; then
+    echo "models-disk: mounted $DEV read-only at $DIR"
+    exit 0
+fi
+
+echo "models-disk: mount of $DEV failed — skipping (workload will download weights)" >&2
+exit 0


### PR DESCRIPTION
## What

A third, **read-only, public-weights** disk for the c8s node-as-CVM, so large model weights (e.g. Qwen3-235B, ~240 GiB HF cache) survive a CVM relaunch instead of re-downloading every boot.

New `models-disk.service` + `models-disk.sh` under the c8s profile mount a pre-populated disk (serial `confai-models`) read-only at `/var/lib/models`, ordered `Before=rke2-server.service` so the cache is present when pods start.

## How it differs from `containerd-data-disk`

This mirrors `containerd-data-disk.{sh,service}` for device discovery and the timeout-wrapped mount, but **drops the crypto and the mkfs**:

| | containerd-data-disk | models-disk |
|---|---|---|
| Encryption | plain-mode dm-crypt, per-boot random key | **none** — public weights, integrity not secrecy |
| mkfs | `mkfs.ext4` every boot (per-boot key = fresh FS) | **none** — disk is pre-populated with an ext4 HF cache |
| Mount | rw | **ro,nodev,nosuid** |
| Absent disk | falls back to tmpfs | **clean no-op** (workload just downloads; no tmpfs) |

Weights are public, so the guarantee wanted is **integrity** (the workload verifies model digests), not confidentiality — hence no dm-crypt. The host (L0) can read the disk; that's fine.

## Preserved load-bearing bits from the model

- **by-id serial matching first** (`/dev/disk/by-id/*confai-models*`): virtio-scsi surfaces the serial only under `/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_<serial>`, **not** in `/sys/block/<dev>/serial` (empty on SCSI). Falls back to a `sd*`/`vd*` sysfs-serial scan for virtio-blk.
- **Brief udev poll (~10s)** so a slow probe doesn't miss the disk.
- **`timeout`-wrapped mount** + capped `TimeoutStartSec` so a wedged device can't hang boot; the script always exits 0.
- Enabled via the profile **preset** (`enable models-disk.service`) so the symlink is baked into the verity root alongside `containerd-data-disk.service`.

Attach from the CLI side with `confai launch --models-pvc <name>` (companion confai PR).

## Testing

- `sh -n`, `bash -n`, and `shellcheck` all pass clean on `models-disk.sh`.
- `.sh` staged mode is `100755` (matches `containerd-data-disk.sh`).
- No Python in the measured image — shell + awk only (there's no awk here; pure shell).
