### PR TITLE
fix(c8s): keep nested cluster networking reachable

### DIFF
--- a/bin/lint
+++ b/bin/lint
@@ -45,3 +45,19 @@ if grep -qE '^[[:space:]]*"sha256:[a-f0-9]{64}"[[:space:]]*:' "$policy"; then
     echo "bin/lint: $policy has a hardcoded always_allow digest; use @NRI_DIGEST@/@CDS_DIGEST@ tokens (rendered from C8S_REF by mkosi.sync)" >&2
     exit 1
 fi
+
+# The c8s node is itself normally nested in an outer RKE2 cluster. Its pod
+# CIDR must not fall back to the outer cluster's default, and Cilium's pool
+# must exactly match the RKE2 server setting or pods receive unroutable IPs.
+rke2_config="$c8s_profile/mkosi.extra/etc/rancher/rke2/config.yaml"
+cilium_config="$c8s_profile/mkosi.extra/var/lib/rancher/rke2/server/manifests/rke2-cilium-config.yaml"
+rke2_pod_cidr=$(sed -n 's/^cluster-cidr:[[:space:]]*//p' "$rke2_config")
+cilium_pod_cidr=$(sed -n '/clusterPoolIPv4PodCIDRList:/,/^[^[:space:]]/s/^[[:space:]]*-[[:space:]]*//p' "$cilium_config" | head -n 1)
+if [ -z "$rke2_pod_cidr" ] || [ "$rke2_pod_cidr" = "10.42.0.0/16" ]; then
+    echo "bin/lint: c8s RKE2 cluster-cidr must be explicit and must not overlap the outer RKE2 default" >&2
+    exit 1
+fi
+if [ "$rke2_pod_cidr" != "$cilium_pod_cidr" ]; then
+    echo "bin/lint: c8s RKE2 cluster-cidr ($rke2_pod_cidr) must match Cilium IPAM ($cilium_pod_cidr)" >&2
+    exit 1
+fi

--- a/docs/C8S-IMAGE.md
+++ b/docs/C8S-IMAGE.md
@@ -81,6 +81,14 @@ BTF-shipping distro kernel makes; the base/gpu images keep RANDSTRUCT.
 
 ## Launch requirements (hard, unlike the gpu image)
 
+- **The inner cluster uses pod CIDR `10.52.0.0/16` and service CIDR
+  `10.53.0.0/16` (CoreDNS `10.53.0.10`).** These deliberately differ from
+  the outer RKE2 host cluster's `10.42.0.0/16` and `10.43.0.0/16` defaults.
+  KubeVirt masquerade preserves the outer client source address; overlapping
+  CIDRs make the guest route replies into its own Cilium network once Cilium
+  starts, rendering every exposed VM port unreachable. Override
+  `cluster-cidr`, `service-cidr`, and `cluster-dns` together via an RKE2 config
+  drop-in when a deployment already uses the `10.52/10.53` ranges.
 - **A virtio-blk disk with device serial `confai-scratch`, ≥64G.** The
   initrd backs the overlay upper with it (per-boot-key encrypted,
   ephemeral). Without it the upper is a 2G tmpfs, which cannot hold RKE2's

--- a/mkosi/base/mkosi.extra/etc/systemd/network/80-dhcp.network
+++ b/mkosi/base/mkosi.extra/etc/systemd/network/80-dhcp.network
@@ -1,5 +1,9 @@
 [Match]
 Type=ether
+# The kernel-created dummy0 link has Type=ether too, but it can never obtain a
+# DHCP lease. If networkd manages it, systemd-networkd-wait-online blocks until
+# its full timeout even though the real uplink is already routable.
+Kind=!dummy
 
 [Network]
 DHCP=yes

--- a/mkosi/base/mkosi.profiles/c8s/mkosi.extra/etc/rancher/rke2/config.yaml
+++ b/mkosi/base/mkosi.profiles/c8s/mkosi.extra/etc/rancher/rke2/config.yaml
@@ -19,6 +19,17 @@
 cni: cilium
 disable-kube-proxy: true
 
+# This node cluster normally runs inside a KubeVirt pod on an outer RKE2
+# cluster. Do not reuse RKE2's 10.42.0.0/16 pod and 10.43.0.0/16 service
+# defaults: KubeVirt masquerade preserves the outer client source address, so
+# overlapping routes make the guest send replies into its own Cilium network
+# after Cilium starts. Keep these values in lockstep with the Cilium IPAM pool
+# in rke2-cilium-config.yaml. Deployments that need different ranges can
+# override all three values in config.yaml.d/.
+cluster-cidr: 10.52.0.0/16
+service-cidr: 10.53.0.0/16
+cluster-dns: 10.53.0.10
+
 # Drop RKE2's bundled ingress-nginx: it binds hostPorts 80/443, which collide
 # with c8s tls-lb's hostPort 443 (the attested front door for workloads —
 # `c8s install` preflights this exact conflict). The node image's external

--- a/mkosi/base/mkosi.profiles/c8s/mkosi.extra/var/lib/rancher/rke2/server/manifests/rke2-cilium-config.yaml
+++ b/mkosi/base/mkosi.profiles/c8s/mkosi.extra/var/lib/rancher/rke2/server/manifests/rke2-cilium-config.yaml
@@ -12,7 +12,7 @@
 #
 #   2. k8sServiceHost / k8sServicePort = 127.0.0.1 : 6443
 #      Cilium agent + install-cni would normally dial the cluster service
-#      IP (10.43.0.1:443) to reach kube-apiserver. With kube-proxy disabled
+#      IP (10.53.0.1:443) to reach kube-apiserver. With kube-proxy disabled
 #      AND Cilium not yet running, that IP has no DNAT — chicken-and-egg.
 #      Pointing Cilium directly at the apiserver's loopback bypasses the
 #      service mesh during Cilium's own bootstrap. For multi-node, set
@@ -42,12 +42,13 @@ spec:
     k8sServiceHost: 127.0.0.1
     k8sServicePort: 6443
 
-    # Pod CIDR — matches RKE2's default. Set explicitly so Cilium's
-    # IPAM operator pre-allocates from the right range.
+    # Pod CIDR — matches the non-default nested-cluster range in config.yaml.
+    # The outer RKE2 cluster uses 10.42.0.0/16; overlapping it breaks replies
+    # through KubeVirt masquerade as soon as the inner Cilium route appears.
     ipam:
       operator:
         clusterPoolIPv4PodCIDRList:
-          - 10.42.0.0/16
+          - 10.52.0.0/16
 
     # Hubble observability. Disable both fields if you care about
     # minimizing in-cluster pods (Hubble adds relay+ui+metrics).


### PR DESCRIPTION
## Summary

- assign the inner RKE2 cluster non-overlapping pod and service CIDRs
- keep the RKE2 pod CIDR and Cilium IPAM pool in lockstep with a lint invariant
- exclude kernel dummy links from the base DHCP match so network-online does not wait for an impossible lease
- document the nested-cluster CIDR requirement

## Root cause

The c8s VM and its outer RKE2 host both used the default 10.42.0.0/16 pod and 10.43.0.0/16 service ranges. KubeVirt masquerade preserves the outer pod source address. Once inner Cilium installed its 10.42 route, replies to the outer client went to cilium_host instead of the virtio uplink, making ports 6443 and 8400 disappear after initially opening.

A separate boot delay came from dummy0 matching Type=ether: networkd managed it and wait-online waited through its timeout even though enp1s0 already had DHCP.

## Validation

- ./bin/lint
- ./bin/test (161 passed, 5 skipped)
- on-host diagnostic: a temporary host route for the outer client via enp1s0 immediately restored both exposed ports; removing it reproduced the failure