### PR TITLE
fix(tdx): ship OVMF.inteltdx.fd, the -bios-bootable firmware (#82)

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -10,7 +10,8 @@ sudo apt-get update
 # DSDT (mkosi/base/acpi-tables/dsdt.asl) that gets injected into the
 # initrd so the kernel's CONFIG_ACPI_TABLE_UPGRADE replaces the
 # VMM-supplied DSDT at boot.
-# ovmf provides the TDVF-capable firmware `confos build` hashes for TDX
+# ovmf provides OVMF.inteltdx.fd (the unified TDX firmware confos hashes +
+# the guest -bios-boots) for TDX builds. NOT OVMF.fd (pflash-style, hangs).
 # measurements. Keep host deps in lockstep with .github/workflows/base.yml.
 sudo apt install -y build-essential systemd-repart systemd-container qemu-utils genisoimage swtpm cpio acpica-tools ovmf
 

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -58,7 +58,13 @@ pub fn run(args: &BuildArgs) -> anyhow::Result<()> {
         let fw = args.tdx_firmware.clone();
         if !fw.exists() {
             anyhow::bail!(
-                "TDX firmware not found: {} (--tdx-firmware). Install ubuntu's `ovmf` package (`apt install ovmf`) or pass --tdx-firmware/-Eenv CONFOS_TDX_FIRMWARE.",
+                "TDX firmware not found: {} (--tdx-firmware). Needs the unified \
+                 Intel TDX build `OVMF.inteltdx.fd` (boots a TD via -bios); \
+                 ubuntu's `ovmf` package ships it under /usr/share/ovmf/. If \
+                 your distro names it differently (e.g. some builds ship only \
+                 OVMF.tdx.fd, which is pflash-style and does NOT -bios-boot), \
+                 point --tdx-firmware / CONFOS_TDX_FIRMWARE at a -bios-capable \
+                 OVMF.inteltdx.fd.",
                 fw.display()
             );
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,11 +151,19 @@ pub struct BuildArgs {
     #[arg(long, env = "CONFOS_FIRMWARE", default_value = "output/OVMF.fd")]
     pub firmware: PathBuf,
 
-    /// Path to OVMF firmware binary used for TDX measurement. Must be a
-    /// build with TDVF code paths compiled in (TD HOB processing, TDCALL
-    /// plumbing). Ubuntu's `ovmf` package binary at
-    /// `/usr/share/ovmf/OVMF.fd` works. confos's IGVM-aware firmware does
-    /// NOT include TDVF and will hang silently when booted as a TDX guest.
+    /// Path to OVMF firmware binary used for TDX measurement. Must be the
+    /// *unified* Intel TDX build (`OVMF.inteltdx.fd`) — a single flat image
+    /// with the TDVF reset vector + metadata that boots a TD via QEMU `-bios`.
+    /// Ubuntu's `ovmf` package ships it at `/usr/share/ovmf/OVMF.inteltdx.fd`.
+    ///
+    /// NOT the plain `/usr/share/ovmf/OVMF.fd`: that is the split/pflash CODE
+    /// image, and while `tdx-measure` can still hash it, it does NOT execute
+    /// as a TD `-bios` firmware — the guest hangs silently with zero console
+    /// output (verified on b200: OVMF.fd → 0 bytes, OVMF.inteltdx.fd → boots
+    /// to `tdx: Guest detected`). Since KubeVirt boots TDX via `-bios`, the
+    /// firmware whose bytes the manifest measures MUST be the -bios-bootable
+    /// one, or `c8s install --measurements <manifest mrtd>` can never match a
+    /// live quote (confidential-metal#82).
     ///
     /// If --platform is `snp`, this firmware is ignored. If --platform is
     /// `tdx` or `both`, the TDX `mrtd` in the manifest is the hash of
@@ -163,7 +171,7 @@ pub struct BuildArgs {
     #[arg(
         long = "tdx-firmware",
         env = "CONFOS_TDX_FIRMWARE",
-        default_value = "/usr/share/ovmf/OVMF.fd"
+        default_value = "/usr/share/ovmf/OVMF.inteltdx.fd"
     )]
     pub tdx_firmware: PathBuf,
 


### PR DESCRIPTION
## The bug

confos defaults `--tdx-firmware` to `/usr/share/ovmf/OVMF.fd`, but **that image does not boot as a TD `-bios` firmware** — a TDX guest on it hangs silently, zero console output. KubeVirt boots TDX via `-bios`, so every c8s node CVM launched through confai/KubeVirt never actually came up on the measured firmware. And because the manifest's `tdx.mrtd` hashes *this* binary, `c8s install --measurements <manifest mrtd>` can never match a live quote — the RA-TLS mesh fail-closes. This is [confidential-metal#82](https://github.com/confidential-dot-ai/confidential-metal/issues/82).

## Root cause (b200, same c8s rootdisk, only firmware varied)

| firmware | `-bios` boot |
|---|---|
| `/usr/share/ovmf/OVMF.fd` (shipped) | **0 bytes, guest dead** |
| `/usr/share/ovmf/OVMF.inteltdx.fd` | **boots to `tdx: Guest detected` → Linux 6.16.12** |

`OVMF.fd` is the split/pflash CODE image; it only boots via `-drive if=pflash` + `-kernel uki` on a *non-TDX* KVM guest (confos's own `QemuTier::Kvm` run path). On TDX+KVM, pflash is unavailable (`pflash with kvm requires KVM readonly memory support`), so `-bios` is the only path — and `OVMF.fd` can't `-bios`-boot.

## The numbers line up exactly

`tdx-measure` (the CI MRTD computation) on each firmware:

- `MRTD(OVMF.fd)` = **`e2fca2d0…`** = the shipped `manifest.json` value → the firmware that **can't boot**
- `MRTD(OVMF.inteltdx.fd)` = **`9309eaae…`** = exactly the digest a live KubeVirt c8s CVM **actually attests**

So today the manifest measures the non-bootable firmware while the guest that *does* boot reports a different MRTD — the entire mismatch, root-caused with matching values.

## Fix

Default `--tdx-firmware` to the **unified Intel TDX build `OVMF.inteltdx.fd`** (the `-bios`-bootable TDVF image Ubuntu's `ovmf` package ships alongside `OVMF.fd`). Then the manifest measures the firmware the guest runs, **stock KubeVirt boots it** with no sidecar/wrapper/pflash, and `--measurements` matches. Build-time error + `bin/setup` note updated to name the requirement.

## Validation

- Live `-bios` boot of `OVMF.inteltdx.fd` on b200 TDX: reaches `tdx: Guest detected` + kernel (63 KB serial). `OVMF.fd`: 0 bytes.
- `tdx-measure` MRTDs match the table above (`9309eaae…` = the observed live-quote digest).
- confos builds; workspace tests pass (the one pre-existing `qemu_scratch::initrd_gates_scratch_on_serial` failure reproduces on unmodified `feat/c8s-profile` — unrelated).

Once merged + a rebuild, `manifest.json`'s `tdx.mrtd` becomes `9309eaae…`, and `c8s install --measurements` works as documented with no interim observed-digest pin.