### PR TITLE
feat(mkosi): rke2-ci profile, the c8s node image minus the admission floor

### DIFF
--- a/bin/build-c8s
+++ b/bin/build-c8s
@@ -36,6 +36,11 @@
 #                      (console=ttyS0, passwordless serial autologin).
 #                      Different measurement, root shell on the host-visible
 #                      serial socket — never ship. Default name: c8s-dev.
+#   C8S_CI=1           CI runner-node variant: compose the rke2-ci profile on
+#                      top, the same image minus the NRI admission floor, so
+#                      a CI cluster can admit arbitrary job images. Different
+#                      measurement; CI runner clusters only, never a
+#                      production node. Default name: c8s-ci.
 #   C8S_NAME=...       output name (default c8s → output/c8s/)
 #   C8S_MEMORY=...     default-memory recorded in the manifest / used by
 #                      `confos run` (default 16G — etcd OOMs at the 4G default)
@@ -67,6 +72,11 @@ if [ "${C8S_DEV:-0}" = 1 ]; then
     DEV_PROFILE=(--profile dev)
     : "${C8S_NAME:=c8s-dev}"
 fi
+CI_PROFILE=()
+if [ "${C8S_CI:-0}" = 1 ]; then
+    CI_PROFILE=(--profile rke2-ci)
+    : "${C8S_NAME:=c8s-ci}"
+fi
 KB_PKGS=dwarves,python3,pkg-config,zlib1g-dev
 
 bin/confos kernel \
@@ -86,6 +96,7 @@ fi
 
 exec bin/confos build "${C8S_NAME:-c8s}" \
     "${PROFILES[@]}" \
+    ${CI_PROFILE[@]+"${CI_PROFILE[@]}"} \
     ${DEV_PROFILE[@]+"${DEV_PROFILE[@]}"} \
     --kernel-config-fragment "$FRAGMENT" \
     --kernel-builder-package "$KB_PKGS" \

--- a/mkosi/base/mkosi.finalize
+++ b/mkosi/base/mkosi.finalize
@@ -39,3 +39,36 @@ rm -f "$BUILDROOT"/etc/ssh/ssh_host_*
 
 # Remove cargo cache if present (non-deterministic)
 rm -rf "$BUILDROOT/root/.cargo"
+
+# ── rke2-ci: strip the NRI admission floor (marker-guarded) ─────────────────
+# The rke2-ci profile's mkosi.extra drops this marker. When present, remove
+# the three floor artifacts the c8s profile baked. Assert-then-delete: if the
+# c8s profile ever moves one of these paths, the build fails here instead of
+# silently shipping the floor in a variant that promises not to have it.
+# Inert for every other composition (marker absent). See
+# mkosi/base/mkosi.profiles/rke2-ci/mkosi.conf for the full rationale.
+if [ -f "$BUILDROOT/usr/local/share/rke2/.confos-no-admission-floor" ]; then
+    floor=(
+        "$BUILDROOT/var/lib/rancher/rke2/agent/etc/containerd/config-v3.toml.d/nri-image-policy.toml"
+        "$BUILDROOT/etc/nri/conf.d/image-policy.yaml"
+        "$BUILDROOT/opt/nri/plugins/10-nri-image-policy"
+    )
+    for f in "${floor[@]}"; do
+        if [ ! -f "$f" ]; then
+            echo "rke2-ci: expected floor artifact missing: ${f#"$BUILDROOT"}" >&2
+            echo "rke2-ci: compose this profile WITH c8s; if c8s moved the file, update this list" >&2
+            exit 1
+        fi
+        rm "$f"
+    done
+    # cred-release.service invokes `c8s cred-release`; the strip must not lose it.
+    if [ ! -x "$BUILDROOT/usr/local/bin/c8s" ]; then
+        echo "rke2-ci: /usr/local/bin/c8s missing after floor strip" >&2
+        exit 1
+    fi
+    # Drop the now-empty NRI dirs. Keep config-v3.toml.d: the baked template
+    # imports from it and an empty glob is a no-op.
+    rmdir "$BUILDROOT/etc/nri/conf.d" "$BUILDROOT/etc/nri" \
+          "$BUILDROOT/opt/nri/plugins" "$BUILDROOT/opt/nri" 2>/dev/null || true
+    echo "rke2-ci: NRI admission floor stripped (3 artifacts)"
+fi

--- a/mkosi/base/mkosi.profiles/rke2-ci/mkosi.conf
+++ b/mkosi/base/mkosi.profiles/rke2-ci/mkosi.conf
@@ -1,0 +1,27 @@
+# Profile: rke2-ci
+#
+# CI runner-node variant: the c8s node image MINUS the NRI admission floor.
+# Compose AFTER the c8s profile (C8S_CI=1 bin/build-c8s). A CI cluster must
+# admit arbitrary job images, so this variant strips the fail-closed
+# nri-image-policy wiring while keeping everything else identical to the
+# product composition: same RKE2 pin + airgap bundles, same CIS/PSA/audit
+# posture, same hardened kernel, same attested cred-release kubeconfig path.
+#
+# Mechanism: this profile's mkosi.extra drops a marker file
+# (/usr/local/share/rke2/.confos-no-admission-floor); the shared
+# mkosi/base/mkosi.finalize sees the marker and does an assert-then-delete
+# of the three floor artifacts, so a path rename in the c8s profile fails
+# the build loudly instead of silently shipping the floor:
+#   - /var/lib/rancher/rke2/agent/etc/containerd/config-v3.toml.d/nri-image-policy.toml
+#     (NRI enablement + the fail-closed required_plugins validator)
+#   - /etc/nri/conf.d/image-policy.yaml (the rendered measured floor)
+#   - /opt/nri/plugins/10-nri-image-policy (the plugin containerd launches)
+#
+# Deliberately KEPT:
+#   - /usr/local/bin/c8s: cred-release.service runs `c8s cred-release`
+#   - config-v3.toml.tmpl: generic drop-in plumbing; an empty glob is a no-op
+#   - the tmpfiles.d /run/nri-image-policy line: an unused empty dir
+#
+# MEASUREMENT NOTE: selecting this profile changes the launch measurement.
+# An rke2-ci image is a distinct attestation identity: CI runner clusters
+# only, never a production node.

--- a/mkosi/base/mkosi.profiles/rke2-ci/mkosi.extra/usr/local/share/rke2/.confos-no-admission-floor
+++ b/mkosi/base/mkosi.profiles/rke2-ci/mkosi.extra/usr/local/share/rke2/.confos-no-admission-floor
@@ -1,0 +1,5 @@
+rke2-ci
+This image was composed with the rke2-ci profile: the NRI admission floor
+(nri-image-policy plugin + fail-closed containerd validator + measured
+policy floor) is deliberately NOT present. CI runner clusters only.
+See mkosi/base/mkosi.profiles/rke2-ci/mkosi.conf.


### PR DESCRIPTION
**Draft, requesting design review from @joaosa** since this touches the image factory. Nothing merges without your sign-off, and I'd rather you reshape the mechanism than take it as-is if there's a better fit.

## Why

The TDX CI runner host (`tdx-gh-runner`, stood up this week: quote verified against Intel with `tcb_status: UpToDate`) needs a node image for its standing ARC runner CVM, the TDX twin of `snp-metal-cvm`. The SNP twin boots the pre-c8s plain rke2 image from June; TDX has no equivalent published artifact. The only TDX rke2 image is the c8s **product** image, and it is correct for products and wrong for CI in exactly one way: the baked fail-closed NRI admission floor denies every ARC pod at container creation.

The wrong fixes were considered and rejected: allowlisting the actions-runner image in CDS puts arbitrary-code-execution CI infrastructure inside the product trust boundary (the runner's job is to execute whatever CI sends it, so admitting its digest semantically admits everything), and the `rke2-dev` variant is a root-autologin never-ship image. The right fix is a variant that differs from the product by exactly the one component that is *policy*, not *hardening*.

## What

`rke2-ci`: an overlay profile composed after `c8s` whose only effect is stripping the three floor artifacts:

| | product `rke2` | `rke2-ci` |
|---|---|---|
| Hardened kernel (no serial console) | yes | yes, unchanged |
| attest profile (attestation-api :8400, cred-release :8443, operator-key RTMR[3]) | yes | yes, unchanged |
| RKE2 pin + airgap bundles + CIS/PSA/audit | yes | yes, unchanged |
| NRI admission floor (plugin, containerd validator drop-in, measured policy floor) | yes | **stripped** |

Mechanism: the profile's `mkosi.extra` drops a marker file; the shared `mkosi.finalize` gains a marker-guarded **assert-then-delete** block. If the c8s profile ever moves a floor path, the build fails loudly instead of silently shipping the floor in a variant that promises not to have it. Inert for every other composition: the product build path diff is empty. `/usr/local/bin/c8s` is deliberately kept (`cred-release.service` runs `c8s cred-release`), which is also why the strip happens at finalize rather than by skipping the NRI image pull.

`bin/build-c8s` gains `C8S_CI=1` following the `C8S_DEV`/`C8S_NO_GPU` pattern. Distinct launch measurement, so an `rke2-ci` image is its own attestation identity: CI runner clusters only, never a production node.

## How it gets consumed (no console, no c8s install)

Boot via plain KubeVirt manifest (rootdisk PVC + `confai-scratch` disk + an `opkeydata` Secret volume), wait on `:8400/health` and `:6443/livez`, then `c8s get-kubeconfig --operator-key` over RA-TLS gives guest cluster-admin, then the ARC scale set installs over that kubeconfig. Verified against source that cred-release is baked and independent of `c8s install`, and that `get-kubeconfig` accepts the variant's measurement. The host/guest CIDR collision that forced the SNP lane onto serial-console delivery is already fixed on the TDX host (outer cluster renumbered to 172.20/172.21, the b300 pattern).

## Open questions for you

1. `C8S_NO_GPU` is documented "validation-only, never publish" because nothing latches `kernel.modules_disabled=1` without the gpu profile. Is that acceptable for a CI runner image, or should the latch move somewhere the no-gpu composition also hits?
2. Mechanism taste: marker + shared-finalize guard vs a profile-local `mkosi.finalize` (works too, needs the exec bit set by someone with a local checkout) vs declarative `RemoveFiles=` (fewer lines, but silently no-ops on path drift).
3. Naming: `rke2-ci` vs something clearer about the admission posture, e.g. `rke2-open`.

Companion plumbing PR (publish `c8s-base:rke2-ci-*` via a `ci=true` dispatch input): linked below. Happy to validate the built image end to end on `tdx-gh-runner` (boot, quote verify, get-kubeconfig, ARC install) before this leaves draft.