### PR TITLE
fix(attest-gpu): allow the per-GPU nvidia char devices in attestation-api

### DIFF
--- a/mkosi/base/mkosi.profiles/attest-gpu/mkosi.extra/etc/systemd/system/attestation-api.service
+++ b/mkosi/base/mkosi.profiles/attest-gpu/mkosi.extra/etc/systemd/system/attestation-api.service
@@ -13,10 +13,13 @@ Restart=on-failure
 RestartSec=3
 # TDX quote device.
 DeviceAllow=/dev/tdx_guest rwm
-# NVIDIA nodes the libnvat/NVML collector opens for SPDM evidence.
+# NVIDIA nodes the libnvat/NVML collector opens for SPDM evidence. The
+# per-GPU /dev/nvidiaN nodes register major 195 as "nvidia" in /proc/devices,
+# so the group rule is char-nvidia; "nvidia-frontend" resolves to nothing on
+# current drivers and NVML then enumerates zero GPUs.
 DeviceAllow=/dev/nvidiactl rwm
 DeviceAllow=/dev/nvidia-uvm rwm
-DeviceAllow=char-nvidia-frontend rwm
+DeviceAllow=char-nvidia rwm
 # --- vsock fence -------------------------------------------------------------
 # This is the ONLY unit in the image allowed AF_VSOCK: the TDX quote is fetched
 # from the host QGS over vsock (CID 2, port 4050). Every other unit carries a


### PR DESCRIPTION
## Problem

`confai verify --require-nvidia-gpu` against a GPU CVM failed with:

```
HTTP 422: {"error":"verification_failed","message":"verification failed: GPU evidence collection failed: no CC GPUs or switches reported by NVAT SDK"}
```

attestation-api's journal showed NVML initializing successfully but enumerating zero GPUs (`collect_evidence_nvml: No GPUs available`), while pods on the same CVM saw all 8 GPUs.

## Root cause

The unit uses `DeviceAllow=`, which makes the device cgroup deny-by-default. The per-GPU rule was `DeviceAllow=char-nvidia-frontend`, but current drivers register major 195 in `/proc/devices` as `nvidia`, so the rule resolved to no device group and `/dev/nvidia0..7` were denied. NVML could open the explicitly-allowed `/dev/nvidiactl` but none of the per-GPU nodes.

## Fix

`DeviceAllow=char-nvidia rwm`.

Reproduced and verified on b300-node-2 / sglang-cvm:
- `systemd-run -p DeviceAllow=... nvidia-smi -L` with the old set → `No devices found`; with `char-nvidia` → all 8 GPUs.
- With a runtime drop-in applying the same change, the full `confai verify --vm sglang-cvm --platform tdx --require-nvidia-gpu --expected-gpu-arch BLACKWELL --expected-gpu-count 8 --expected-nvswitch-count 0` run passes: 8 Blackwell GPUs, nonce-bound, secure_boot=true, measurement=success.

Needs a c8s-base image rebuild (CONFOS_REF bump in c8s) to reach launched CVMs.