### PR TITLE
fix(tdx): vendor the -bios-bootable OVMF.inteltdx.fd (#82)

### DIFF
--- a/.github/workflows/c8s.yml
+++ b/.github/workflows/c8s.yml
@@ -98,10 +98,10 @@ jobs:
         # Host deps for `confos build` — keep in lockstep with bin/setup.
         run: |
           sudo apt-get update -y
-          # ovmf-inteltdx ships /usr/share/ovmf/OVMF.inteltdx.fd, the unified
-          # -bios-bootable TDX firmware confos measures (base `ovmf` only has
-          # the non-TDX OVMF.fd). #82.
-          sudo apt-get install -y systemd-container ovmf ovmf-inteltdx cpio acpica-tools
+          # No ovmf-inteltdx here: confos measures the -bios-bootable TDX
+          # firmware vendored at firmware/OVMF.inteltdx.fd (#82). Base `ovmf`
+          # is still needed for the SNP path.
+          sudo apt-get install -y systemd-container ovmf cpio acpica-tools
 
       - name: Cache kernel tools
         uses: actions/cache@v5

--- a/bin/setup
+++ b/bin/setup
@@ -10,10 +10,11 @@ sudo apt-get update
 # DSDT (mkosi/base/acpi-tables/dsdt.asl) that gets injected into the
 # initrd so the kernel's CONFIG_ACPI_TABLE_UPGRADE replaces the
 # VMM-supplied DSDT at boot.
-# ovmf provides OVMF.inteltdx.fd (the unified TDX firmware confos hashes +
-# the guest -bios-boots) for TDX builds. NOT OVMF.fd (pflash-style, hangs).
-# measurements. Keep host deps in lockstep with .github/workflows/base.yml.
-sudo apt install -y build-essential systemd-repart systemd-container qemu-utils genisoimage swtpm cpio acpica-tools ovmf ovmf-inteltdx
+# ovmf provides the OVMF.fd confos uses for the SNP measurement path. The TDX
+# firmware (OVMF.inteltdx.fd, -bios-bootable) is vendored at firmware/ — see
+# firmware/README, #82 — not apt-installed. Keep host deps in lockstep with
+# .github/workflows/base.yml.
+sudo apt install -y build-essential systemd-repart systemd-container qemu-utils genisoimage swtpm cpio acpica-tools ovmf
 
 echo "==> Installing uv..."
 which uv || curl -LsSf https://astral.sh/uv/install.sh | sh

--- a/firmware/LICENSE
+++ b/firmware/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2019, TianoCore and contributors.  All rights reserved.
+
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+The BSD-2-Clause-Patent (the Subject Patent Claims grant) applies as
+published at https://spdx.org/licenses/BSD-2-Clause-Patent.html

--- a/firmware/README.md
+++ b/firmware/README.md
@@ -1,0 +1,18 @@
+# Vendored TDX firmware
+
+`OVMF.inteltdx.fd` — the unified, `-bios`-bootable Intel TDX firmware (TDVF)
+confos measures for the TDX `mrtd`, and the firmware KubeVirt's virt-launcher
+boots a TD with.
+
+- **Source:** `quay.io/kubevirt/virt-launcher:v1.9.0-beta.0`,
+  `/usr/share/edk2/ovmf/OVMF.inteltdx.fd` (edk2-ovmf, RHEL/CentOS build).
+- **sha256:** `a7edaeff6fc4bef8924461cb0fb68a194c3595d08ccad2720cca926dea12f7cf`
+- **License:** BSD-2-Clause-Patent (edk2 / TianoCore) — see `LICENSE`.
+
+Why vendored (confidential-metal#82): Ubuntu's `ovmf` package ships only the
+non-TDX `OVMF.fd` (does not `-bios`-boot a TD); `ovmf-inteltdx` is absent on
+noble and ships an MS-keys `.ms.fd` on resolute (doesn't finish-boot an
+unsigned UKI). Vendoring the exact firmware the guest actually boots removes
+all distro/package drift and guarantees `manifest.json`'s `tdx.mrtd` equals a
+live quote's MRTD. Verified: tdx-measure(this file) == 9309eaae… == the digest
+a live b200 c8s CVM attests, and it boots the c8s rootdisk to Linux 6.16.12.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,19 +151,22 @@ pub struct BuildArgs {
     #[arg(long, env = "CONFOS_FIRMWARE", default_value = "output/OVMF.fd")]
     pub firmware: PathBuf,
 
-    /// Path to OVMF firmware binary used for TDX measurement. Must be the
-    /// *unified* Intel TDX build (`OVMF.inteltdx.fd`) — a single flat image
-    /// with the TDVF reset vector + metadata that boots a TD via QEMU `-bios`.
-    /// Ubuntu's `ovmf` package ships it at `/usr/share/ovmf/OVMF.inteltdx.fd`.
+    /// Path to OVMF firmware binary used for TDX measurement. Defaults to the
+    /// firmware vendored at `firmware/OVMF.inteltdx.fd` — the unified,
+    /// `-bios`-bootable Intel TDX build (TDVF) that KubeVirt's virt-launcher
+    /// boots a TD with, so the manifest measures exactly what the guest runs.
     ///
-    /// NOT the plain `/usr/share/ovmf/OVMF.fd`: that is the split/pflash CODE
-    /// image, and while `tdx-measure` can still hash it, it does NOT execute
-    /// as a TD `-bios` firmware — the guest hangs silently with zero console
-    /// output (verified on b200: OVMF.fd → 0 bytes, OVMF.inteltdx.fd → boots
-    /// to `tdx: Guest detected`). Since KubeVirt boots TDX via `-bios`, the
-    /// firmware whose bytes the manifest measures MUST be the -bios-bootable
-    /// one, or `c8s install --measurements <manifest mrtd>` can never match a
-    /// live quote (confidential-metal#82).
+    /// Do NOT point this at the plain `/usr/share/ovmf/OVMF.fd`: that is the
+    /// split/pflash CODE image, and while `tdx-measure` can still hash it, it
+    /// does NOT execute as a TD `-bios` firmware — the guest hangs silently
+    /// with zero console output (verified on b200: OVMF.fd → 0 bytes, the
+    /// vendored inteltdx → boots to `tdx: Guest detected` → Linux). Since
+    /// KubeVirt boots TDX via `-bios`, the firmware whose bytes the manifest
+    /// measures MUST be the -bios-bootable one, or `c8s install --measurements
+    /// <manifest mrtd>` can never match a live quote (confidential-metal#82).
+    /// The firmware is vendored rather than apt-installed because Ubuntu's
+    /// `ovmf` ships only the non-bootable OVMF.fd, `ovmf-inteltdx` is absent
+    /// on noble, and resolute's is an MS-keys `.ms.fd` — see firmware/README.
     ///
     /// If --platform is `snp`, this firmware is ignored. If --platform is
     /// `tdx` or `both`, the TDX `mrtd` in the manifest is the hash of
@@ -171,7 +174,7 @@ pub struct BuildArgs {
     #[arg(
         long = "tdx-firmware",
         env = "CONFOS_TDX_FIRMWARE",
-        default_value = "/usr/share/ovmf/OVMF.inteltdx.fd"
+        default_value = "firmware/OVMF.inteltdx.fd"
     )]
     pub tdx_firmware: PathBuf,
 


### PR DESCRIPTION
Follow-up to #60/#61 — the final firmware fix for #82.

## Why the package approach didn't work
#61 tried `apt install ovmf-inteltdx`, but:
- **noble** (the GitHub runner) has **no `ovmf-inteltdx` package** — base `ovmf` ships only the non-TDX `OVMF.fd` (`E: Unable to locate package ovmf-inteltdx`).
- **resolute**'s `ovmf-inteltdx` ships `OVMF.inteltdx.**ms**.fd` (Microsoft SecureBoot keys) — verified on b200 it reaches `BdsDxe` but won't finish-boot our unsigned UKI (347 bytes serial, no kernel).

Distro packaging of a `-bios`-bootable, unsigned-friendly TDX firmware is a moving target across Ubuntu releases.

## Fix
Vendor the exact firmware **KubeVirt's virt-launcher already boots a TD with** and measure that:
- `firmware/OVMF.inteltdx.fd` from `quay.io/kubevirt/virt-launcher:v1.9.0-beta.0` (`/usr/share/edk2/ovmf/OVMF.inteltdx.fd`), sha `a7edaeff…`, **BSD-2-Clause-Patent** (edk2/TianoCore — redistributable; `firmware/LICENSE` + `firmware/README.md` carry provenance).
- Default `--tdx-firmware` → `firmware/OVMF.inteltdx.fd`; reverts the apt-fetch (base `ovmf` retained for SNP).

## Verified (b200)
- `tdx-measure(firmware/OVMF.inteltdx.fd)` = **`9309eaae…`** = the MRTD a **live b200 c8s CVM actually attests**.
- It `-bios`-boots the c8s rootdisk to **Linux 6.16.12** (the old shipped `OVMF.fd` → 0 bytes).

So after this + a rebuild, `manifest.json`'s `tdx.mrtd` = `9309eaae…`, and `c8s install --measurements 9309eaae…` matches a live quote with **stock KubeVirt, no wrapper/hook/pflash** — closing #82. No distro dependency for the measured firmware.