### PR TITLE
fix(gpu): survive slow or degraded GPU bring-up at boot

### DIFF
--- a/bin/lint
+++ b/bin/lint
@@ -77,3 +77,23 @@ if ! grep -qx 'modprobe nvidia' "$flr_helper"; then
     echo "bin/lint: $flr_helper must explicitly load nvidia after the GPU resets" >&2
     exit 1
 fi
+
+# Type=oneshot units have no start timeout by default, and persistenced's
+# forking attach outruns the manager default; every GPU bring-up unit must
+# carry an explicit TimeoutStartSec so a wedged GPU fails visibly instead of
+# hanging the ordered chain (or being killed mid-attach).
+for unit in nvidia-gpu-flr nvidia-persistenced nvidia-cc-ready; do
+    unit_file="$gpu_profile/etc/systemd/system/$unit.service"
+    if ! grep -q '^TimeoutStartSec=' "$unit_file"; then
+        echo "bin/lint: $unit_file must set an explicit TimeoutStartSec" >&2
+        exit 1
+    fi
+done
+
+# The per-GPU reset write runs under set -e; unguarded, one wedged GPU aborts
+# the script before modprobe and the boot is GPU-dead once the modules latch
+# seals loading. The write must stay inside a failure-tolerant guard.
+if ! grep -q 'if ! echo 1 > "$dev/reset"' "$flr_helper"; then
+    echo "bin/lint: $flr_helper must guard the per-GPU reset write (one failed FLR must not abort bring-up)" >&2
+    exit 1
+fi

--- a/mkosi/base/mkosi.profiles/gpu/mkosi.extra/etc/systemd/system/nvidia-cc-ready.service
+++ b/mkosi/base/mkosi.profiles/gpu/mkosi.extra/etc/systemd/system/nvidia-cc-ready.service
@@ -8,9 +8,12 @@ Wants=nvidia-persistenced.service
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-# The helper polls up to 180s for a parseable Ready State plus 30s of -srs
-# read-back; the systemd default (90s) would kill it mid-poll and leave the
-# GPUs un-readied (NVAT then reports no CC GPUs).
+# Type=oneshot has NO start timeout by default (systemd.service(5):
+# DefaultTimeoutStartSec does not apply to oneshot), so a hung nvidia-smi
+# would stall this unit — and everything ordered After= it, including the
+# modules latch — indefinitely. Bound it above the helper's own worst case
+# (180s Ready-State poll + 30s -srs read-back) so a hang fails visibly
+# instead.
 TimeoutStartSec=300
 ExecStart=/usr/local/bin/nvidia-cc-ready
 

--- a/mkosi/base/mkosi.profiles/gpu/mkosi.extra/etc/systemd/system/nvidia-cc-ready.service
+++ b/mkosi/base/mkosi.profiles/gpu/mkosi.extra/etc/systemd/system/nvidia-cc-ready.service
@@ -8,6 +8,10 @@ Wants=nvidia-persistenced.service
 [Service]
 Type=oneshot
 RemainAfterExit=yes
+# The helper polls up to 180s for a parseable Ready State plus 30s of -srs
+# read-back; the systemd default (90s) would kill it mid-poll and leave the
+# GPUs un-readied (NVAT then reports no CC GPUs).
+TimeoutStartSec=300
 ExecStart=/usr/local/bin/nvidia-cc-ready
 
 # vsock fence: only attestation-api may use AF_VSOCK (see kernel/gpu.config).

--- a/mkosi/base/mkosi.profiles/gpu/mkosi.extra/etc/systemd/system/nvidia-gpu-flr.service
+++ b/mkosi/base/mkosi.profiles/gpu/mkosi.extra/etc/systemd/system/nvidia-gpu-flr.service
@@ -10,11 +10,13 @@ Before=nvidia-persistenced.service nvidia-cc-ready.service
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-# Worst case at 8 GPUs: ~17s of FLRs + ~65s driver probe + the script's
-# 180s bound-wait loop ≈ 260s. The systemd default (90s) kills the script
-# mid-bring-up on a slow boot — before modprobe on the slowest paths — and
-# nothing later reloads the driver (modules-latch seals module loading).
-# Bounded rather than infinity so a truly wedged GPU cannot hang boot.
+# Type=oneshot has NO start timeout by default (systemd.service(5):
+# DefaultTimeoutStartSec does not apply to oneshot). A wedged reset write or
+# a D-state modprobe would therefore hang this unit's start job forever —
+# and with it persistenced, cc-ready and the modules latch, all ordered
+# After= this unit. Bound well above the honest worst case at 8 GPUs (~17s
+# of FLRs + ~65s driver probe + the 180s bound-wait loop ≈ 260s) so a hang
+# becomes a visible unit failure instead.
 TimeoutStartSec=600
 ExecStart=/usr/local/bin/nvidia-gpu-flr
 

--- a/mkosi/base/mkosi.profiles/gpu/mkosi.extra/etc/systemd/system/nvidia-gpu-flr.service
+++ b/mkosi/base/mkosi.profiles/gpu/mkosi.extra/etc/systemd/system/nvidia-gpu-flr.service
@@ -10,6 +10,12 @@ Before=nvidia-persistenced.service nvidia-cc-ready.service
 [Service]
 Type=oneshot
 RemainAfterExit=yes
+# Worst case at 8 GPUs: ~17s of FLRs + ~65s driver probe + the script's
+# 180s bound-wait loop ≈ 260s. The systemd default (90s) kills the script
+# mid-bring-up on a slow boot — before modprobe on the slowest paths — and
+# nothing later reloads the driver (modules-latch seals module loading).
+# Bounded rather than infinity so a truly wedged GPU cannot hang boot.
+TimeoutStartSec=600
 ExecStart=/usr/local/bin/nvidia-gpu-flr
 
 # vsock fence: only attestation-api may use AF_VSOCK (see kernel/gpu.config).

--- a/mkosi/base/mkosi.profiles/gpu/mkosi.extra/etc/systemd/system/nvidia-persistenced.service
+++ b/mkosi/base/mkosi.profiles/gpu/mkosi.extra/etc/systemd/system/nvidia-persistenced.service
@@ -18,6 +18,10 @@ Wants=nvidia-gpu-flr.service syslog.target
 
 [Service]
 Type=forking
+# The parent exits only after the per-GPU SPDM attach completes: ~63s
+# observed on a good 8×B200 boot, leaving no margin under the systemd
+# default (90s). A start-timeout kill here destroys every held CC session.
+TimeoutStartSec=300
 # Skip (not fail) on a GPU-less boot — keeps the image degraded-nothing when
 # booted without a GPU attached.
 ExecCondition=/bin/sh -c 'grep -qx 0x10de /sys/bus/pci/devices/*/vendor 2>/dev/null'

--- a/mkosi/base/mkosi.profiles/gpu/mkosi.extra/usr/local/bin/nvidia-gpu-flr
+++ b/mkosi/base/mkosi.profiles/gpu/mkosi.extra/usr/local/bin/nvidia-gpu-flr
@@ -30,18 +30,32 @@ if grep -q '^nvidia ' /proc/modules; then
     exit 1
 fi
 
+gpu_count=0
 reset_count=0
 for dev in /sys/bus/pci/devices/*; do
     [[ "$(cat "$dev/vendor" 2>/dev/null)" == "0x10de" ]] || continue
+    gpu_count=$((gpu_count + 1))
     [[ -f "$dev/reset" ]] || { echo "nvidia-gpu-flr: $(basename "$dev") has no reset method; skipping" >&2; continue; }
     echo "nvidia-gpu-flr: FLR $(basename "$dev")"
-    echo 1 > "$dev/reset"
+    # A failed reset (device wedged from a prior guest's teardown, EIO from
+    # the host's vfio) must not abort the whole bring-up: under set -e an
+    # unguarded write here would exit before modprobe, and once
+    # nvidia-modules-latch seals module loading the boot is GPU-dead with no
+    # recovery but a reboot. Degraded (some GPUs un-FLR'd, probe may fail
+    # per-GPU) beats none.
+    if ! echo 1 > "$dev/reset"; then
+        echo "nvidia-gpu-flr: FLR of $(basename "$dev") FAILED; continuing — its first probe lands pre-FLR and may not attach" >&2
+        continue
+    fi
     reset_count=$((reset_count + 1))
 done
 
-if [[ "$reset_count" -eq 0 ]]; then
+if [[ "$gpu_count" -eq 0 ]]; then
     echo "nvidia-gpu-flr: no NVIDIA devices present; nothing to do."
     exit 0
+fi
+if [[ "$reset_count" -lt "$gpu_count" ]]; then
+    echo "nvidia-gpu-flr: FLR'd only $reset_count/$gpu_count device(s); loading the driver anyway" >&2
 fi
 
 # Let the FLR(s) settle (~1s each on B200) before the driver's first probe.
@@ -50,7 +64,7 @@ sleep 3
 # NOW load the driver — this is the first time anything touches the freshly
 # reset GPUs, so every SPDM session establishes cleanly. modprobe nvidia_uvm
 # pulls nvidia; list both so a missing dep is obvious.
-echo "nvidia-gpu-flr: reset $reset_count device(s); loading driver"
+echo "nvidia-gpu-flr: reset $reset_count/$gpu_count device(s); loading driver"
 modprobe nvidia
 modprobe nvidia_uvm
 
@@ -72,7 +86,7 @@ modprobe nvidia_uvm
 # when run during the persistenced activation window). /proc reads are free.
 for _ in $(seq 1 90); do
     bound=$(ls /proc/driver/nvidia/gpus/ 2>/dev/null | wc -l)
-    [[ "$bound" -ge "$reset_count" ]] && break
+    [[ "$bound" -ge "$gpu_count" ]] && break
     sleep 2
 done
-echo "nvidia-gpu-flr: $bound/$reset_count GPU(s) bound and ready for persistenced"
+echo "nvidia-gpu-flr: $bound/$gpu_count GPU(s) bound and ready for persistenced"


### PR DESCRIPTION
## Problem

On poc115-node (8x B200, TDX, `c8s-base` CDI image) the same image intermittently boots with no NVIDIA driver: `nvidia.ko` present on disk and indexed in `modules.dep`, all six `nvidia-*` units enabled, yet `/proc/modules` empty, only `/dev/nvidiactl` created, the device plugin in CrashLoopBackOff with `NVML: Driver Not Loaded`, and `/attest` returning `422 no CC GPUs or switches reported by NVAT SDK`. Two consecutive boots failed; the third succeeded with no change to the image. Because `nvidia-modules-latch` seals module loading (`kernel.modules_disabled=1`), a missed load window is unrecoverable until reboot — and destroys its own evidence.

Related: #71 (same 422 surface on B300, driver loaded, ready-state gate suspected).

## Root cause

Two distinct defects (per systemd.service(5), `DefaultTimeoutStartSec` does **not** apply to `Type=oneshot` units — verified against the man page, and corrected here after the first version of this PR claimed otherwise):

- In `nvidia-gpu-flr`, `echo 1 > "$dev/reset"` is unguarded under `set -euo pipefail`: one wedged GPU (e.g. left mid-teardown by a killed guest) aborts the script **before `modprobe`**, so zero GPUs get a driver. This is the load-bearing fix and the mechanism consistent with the captured failing boots (unit completed, module absent, latch reached).
- Timeout posture was wrong on both sides: the two oneshot units (`nvidia-gpu-flr`, `nvidia-cc-ready`) had **no start timeout at all** — a wedged reset write or hung nvidia-smi stalls the whole `After=` chain (latch included) indefinitely — while `nvidia-persistenced` (`Type=forking`) ran under the 90s manager default with **63s of measured attach time on a healthy 8x B200 boot** (journal: flr finished t=115s, persistenced success t=178s), where a start-timeout kill destroys every held CC session.

## Fix

Explicit `TimeoutStartSec=` per unit, sized to each unit's own worst case (300/300/600): the oneshot units gain a bound where none existed, persistenced gains margin over its measured attach. The FLR loop logs and skips a failed reset instead of aborting, then loads the driver for the GPUs that remain; the bound-wait targets the enumerated GPU count rather than the reset count.

## Verification

`bash -n` + shellcheck clean (one pre-existing SC2012 info untouched). Reset-failure path exercised in an isolated harness of the loop: the old unguarded line aborts before modprobe (`exit=1`); the guarded version continues (`reset 1/3; loading driver`, exit 0). Timeout values validated against measured journal timings from a healthy 8-GPU boot:

```
[   93.99] Starting nvidia-gpu-flr.service...
[   94.47] nvidia-gpu-flr: FLR 0000:0b:00.0
...
[  114.26] nvidia-gpu-flr: reset 8 device(s); loading driver
[  115.13] nvidia-gpu-flr: 8/8 GPU(s) bound and ready for persistenced
[  178.21] unit=nvidia-persistenced ... res=success
[  183.86] nvidia-cc-ready: Confidential Compute GPUs Ready state: ready
```

Multi-boot soak needs an image rebuild; the rebuilt image's measurements change, so floor pairing must be redone.

`bin/lint` now pins both invariants: every bring-up unit carries an explicit `TimeoutStartSec`, and the reset write stays failure-guarded.
