### PR TITLE
fix(gpu): prevent udev probe before FLR

### DIFF
--- a/bin/lint
+++ b/bin/lint
@@ -61,3 +61,19 @@ if [ "$rke2_pod_cidr" != "$cilium_pod_cidr" ]; then
     echo "bin/lint: c8s RKE2 cluster-cidr ($rke2_pod_cidr) must match Cilium IPAM ($cilium_pod_cidr)" >&2
     exit 1
 fi
+
+# Omitting modules-load.d does not prevent udev coldplug from resolving an
+# NVIDIA PCI modalias and running `modprobe -b` before the FLR oneshot. The
+# alias blacklist is therefore part of the CC boot-order invariant; the
+# explicit post-reset modprobe by module name remains allowed.
+gpu_profile=mkosi/base/mkosi.profiles/gpu/mkosi.extra
+flr_blacklist="$gpu_profile/etc/modprobe.d/nvidia-flr-first.conf"
+flr_helper="$gpu_profile/usr/local/bin/nvidia-gpu-flr"
+if ! grep -qE '^[[:space:]]*blacklist[[:space:]]+nvidia([[:space:]]*(#.*)?)?$' "$flr_blacklist"; then
+    echo "bin/lint: $flr_blacklist must blacklist alias-based nvidia autoload" >&2
+    exit 1
+fi
+if ! grep -qx 'modprobe nvidia' "$flr_helper"; then
+    echo "bin/lint: $flr_helper must explicitly load nvidia after the GPU resets" >&2
+    exit 1
+fi

--- a/docs/GPU-CC-OPERATIONS.md
+++ b/docs/GPU-CC-OPERATIONS.md
@@ -15,10 +15,13 @@ unless the PCI function was **freshly FLR-reset**, and it allows exactly **one**
 attach per reset. Two consequences the image must honour:
 
 - **FLR before the driver's first probe.** We do NOT auto-load `nvidia` via
-  `modules-load.d` (deleted) — that would let the kernel probe every GPU before
-  any reset. `nvidia-gpu-flr.service` FLRs every GPU via
-  `/sys/bus/pci/.../reset` (no driver bound → clean), *then* modprobes the
-  driver, so its first probe lands on reset functions.
+  `modules-load.d`. That alone is not enough: udev coldplug resolves each PCI
+  modalias and calls `modprobe -b`, which can probe every GPU before the reset
+  unit reaches `multi-user.target`. `nvidia-flr-first.conf` therefore
+  blacklists alias-based `nvidia` loads. `nvidia-gpu-flr.service` FLRs every
+  GPU via `/sys/bus/pci/.../reset` (no driver bound → clean), *then* explicitly
+  modprobes the driver by name; an explicit load is not blocked by the alias
+  blacklist, so its first probe lands on freshly reset functions.
 - **`nvidia-persistenced` is load-bearing, not an optimisation.** It performs
   and *holds* that one good attach for the life of the VM. If it exits, a
   transient client (`nvidia-smi`) tears the session down and the next attach
@@ -41,8 +44,9 @@ Failure signature when this is wrong: `NVRM: osInitNvMapping: *** Cannot attach
 gpu` → `RmInitAdapter failed! (0x22:0x56:894)`, `nvidia-smi: No devices were
 found`. It is **silent at 1 GPU and racy at 8** (the old modules-load ordering
 recovered 5/8 and left 3 stuck) — which is why it slipped past single-GPU
-validation. Enforced in `usr/local/bin/nvidia-gpu-flr` +
-`nvidia-persistenced.service` + `bin/steep-fetch-gpu` (stages libnvidia-cfg).
+validation. Enforced in `etc/modprobe.d/nvidia-flr-first.conf` +
+`usr/local/bin/nvidia-gpu-flr` + `nvidia-persistenced.service` +
+`bin/steep-fetch-gpu` (stages libnvidia-cfg).
 
 The host-side FLR that vfio does at VM-open does NOT satisfy this by the time
 the guest driver attaches — the reset must happen *inside* the guest.

--- a/docs/GPU-IMAGE-PLAN.md
+++ b/docs/GPU-IMAGE-PLAN.md
@@ -58,7 +58,8 @@ kernel/version                             6.16.12 (folded in from feat/kernel-6
 bin/steep-fetch-gpu                        fetch(pinned sha)→build in kernel-builder nspawn→sign→depmod→stage
 mkosi/base/mkosi.profiles/gpu/
   mkosi.conf                               apt: kmod, pciutils; doc header
-  mkosi.extra/etc/modules-load.d/nvidia.conf
+  mkosi.extra/etc/modprobe.d/nvidia-flr-first.conf                  (blocks udev autoprobe until FLR)
+  mkosi.extra/usr/local/bin/nvidia-gpu-flr                          (FLR all, then explicit modprobe)
   mkosi.extra/etc/systemd/system/nvidia-persistenced.service        (--uvm-persistence-mode baked)
   mkosi.extra/etc/systemd/system/nvidia-cc-ready.service            (oneshot conf-compute -srs 1)
   mkosi.extra/etc/systemd/system/nvidia-modules-latch.service       (sysctl modules_disabled=1)

--- a/mkosi/base/mkosi.profiles/gpu/mkosi.conf
+++ b/mkosi/base/mkosi.profiles/gpu/mkosi.conf
@@ -26,7 +26,7 @@
 
 [Content]
 Packages=
-    # kmod: modprobe/depmod at runtime (systemd-modules-load loads nvidia).
+    # kmod: depmod at image build and explicit post-FLR modprobe at runtime.
     kmod
     # pciutils: lspci, for operators debugging GPU passthrough in the guest.
     pciutils

--- a/mkosi/base/mkosi.profiles/gpu/mkosi.extra/etc/modprobe.d/nvidia-flr-first.conf
+++ b/mkosi/base/mkosi.profiles/gpu/mkosi.extra/etc/modprobe.d/nvidia-flr-first.conf
@@ -1,0 +1,8 @@
+# A CC GPU must be FLR-reset before the NVIDIA driver's first probe.  Merely
+# omitting modules-load.d is not sufficient: udev coldplug resolves the PCI
+# modalias and invokes `modprobe -b`, which would otherwise load nvidia before
+# nvidia-gpu-flr.service runs.
+#
+# `blacklist` suppresses alias-based loads.  It does not block the service's
+# explicit `modprobe nvidia` after every GPU has been reset.
+blacklist nvidia

--- a/mkosi/base/mkosi.profiles/gpu/mkosi.extra/etc/systemd/system/nvidia-gpu-flr.service
+++ b/mkosi/base/mkosi.profiles/gpu/mkosi.extra/etc/systemd/system/nvidia-gpu-flr.service
@@ -1,6 +1,8 @@
 [Unit]
 Description=FLR NVIDIA GPUs before first driver attach (CC SPDM precondition)
-# After the module is resident, strictly before anything can attach the GPU.
+# Wait for unrelated declarative boot modules, then reset the GPUs and load
+# nvidia explicitly. PCI-modalias autoload is suppressed by modprobe.d so udev
+# coldplug cannot race this unit and consume the one valid post-FLR probe.
 # See /usr/local/bin/nvidia-gpu-flr for the full rationale.
 After=systemd-modules-load.service
 Before=nvidia-persistenced.service nvidia-cc-ready.service

--- a/mkosi/base/mkosi.profiles/gpu/mkosi.extra/etc/systemd/system/nvidia-persistenced.service
+++ b/mkosi/base/mkosi.profiles/gpu/mkosi.extra/etc/systemd/system/nvidia-persistenced.service
@@ -1,11 +1,13 @@
 [Unit]
 Description=NVIDIA Persistence Daemon
-# Modules are loaded by systemd-modules-load.service (see
-# /etc/modules-load.d/nvidia.conf). The daemon performs the FIRST driver
-# attach and HOLDS it for the life of the VM — load-bearing in CC mode, where
-# the GPU forbids re-establishing the SPDM session after teardown without a
-# fresh FLR. It must attach only AFTER nvidia-gpu-flr resets the GPU (the CC
-# SPDM precondition — see /usr/local/bin/nvidia-gpu-flr).
+# The driver is modprobe'd by nvidia-gpu-flr, NOT by modules-load.d or udev.
+# Alias-based autoload is blacklisted so the first probe cannot race ahead of
+# the reset (see /etc/modprobe.d/nvidia-flr-first.conf).
+#
+# This daemon performs the FIRST driver attach and HOLDS it for the life of the
+# VM — load-bearing in CC mode, where the GPU forbids re-establishing the SPDM
+# session after teardown without a fresh FLR. It must therefore attach only
+# AFTER nvidia-gpu-flr has reset the GPUs and loaded the driver.
 After=systemd-modules-load.service nvidia-gpu-flr.service
 # Wants (not Requires) for the FLR unit deliberately: Requires= propagates
 # stops, so an operator re-running the oneshot at runtime would take
@@ -31,4 +33,3 @@ RestrictAddressFamilies=AF_UNIX
 
 [Install]
 WantedBy=multi-user.target
-

--- a/mkosi/base/mkosi.profiles/gpu/mkosi.extra/usr/local/bin/nvidia-gpu-flr
+++ b/mkosi/base/mkosi.profiles/gpu/mkosi.extra/usr/local/bin/nvidia-gpu-flr
@@ -7,9 +7,10 @@
 # unless the function was freshly FLR-reset, and only ONE attach is allowed per
 # FLR. The critical ordering consequence: the very FIRST driver probe of each
 # GPU must land on a freshly-FLR'd function. So we do NOT auto-load nvidia via
-# modules-load.d (that would let the kernel probe all GPUs before any FLR).
-# Instead we FLR every GPU here — with no driver bound, so the reset is clean —
-# and only then modprobe the driver, so its first probe is the good one.
+# modules-load.d, and /etc/modprobe.d/nvidia-flr-first.conf blocks udev's PCI-
+# modalias coldplug from doing the same thing. Instead we FLR every GPU here —
+# with no driver bound, so the reset is clean — and only then explicitly
+# modprobe the driver, so its first probe is the good one.
 #
 # Getting this wrong is silent at 1 GPU and racy at 8: with modules-load.d
 # auto-loading nvidia first, the pre-FLR probe fails and the post-FLR re-attach
@@ -20,6 +21,14 @@
 # of the VM (in CC mode a torn-down session can't be re-established without
 # another FLR). Safe on a GPU-less boot: no 0x10de devices -> no-op.
 set -euo pipefail
+
+# The modprobe blacklist is the boot-order fence. Fail with a useful diagnosis
+# if another loader bypassed it; probing before FLR consumes the only usable CC
+# attach and cannot be repaired reliably during this boot.
+if grep -q '^nvidia ' /proc/modules; then
+    echo "nvidia-gpu-flr: nvidia loaded before FLR; refusing unsafe reset/probe sequence" >&2
+    exit 1
+fi
 
 reset_count=0
 for dev in /sys/bus/pci/devices/*; do


### PR DESCRIPTION
## Summary

- blacklist alias-based NVIDIA module autoload so udev coldplug cannot probe CC GPUs before the guest FLR unit
- retain the explicit post-reset modprobe and fail clearly if another loader bypasses the fence
- document and lint the FLR-before-first-probe invariant

## Host evidence

On poc115-node with eight passed-through B200s, udev coldplug began NVIDIA probes roughly ten seconds before nvidia-gpu-flr.service. All eight probes failed and the devices fell off the bus; the later FLR unit then failed to load the driver, so NVAT reported no CC GPUs or switches.

A modprobe blacklist applies to alias-based modprobe -b calls from udev, while the explicit modprobe nvidia in nvidia-gpu-flr remains allowed after every device has been reset.

## Validation

- bin/lint
- bash -n bin/lint mkosi/base/mkosi.profiles/gpu/mkosi.extra/usr/local/bin/nvidia-gpu-flr
- git diff --check

Full validation still requires rebuilding the c8s production image and booting all eight B200s.