### PR TITLE
docs(gpu): correct the persistenced comment about module loading

### DIFF
--- a/mkosi/base/mkosi.profiles/gpu/mkosi.extra/etc/systemd/system/nvidia-persistenced.service
+++ b/mkosi/base/mkosi.profiles/gpu/mkosi.extra/etc/systemd/system/nvidia-persistenced.service
@@ -1,11 +1,15 @@
 [Unit]
 Description=NVIDIA Persistence Daemon
-# Modules are loaded by systemd-modules-load.service (see
-# /etc/modules-load.d/nvidia.conf). The daemon performs the FIRST driver
-# attach and HOLDS it for the life of the VM — load-bearing in CC mode, where
-# the GPU forbids re-establishing the SPDM session after teardown without a
-# fresh FLR. It must attach only AFTER nvidia-gpu-flr resets the GPU (the CC
-# SPDM precondition — see /usr/local/bin/nvidia-gpu-flr).
+# The driver is modprobe'd by nvidia-gpu-flr, NOT by modules-load.d — that is
+# the whole point of the FLR unit, and there is deliberately no
+# /etc/modules-load.d/nvidia.conf in this image (auto-loading would let the
+# kernel probe every GPU before any reset; see the rationale at the top of
+# /usr/local/bin/nvidia-gpu-flr).
+#
+# This daemon performs the FIRST driver attach and HOLDS it for the life of the
+# VM — load-bearing in CC mode, where the GPU forbids re-establishing the SPDM
+# session after teardown without a fresh FLR. It must therefore attach only
+# AFTER nvidia-gpu-flr has reset the GPUs and loaded the driver.
 After=systemd-modules-load.service nvidia-gpu-flr.service
 # Wants (not Requires) for the FLR unit deliberately: Requires= propagates
 # stops, so an operator re-running the oneshot at runtime would take


### PR DESCRIPTION
The `nvidia-persistenced.service` comment says the driver is loaded by `systemd-modules-load.service` via `/etc/modules-load.d/nvidia.conf`. Neither is true, and the inaccuracy points at the approach this profile deliberately rejected.

There is no `/etc/modules-load.d` anywhere in the repo. `nvidia-gpu-flr` does the `modprobe` itself, and its own header explains why:

> ```
> # GPU must land on a freshly-FLR'd function. So we do NOT auto-load nvidia via
> # modules-load.d (that would let the kernel probe all GPUs before any FLR).
> # Getting this wrong is silent at 1 GPU and racy at 8.
> ```

So a reader who follows the persistenced comment concludes modules-load.d auto-loading is the current design — in the one unit whose entire ordering constraint exists to prevent exactly that. That is an expensive comment to leave in a file where the ordering *is* the subject.

Comments only. No directive changed; `After=`/`Wants=` are untouched, since ordering after `systemd-modules-load.service` is harmless and I did not want to conflate a doc fix with a behaviour change.

Found while debugging GPU attestation on B300 (#71) — I went looking for `/etc/modules-load.d/nvidia.conf` on the strength of this comment, and spent a while concluding the file was missing rather than never intended.
