### PR TITLE
fix(boot): stop the 120s wait-online stall from the phantom dummy0 link

### DIFF
--- a/mkosi/base/mkosi.conf
+++ b/mkosi/base/mkosi.conf
@@ -84,7 +84,21 @@ Packages=
 # free-list shuffling *available* — without this param (or memory-side
 # caches, which VMs don't have) it stays inert. See the KSPP block in
 # kernel/hardening.config.
-KernelCommandLine=systemd.condition-first-boot=no page_alloc.shuffle=1
+#
+# dummy.numdummies=0: the dummy driver is built in (CONFIG_DUMMY=y, kept for
+# Cilium's benefit) and its module_init creates `numdummies` links — default 1
+# — so every guest boots with a dummy0 that is state DOWN, qdisc noop and
+# permanently carrier-less. cloud-init classifies it as an ethernet NIC and
+# writes dhcp4/dhcp6 for it into /etc/netplan/50-cloud-init.yaml; netplan's
+# generator then hands `-i dummy0` to systemd-networkd-wait-online, which
+# blocks for its full 120s timeout and exits 1 on every boot, delaying
+# everything ordered After=network-online.target. The Kind=!dummy match in
+# mkosi.extra/etc/systemd/network/80-dhcp.network only stops *networkd* from
+# managing the link; it cannot stop cloud-init from enumerating it. Setting
+# numdummies=0 keeps the driver (`ip link add type dummy` still works on
+# demand) while creating no link at boot, which removes the input to that
+# whole chain.
+KernelCommandLine=systemd.condition-first-boot=no page_alloc.shuffle=1 dummy.numdummies=0
 
 [Output]
 Format=disk

--- a/mkosi/base/mkosi.profiles/dev/mkosi.conf
+++ b/mkosi/base/mkosi.profiles/dev/mkosi.conf
@@ -42,5 +42,11 @@
 # interactive prompt would vanish under `confos run`. With hvc0 last,
 # /dev/console = hvc0 for `confos run`, while ttyS0 still carries kernel+boot
 # output for KubeVirt's serial console.
+#
+# Because this line replaces the base cmdline wholesale rather than appending
+# to it, every base parameter has to be repeated here — including
+# dummy.numdummies=0. Leaving it out would reintroduce the boot-time dummy0
+# link and the 120s systemd-networkd-wait-online stall on dev images only.
+# See the comment in mkosi/base/mkosi.conf for the full causal chain.
 KernelCommandLine=
-KernelCommandLine=console=ttyS0 console=hvc0 systemd.condition-first-boot=no page_alloc.shuffle=1
+KernelCommandLine=console=ttyS0 console=hvc0 systemd.condition-first-boot=no page_alloc.shuffle=1 dummy.numdummies=0


### PR DESCRIPTION
Every guest boot burned exactly two minutes in systemd-networkd-wait-online.service, which then *failed*, delaying every unit ordered After=network-online.target (attestation-api, rke2-server, cred-release, nri-node-ip) by the same two minutes.

Causal chain, verified end to end on a live guest:

1. CONFIG_DUMMY=y in kernel/c8s.config and kernel/c8s-dev.config. It is built in, not a module, so the driver's module_init runs at boot and creates `numdummies` links. The default is 1, so every guest comes up with a dummy0 that is state DOWN, qdisc noop and permanently carrier-less.
2. cloud-init enumerates links, sees dummy0's ARPHRD_ETHER type, classifies it as an ethernet NIC and writes it into /etc/netplan/50-cloud-init.yaml with dhcp4: true / dhcp6: true.
3. netplan's generator turns that stanza into /run/systemd/generator.late/systemd-networkd-wait-online.service.d/10-netplan.conf with ExecStart=/lib/systemd/systemd-networkd-wait-online --any --dns \ -o routable -i dummy0
4. dummy0 has no carrier and can never become routable, so wait-online sits there for its full 120s timeout and exits 1. network-online.target is reached immediately afterwards, so the delay lands on every consumer of that target.

The existing mitigation, `Kind=!dummy` in
mkosi/base/mkosi.extra/etc/systemd/network/80-dhcp.network, addresses a different layer: it stops *networkd* from adopting the link, but cloud-init enumerates links from the kernel directly and is entirely unaffected by networkd's match rules. It is kept — it is still correct — but it was never sufficient on its own.

Fix: add `dummy.numdummies=0` to the guest kernel command line.

Why numdummies=0 rather than the alternatives:

  - vs. dropping CONFIG_DUMMY: the config comment records that Cilium wants the dummy driver available for the host netns reverse-path verification flow. numdummies=0 keeps the capability intact — `ip link add ... type dummy` still works on demand — and only suppresses the pointless boot-time instance. Removing the driver would trade a boot stall for a latent functional regression in a component we do not control.

  - vs. another wait-online drop-in (e.g. shipping our own 10-no-dummy.conf, or --ignore=dummy0): that is a fourth patch on top of a three-layer misconfiguration. netplan's generator writes into /run/systemd/generator.late, which outranks /etc drop-ins by unit-load ordering, so we would be fighting a generator on every boot and the fix would silently break whenever netplan changed its emission. It also leaves the wrong netplan file on disk, so anything else reading 50-cloud-init.yaml still sees a NIC that does not exist.

  - vs. a cloud-init network-config override: heavier, image-wide, and it would have to be kept in sync with the real NIC layout. Deleting the input is strictly simpler than teaching three consumers to ignore it.

Removing the link at the source means cloud-init never sees it, netplan never emits the stanza, and wait-online never gets -i dummy0. One parameter, no per-consumer workarounds.

The dev profile replaces the base cmdline wholesale (it has to, to control console= ordering) rather than appending to it, so the parameter is repeated in mkosi/base/mkosi.profiles/dev/mkosi.conf as well. Without that, dev images alone would keep the stall.

Nothing in the cluster consumes dummy0: `ip -d link show type dummy` lists only that one DOWN device, the Cilium DaemonSet spec makes no reference to dummy interfaces, and Cilium's datapath comes up on cilium_host / cilium_net / cilium_vxlan as usual.

