### PR TITLE
fix(c8s): node-image admission inventory, and a reproducible GPU module build

### DIFF
--- a/bin/build-c8s
+++ b/bin/build-c8s
@@ -59,6 +59,7 @@ cd "$(dirname "${BASH_SOURCE[0]}")/.."
 # $SRCDIR/mkosi.local/c8s-ref; absent or empty defaults to main.
 mkdir -p mkosi/base/mkosi.local
 printf '%s\n' "${C8S_REF:-}" > mkosi/base/mkosi.local/c8s-ref
+printf '%s\n' "${C8S_REGISTRY:-}" > mkosi/base/mkosi.local/c8s-registry
 
 FRAGMENT=kernel/c8s.config
 DEV_PROFILE=()

--- a/bin/steep-fetch-gpu
+++ b/bin/steep-fetch-gpu
@@ -138,9 +138,15 @@ sudo systemd-nspawn --quiet --register=no --keep-unit --ephemeral \
     # src/nvidia-modeset too, which needs g++ and (for its .ko) CONFIG_DRM —
     # neither of which we want. NV_KERNEL_MODULES already excludes the modeset
     # .ko; this also skips its object build.
-    make -C /nv SYSSRC=/ksrc -j${NPROC} kernel-open/nvidia/nv-kernel.o_binary
+    make -C /nv SYSSRC=/ksrc -j${NPROC} \\
+      KCFLAGS='-frandom-seed=\$(srctree)/\$@' \\
+      NV_BUILD_USER=c8s NV_BUILD_HOST=confos DATE='date -u -d @0' \\
+      kernel-open/nvidia/nv-kernel.o_binary
     # Then build just the .ko we ship, straight from kernel-open/ via kbuild.
-    make -C /nv/kernel-open SYSSRC=/ksrc NV_KERNEL_MODULES='${NV_NAMES}' -j${NPROC} modules
+    make -C /nv/kernel-open SYSSRC=/ksrc NV_KERNEL_MODULES='${NV_NAMES}' -j${NPROC} \\
+      KCFLAGS='-frandom-seed=\$(srctree)/\$@' \\
+      NV_BUILD_USER=c8s NV_BUILD_HOST=confos DATE='date -u -d @0' \\
+      modules
     test -f /nv/kernel-open/nvidia.ko"
 
 # The nspawn build ran as root (uid 0 in container == uid 0 on host via the

--- a/mkosi/base/mkosi.profiles/c8s/image-policy.yaml.in
+++ b/mkosi/base/mkosi.profiles/c8s/image-policy.yaml.in
@@ -27,8 +27,36 @@
 #   - pull.url must be https, and attestation_api_url is then required.
 #   - empty cds_measurements = accept any RA-TLS-attested CDS (warns).
 
+# The CPU TEE this image boots on. bin/build-c8s composes the c8s profile with
+# `--platform tdx`, so this image is TDX-only and the value is fixed.
+#
+# It types the RA-TLS identity the admission inventory serves to CDS, and CDS
+# refuses a peer whose type disagrees with the evidence envelope the
+# attestation-api returns. The plugin defaults this to snp for backward
+# compatibility, so omitting it here denies every sandbox token on the node,
+# which denies every adopted workload a certificate.
+platform: "tdx"
+
 plugin:
   health_addr: "unix:///var/run/nri-image-policy/health.sock"
+
+# The node-CVM admission inventory (c8s docs/ratls.md, "Sandbox identity").
+# get-cert dials this socket for its pod's digests before CDS will issue a
+# certificate. In --cvm-mode=node the chart's nri-image-policy installer is
+# disabled, so nothing rewrites this file after boot and the section must be
+# baked in; without it the socket is never created and every adopted workload
+# hangs waiting for a certificate that cannot be issued.
+workload_claims:
+  socket_dir: "/var/run/nri-image-policy"
+  # The plugin is launched by containerd on the host, so its /proc is the
+  # host's — a caller PID from SO_PEERCRED resolves directly.
+  proc_root: "/proc"
+  # Empty falls back to NodeIPFile (node-ip in socket_dir). On a Kubernetes-
+  # hosted install the chart's installer writes that from its own status.hostIP;
+  # a node-as-CVM has no installer, so nri-node-ip.service writes it at boot
+  # instead. Without either, this resolves to 127.0.0.1 and the plugin refuses
+  # to start with "inventory host is not a routable unicast address".
+  advertise_host: ""
 
 allowlist:
   # Cold-boot floor, both entries resolved from C8S_REF by mkosi.sync:

--- a/mkosi/base/mkosi.profiles/c8s/mkosi.extra/etc/systemd/system/nri-node-ip.service
+++ b/mkosi/base/mkosi.profiles/c8s/mkosi.extra/etc/systemd/system/nri-node-ip.service
@@ -1,0 +1,22 @@
+# Publish this node's address for nri-image-policy's admission inventory.
+#
+# Must run before rke2 starts containerd, because containerd launches the
+# baked plugin as a child and the plugin reads the file during startup. See
+# nri-node-ip.sh for why a node-as-CVM has no other writer.
+[Unit]
+Description=Publish the node address for the nri-image-policy admission inventory
+Before=rke2-server.service rke2-agent.service
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/local/bin/nri-node-ip.sh
+# Never block boot. The script exits 0 when it cannot resolve an address; the
+# plugin then fails its own advertise_host check with a message that names the
+# cause, which is a better failure than a node that will not boot.
+TimeoutStartSec=30
+
+[Install]
+WantedBy=multi-user.target

--- a/mkosi/base/mkosi.profiles/c8s/mkosi.extra/usr/lib/systemd/system-preset/50-rke2.preset
+++ b/mkosi/base/mkosi.profiles/c8s/mkosi.extra/usr/lib/systemd/system-preset/50-rke2.preset
@@ -25,6 +25,10 @@ enable containerd-data-disk.service
 # Read-only weights disk (serial=confai-models). Enabled always; a no-op boot
 # when the disk isn't attached (GPU-less / no-weights launches).
 enable models-disk.service
+# Publish the node address the nri-image-policy admission inventory advertises
+# to CDS. Ordered before rke2 so the file exists when containerd launches the
+# baked plugin.
+enable nri-node-ip.service
 enable rke2-server.service
 disable rke2-agent.service
 # NTP: sync the free-running TDX guest clock so it doesn't drift behind the

--- a/mkosi/base/mkosi.profiles/c8s/mkosi.extra/usr/local/bin/nri-node-ip.sh
+++ b/mkosi/base/mkosi.profiles/c8s/mkosi.extra/usr/local/bin/nri-node-ip.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+# Write this node's address where nri-image-policy looks for it.
+#
+# The plugin's admission inventory advertises an address CDS dials back on
+# (workload_claims.advertise_host). On a Kubernetes-hosted install the chart's
+# installer DaemonSet writes it from its own status.hostIP. A node-as-CVM has
+# no such installer — the plugin is a containerd child on the host — so with
+# the value unset it resolves to 127.0.0.1 and the plugin refuses to start:
+#
+#   workloadclaims: inventory host "127.0.0.1" is not a routable unicast address
+#
+# The address is a dial target, not a trust input. CDS still requires whatever
+# answers to pass mutually-attested RA-TLS on a privileged port, so naming the
+# wrong one fails closed rather than opening anything.
+set -eu
+
+DIR=/var/run/nri-image-policy
+# The plugin creates this at startup, but this unit is ordered before rke2
+# brings containerd up, so it does not exist yet.
+mkdir -p "$DIR"
+
+# The source address of the default route: the one interface a CDS elsewhere in
+# the cluster can reach. `ip route get` resolves it without assuming an
+# interface name, which differs across launch shapes.
+ADDR=$(ip -4 route get 1.1.1.1 2>/dev/null | sed -n 's/.* src \([0-9.]*\).*/\1/p' | head -1)
+
+if [ -z "$ADDR" ]; then
+    # No default route yet. Leave the file absent rather than writing a
+    # loopback address: the plugin's own check rejects that with a message
+    # naming the cause, which beats advertising an address nothing can reach.
+    echo "nri-node-ip: no IPv4 default route; leaving $DIR/node-ip unwritten" >&2
+    exit 0
+fi
+
+printf '%s\n' "$ADDR" > "$DIR/node-ip"
+echo "nri-node-ip: advertised $ADDR"

--- a/mkosi/base/mkosi.profiles/c8s/mkosi.sync
+++ b/mkosi/base/mkosi.profiles/c8s/mkosi.sync
@@ -49,8 +49,14 @@ RKE2_IMAGES_CILIUM_SHA256="1ab41422cc16f5d030b8f62889133dff5d9dce985fbf13360c160
 # (written by bin/build-c8s — an exported var never reaches this sandbox: mkosi
 # runs under sudo, stripping the env). Empty = main. The tag must be published
 # (c8s docker.yml on main, or workflow_dispatch for a feature branch).
-NRI_REPO="ghcr.io/confidential-dot-ai/nri-image-policy"
-CDS_REPO="ghcr.io/confidential-dot-ai/cds"
+# The registry the two component images resolve from. Overridable via
+# $SRCDIR/mkosi.local/c8s-registry (written by bin/build-c8s from C8S_REGISTRY)
+# so an unmerged or air-gapped build can bake components from a local registry
+# without publishing them. Defaults to the published org.
+C8S_REGISTRY=$(cat "$SRCDIR/mkosi.local/c8s-registry" 2>/dev/null || true)
+C8S_REGISTRY="${C8S_REGISTRY:-ghcr.io/confidential-dot-ai}"
+NRI_REPO="${C8S_REGISTRY}/nri-image-policy"
+CDS_REPO="${C8S_REGISTRY}/cds"
 C8S_REF=$(cat "$SRCDIR/mkosi.local/c8s-ref" 2>/dev/null || true)
 C8S_REF="${C8S_REF:-main}"
 echo "c8s sync: resolving nri-image-policy + cds at c8s ref ${C8S_REF}"


### PR DESCRIPTION
## Problem

Three defects found by executing the full node-as-CVM bring-up on TDX hardware.

**Adopted workloads never got a certificate.** The baked `image-policy.yaml` had no `workload_claims` section and no `platform`, so the admission inventory socket never existed and every injected `c8s-cert` sidecar sat at `Init:1/2` indefinitely.

**Two builds of the same commit produced different measurements.** RTMR[1] and RTMR[2] differed between runs minutes apart on one machine.

**Components could only be baked from ghcr**, so an unmerged or air-gapped build had to publish first.

## Root cause

`workload_claims` and `platform` matter only in `--cvm-mode=node`, and the chart can only render them from its installer DaemonSet — which node mode disables. Nothing wrote them. Separately, `advertise_host` unset resolves to 127.0.0.1 and the plugin refuses to start:

```
workloadclaims: inventory host "127.0.0.1" is not a routable unicast address
```

For the nondeterminism, a file-level diff of both mounted rootfs trees narrowed it to **2 files out of 10,240**: `nvidia.ko` and `nvidia-uvm.ko`. Kernel and initrd were already byte-identical, so `SourceDateEpoch=0` and the mkosi assembly were never at fault. Two causes, both in the out-of-tree module build:

- `CONFIG_GCC_PLUGIN_LATENT_ENTROPY=y` instruments `__init` functions with constants read from `/dev/urandom` at compile time, visible as 64-bit `movabs` immediates in `.init.text` and nowhere else.
- NVIDIA stamps a version banner into `.rodata` from `NV_BUILD_USER`, `NV_BUILD_HOST` and a shell `date`. Under mkosi the hostname is the nspawn container's random name, so it read `(root@image-dd52f3f8ae638a07) Thu Jul 30 07:05:38 UTC 2026`.

## Fix

Bake `workload_claims` + `platform` into the NRI config, and add `nri-node-ip.service` to supply `advertise_host` at boot from the default route's source address. That address is a dial target, not a trust input — CDS still requires whatever answers to pass mutually-attested RA-TLS on a privileged port, so naming the wrong one fails closed.

For reproducibility: the latent-entropy plugin already supports determinism and falls back to urandom only when no `-frandom-seed` was passed, so `KCFLAGS` now passes the kernel's own per-file form. The three banner variables are `?=` and are now pinned.

`C8S_REGISTRY` (via `mkosi.local/c8s-registry`, since an exported var never reaches the mkosi sandbox) overrides the component registry. Defaults to the published org, so existing builds are unchanged.

## Why reproducibility matters here

Every verification path compares live RTMR[1] and RTMR[2] against references, and the honest source of those is "rebuild from source and check". Before this, two builds of one commit disagreed, so the references could only come from whoever ran the build.

## Verification

Built the full image twice: MRTD, RTMR[1], RTMR[2] and the rootfs hash identical. `bash -n` clean on all four modified scripts. Validated as part of an end-to-end run executed three times on b300-node-1.