### PR TITLE
ci(tdx): install ovmf-inteltdx so the measured firmware exists (#82)

### DIFF
--- a/.github/workflows/c8s.yml
+++ b/.github/workflows/c8s.yml
@@ -98,7 +98,10 @@ jobs:
         # Host deps for `confos build` — keep in lockstep with bin/setup.
         run: |
           sudo apt-get update -y
-          sudo apt-get install -y systemd-container ovmf cpio acpica-tools
+          # ovmf-inteltdx ships /usr/share/ovmf/OVMF.inteltdx.fd, the unified
+          # -bios-bootable TDX firmware confos measures (base `ovmf` only has
+          # the non-TDX OVMF.fd). #82.
+          sudo apt-get install -y systemd-container ovmf ovmf-inteltdx cpio acpica-tools
 
       - name: Cache kernel tools
         uses: actions/cache@v5

--- a/bin/setup
+++ b/bin/setup
@@ -13,7 +13,7 @@ sudo apt-get update
 # ovmf provides OVMF.inteltdx.fd (the unified TDX firmware confos hashes +
 # the guest -bios-boots) for TDX builds. NOT OVMF.fd (pflash-style, hangs).
 # measurements. Keep host deps in lockstep with .github/workflows/base.yml.
-sudo apt install -y build-essential systemd-repart systemd-container qemu-utils genisoimage swtpm cpio acpica-tools ovmf
+sudo apt install -y build-essential systemd-repart systemd-container qemu-utils genisoimage swtpm cpio acpica-tools ovmf ovmf-inteltdx
 
 echo "==> Installing uv..."
 which uv || curl -LsSf https://astral.sh/uv/install.sh | sh


### PR DESCRIPTION
Follow-up to #60. #60 correctly defaults `--tdx-firmware` to `/usr/share/ovmf/OVMF.inteltdx.fd`, but the rebuild failed: the noble GitHub runner's base `ovmf` package (2024.02) ships **only** `OVMF.fd` — the unified TDX firmware is in the separate **`ovmf-inteltdx`** package (confirmed via packages.ubuntu.com: noble's `ovmf` filelist has no inteltdx; `ovmf-inteltdx` exists in noble/noble-updates and installs `/usr/share/ovmf/OVMF.inteltdx.fd`).

The build-time guard from #60 caught it cleanly:
```
Error: TDX firmware not found: /usr/share/ovmf/OVMF.inteltdx.fd (--tdx-firmware). Needs the unified Intel TDX build…
```

Fix: add `ovmf-inteltdx` to the host build deps (`c8s.yml` + `bin/setup`). `base.yml` is unchanged — it builds SNP and measures nothing on the TDX path.

With this, the rebuild finds the firmware, and `manifest.json`'s `tdx.mrtd` becomes `9309eaae…` (the -bios-bootable firmware, = what live CVMs attest).