### PR TITLE
mkosi: restore snapshot.ubuntu.com mirror pins, lint against unpinned mirrors

### DIFF
--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -14,16 +14,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Setup Rust
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
 
       - name: Setup uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
 
       - name: Setup mkosi
-        uses: systemd/mkosi@v26
+        uses: systemd/mkosi@84af20892b61c8e177e391f997ded8b4cb5514f2 # v26
 
       - name: Install build deps (nspawn, TDVF firmware, iasl, cpio)
         # Host deps for `confos build` — keep in lockstep with bin/setup.
@@ -32,13 +32,13 @@ jobs:
           sudo apt-get install -y systemd-container ovmf cpio acpica-tools
 
       - name: Cache kernel tools
-        uses: actions/cache@v5
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: mkosi/kernel-builder/mkosi.tools
           key: ${{ runner.os }}-tools-${{ hashFiles('mkosi/kernel-builder/mkosi.conf') }}
 
       - name: Cache kernel
-        uses: actions/cache@v5
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: output/kernel
           key: ${{ runner.os }}-kernel-${{ hashFiles('mkosi/kernel-builder/{mkosi.conf,mkosi.tools.manifest}','kernel/*') }}
@@ -47,7 +47,7 @@ jobs:
         run: bin/confos kernel
 
       - name: Cache base image tools
-        uses: actions/cache@v5
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: mkosi/base/mkosi.tools
           key: ${{ runner.os }}-tools-${{ hashFiles('mkosi/base/mkosi.conf.d/tools.conf') }}
@@ -56,7 +56,7 @@ jobs:
         run: bin/confos build
 
       - name: Setup ORAS
-        uses: oras-project/setup-oras@v1
+        uses: oras-project/setup-oras@22ce207df3b08e061f537244349aac6ae1d214f6 # v1.2.4
 
       - name: Push to GHCR
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           persist-credentials: false
           submodules: recursive
@@ -66,7 +66,7 @@ jobs:
         shell: bash
         run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.32.0/cargo-dist-installer.sh | sh"
       - name: Cache dist
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: cargo-dist-cache
           path: ~/.cargo/bin/dist
@@ -82,7 +82,7 @@ jobs:
           cat plan-dist-manifest.json
           echo "manifest=$(jq -c "." plan-dist-manifest.json)" >> "$GITHUB_OUTPUT"
       - name: "Upload dist-manifest.json"
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: artifacts-plan-dist-manifest
           path: plan-dist-manifest.json
@@ -116,7 +116,7 @@ jobs:
       - name: enable windows longpaths
         run: |
           git config --global core.longpaths true
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           persist-credentials: false
           submodules: recursive
@@ -131,7 +131,7 @@ jobs:
         run: ${{ matrix.install_dist.run }}
       # Get the dist-manifest
       - name: Fetch local artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: artifacts-*
           path: target/distrib/
@@ -158,7 +158,7 @@ jobs:
 
           cp dist-manifest.json "$BUILD_MANIFEST_NAME"
       - name: "Upload artifacts"
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: artifacts-build-local-${{ join(matrix.targets, '_') }}
           path: |
@@ -175,19 +175,19 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/global-dist-manifest.json
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           persist-credentials: false
           submodules: recursive
       - name: Install cached dist
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: cargo-dist-cache
           path: ~/.cargo/bin/
       - run: chmod +x ~/.cargo/bin/dist
       # Get all the local artifacts for the global tasks to use (for e.g. checksums)
       - name: Fetch local artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: artifacts-*
           path: target/distrib/
@@ -205,7 +205,7 @@ jobs:
 
           cp dist-manifest.json "$BUILD_MANIFEST_NAME"
       - name: "Upload artifacts"
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: artifacts-build-global
           path: |
@@ -225,19 +225,19 @@ jobs:
     outputs:
       val: ${{ steps.host.outputs.manifest }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           persist-credentials: false
           submodules: recursive
       - name: Install cached dist
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: cargo-dist-cache
           path: ~/.cargo/bin/
       - run: chmod +x ~/.cargo/bin/dist
       # Fetch artifacts from scratch-storage
       - name: Fetch artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: artifacts-*
           path: target/distrib/
@@ -250,14 +250,14 @@ jobs:
           cat dist-manifest.json
           echo "manifest=$(jq -c "." dist-manifest.json)" >> "$GITHUB_OUTPUT"
       - name: "Upload dist-manifest.json"
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           # Overwrite the previous copy
           name: artifacts-dist-manifest
           path: dist-manifest.json
       # Create a GitHub Release while uploading all files to it
       - name: "Download GitHub Artifacts"
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: artifacts-*
           path: artifacts
@@ -290,7 +290,7 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           persist-credentials: false
           submodules: recursive

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
           submodules: recursive
@@ -66,7 +66,7 @@ jobs:
         shell: bash
         run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.32.0/cargo-dist-installer.sh | sh"
       - name: Cache dist
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        uses: actions/upload-artifact@v7
         with:
           name: cargo-dist-cache
           path: ~/.cargo/bin/dist
@@ -82,7 +82,7 @@ jobs:
           cat plan-dist-manifest.json
           echo "manifest=$(jq -c "." plan-dist-manifest.json)" >> "$GITHUB_OUTPUT"
       - name: "Upload dist-manifest.json"
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        uses: actions/upload-artifact@v7
         with:
           name: artifacts-plan-dist-manifest
           path: plan-dist-manifest.json
@@ -116,7 +116,7 @@ jobs:
       - name: enable windows longpaths
         run: |
           git config --global core.longpaths true
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
           submodules: recursive
@@ -131,7 +131,7 @@ jobs:
         run: ${{ matrix.install_dist.run }}
       # Get the dist-manifest
       - name: Fetch local artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        uses: actions/download-artifact@v8
         with:
           pattern: artifacts-*
           path: target/distrib/
@@ -158,7 +158,7 @@ jobs:
 
           cp dist-manifest.json "$BUILD_MANIFEST_NAME"
       - name: "Upload artifacts"
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        uses: actions/upload-artifact@v7
         with:
           name: artifacts-build-local-${{ join(matrix.targets, '_') }}
           path: |
@@ -175,19 +175,19 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/global-dist-manifest.json
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
           submodules: recursive
       - name: Install cached dist
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        uses: actions/download-artifact@v8
         with:
           name: cargo-dist-cache
           path: ~/.cargo/bin/
       - run: chmod +x ~/.cargo/bin/dist
       # Get all the local artifacts for the global tasks to use (for e.g. checksums)
       - name: Fetch local artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        uses: actions/download-artifact@v8
         with:
           pattern: artifacts-*
           path: target/distrib/
@@ -205,7 +205,7 @@ jobs:
 
           cp dist-manifest.json "$BUILD_MANIFEST_NAME"
       - name: "Upload artifacts"
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        uses: actions/upload-artifact@v7
         with:
           name: artifacts-build-global
           path: |
@@ -225,19 +225,19 @@ jobs:
     outputs:
       val: ${{ steps.host.outputs.manifest }}
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
           submodules: recursive
       - name: Install cached dist
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        uses: actions/download-artifact@v8
         with:
           name: cargo-dist-cache
           path: ~/.cargo/bin/
       - run: chmod +x ~/.cargo/bin/dist
       # Fetch artifacts from scratch-storage
       - name: Fetch artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        uses: actions/download-artifact@v8
         with:
           pattern: artifacts-*
           path: target/distrib/
@@ -250,14 +250,14 @@ jobs:
           cat dist-manifest.json
           echo "manifest=$(jq -c "." dist-manifest.json)" >> "$GITHUB_OUTPUT"
       - name: "Upload dist-manifest.json"
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        uses: actions/upload-artifact@v7
         with:
           # Overwrite the previous copy
           name: artifacts-dist-manifest
           path: dist-manifest.json
       # Create a GitHub Release while uploading all files to it
       - name: "Download GitHub Artifacts"
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        uses: actions/download-artifact@v8
         with:
           pattern: artifacts-*
           path: artifacts
@@ -290,7 +290,7 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
           submodules: recursive

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,10 +26,10 @@ jobs:
         continue-on-error: ${{ matrix.checks == 'advisories' }}
         steps:
             - name: Check out repo
-              uses: actions/checkout@v6
+              uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
             - name: Install cargo-deny
-              uses: EmbarkStudios/cargo-deny-action@v2
+              uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2.1.1
               with:
                   command: check ${{ matrix.checks }}
 
@@ -38,8 +38,8 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            - uses: actions/checkout@v6
-            - uses: actions-rust-lang/setup-rust-toolchain@v1
+            - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+            - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
               with:
                   components: rustfmt, clippy
             - name: Run linters
@@ -57,19 +57,21 @@ jobs:
                     - ubuntu-24.04-arm # linux-arm
 
         steps:
-            - uses: actions/checkout@v6
-            - uses: actions-rust-lang/setup-rust-toolchain@v1
-            - uses: taiki-e/install-action@nextest
+            - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+            - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
+            - uses: taiki-e/install-action@91ddec75689c4c78665b598d188dc821c5a43e5c # v2.85.9
+              with:
+                tool: nextest
             - run: ./bin/test
 
     build:
         name: Build Confidential OS Builder
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v6
-            - uses: actions-rust-lang/setup-rust-toolchain@v1
+            - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+            - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
             - run: cargo build --release
-            - uses: actions/upload-artifact@v7
+            - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
               with:
                   name: confos
                   path: target/release/confos

--- a/bin/build-c8s
+++ b/bin/build-c8s
@@ -41,9 +41,9 @@
 #                      `confos run` (default 16G — etcd OOMs at the 4G default)
 #   C8S_REF=...        bake the c8s components (nri plugin + the CDS digest in
 #                      the NRI floor) from a specific c8s COMMIT (short SHA)
-#                      instead of the pin in the c8s profile's mkosi.sync.
-#                      mkosi.sync resolves nri-image-policy:<ref>
-#                      and cds:<ref> to digests. The images must be published
+#                      instead of the pin in the c8s profile's mkosi.sync,
+#                      which resolves nri-image-policy:<ref> and cds:<ref> to
+#                      digests. The images must be published
 #                      first (c8s docker.yml on main, or workflow_dispatch for a
 #                      branch). Use to test an unmerged c8s build end-to-end.
 #

--- a/bin/build-c8s
+++ b/bin/build-c8s
@@ -41,7 +41,8 @@
 #                      `confos run` (default 16G — etcd OOMs at the 4G default)
 #   C8S_REF=...        bake the c8s components (nri plugin + the CDS digest in
 #                      the NRI floor) from a specific c8s COMMIT (short SHA)
-#                      instead of main. mkosi.sync resolves nri-image-policy:<ref>
+#                      instead of the pin in the c8s profile's mkosi.sync.
+#                      mkosi.sync resolves nri-image-policy:<ref>
 #                      and cds:<ref> to digests. The images must be published
 #                      first (c8s docker.yml on main, or workflow_dispatch for a
 #                      branch). Use to test an unmerged c8s build end-to-end.

--- a/bin/lint
+++ b/bin/lint
@@ -99,9 +99,22 @@ if ! grep -q 'if ! echo 1 > "$dev/reset"' "$flr_helper"; then
 fi
 
 # Apt mirrors must stay time-pinned to snapshot.ubuntu.com; archive.ubuntu.com drifts daily, making the measurement a function of build date.
+git rev-parse --is-inside-work-tree >/dev/null
 unpinned=$(git grep -nE '^(Mirror|ToolsTreeMirror)=' -- 'mkosi/*.conf' | grep -v 'snapshot\.ubuntu\.com' || true)
 if [ -n "$unpinned" ]; then
     echo "bin/lint: apt mirrors must point at a snapshot.ubuntu.com timestamp:" >&2
     echo "$unpinned" >&2
     exit 1
 fi
+# Presence, not just value: an image that installs packages with no Mirror= (or builds a tools tree with no ToolsTreeMirror=) uses the default drifting archive.ubuntu.com.
+for conf in mkosi/*/mkosi.conf; do
+    dir=$(dirname "$conf")
+    if git grep -qE '^Packages=' -- "$dir/*.conf" && ! git grep -qE '^Mirror=https://snapshot\.ubuntu\.com/' -- "$dir/*.conf"; then
+        echo "bin/lint: $dir installs packages but declares no snapshot.ubuntu.com Mirror= pin" >&2
+        exit 1
+    fi
+    if git grep -qE '^ToolsTree=' -- "$dir/*.conf" && ! git grep -qE '^ToolsTreeMirror=https://snapshot\.ubuntu\.com/' -- "$dir/*.conf"; then
+        echo "bin/lint: $dir builds a tools tree but declares no snapshot.ubuntu.com ToolsTreeMirror= pin" >&2
+        exit 1
+    fi
+done

--- a/bin/lint
+++ b/bin/lint
@@ -97,3 +97,13 @@ if ! grep -q 'if ! echo 1 > "$dev/reset"' "$flr_helper"; then
     echo "bin/lint: $flr_helper must guard the per-GPU reset write (one failed FLR must not abort bring-up)" >&2
     exit 1
 fi
+
+# Every apt mirror must stay time-pinned to snapshot.ubuntu.com; an
+# archive.ubuntu.com mirror drifts daily, making the measurement a function
+# of build date. Outage workarounds must not outlive the outage.
+unpinned=$(grep -rn '^\(Mirror\|ToolsTreeMirror\)=' mkosi --include='*.conf' | grep -v 'snapshot\.ubuntu\.com' || true)
+if [ -n "$unpinned" ]; then
+    echo "bin/lint: apt mirrors must point at a snapshot.ubuntu.com timestamp:" >&2
+    echo "$unpinned" >&2
+    exit 1
+fi

--- a/bin/lint
+++ b/bin/lint
@@ -99,7 +99,7 @@ if ! grep -q 'if ! echo 1 > "$dev/reset"' "$flr_helper"; then
 fi
 
 # Apt mirrors must stay time-pinned to snapshot.ubuntu.com; archive.ubuntu.com drifts daily, making the measurement a function of build date.
-unpinned=$(grep -rn '^\(Mirror\|ToolsTreeMirror\)=' mkosi --include='*.conf' | grep -v 'snapshot\.ubuntu\.com' || true)
+unpinned=$(git grep -nE '^(Mirror|ToolsTreeMirror)=' -- 'mkosi/*.conf' | grep -v 'snapshot\.ubuntu\.com' || true)
 if [ -n "$unpinned" ]; then
     echo "bin/lint: apt mirrors must point at a snapshot.ubuntu.com timestamp:" >&2
     echo "$unpinned" >&2

--- a/bin/lint
+++ b/bin/lint
@@ -98,9 +98,7 @@ if ! grep -q 'if ! echo 1 > "$dev/reset"' "$flr_helper"; then
     exit 1
 fi
 
-# Every apt mirror must stay time-pinned to snapshot.ubuntu.com; an
-# archive.ubuntu.com mirror drifts daily, making the measurement a function
-# of build date. Outage workarounds must not outlive the outage.
+# Apt mirrors must stay time-pinned to snapshot.ubuntu.com; archive.ubuntu.com drifts daily, making the measurement a function of build date.
 unpinned=$(grep -rn '^\(Mirror\|ToolsTreeMirror\)=' mkosi --include='*.conf' | grep -v 'snapshot\.ubuntu\.com' || true)
 if [ -n "$unpinned" ]; then
     echo "bin/lint: apt mirrors must point at a snapshot.ubuntu.com timestamp:" >&2

--- a/docs/REPRODUCIBILITY.md
+++ b/docs/REPRODUCIBILITY.md
@@ -54,11 +54,9 @@ Identical package *versions* across builds are enforced by pinning
 `snapshot.ubuntu.com` URL. Bumping that timestamp is the deliberate act
 that picks up security updates — and changes the roothash.
 
-> **Current status:** as of 2026-07-06 both mirrors are temporarily
-> reverted to the rolling `archive.ubuntu.com` mirror because of a
-> snapshot-service outage (see the `TEMP` comment in each mkosi.conf).
-> Until the pin is restored, package versions — and therefore
-> measurements — can drift between builds.
+`bin/lint` fails on any `Mirror=`/`ToolsTreeMirror=` that does not point
+at `snapshot.ubuntu.com`, so an outage workaround cannot outlive the
+outage.
 
 mkosi itself is pinned to v26 — `bin/setup` and CI install exactly
 `mkosi.git@v26`, and `mkosi.conf` enforces `MinimumVersion=26` as a

--- a/docs/REPRODUCIBILITY.md
+++ b/docs/REPRODUCIBILITY.md
@@ -49,7 +49,8 @@ We use several techniques to ensure the results of our builds are reproducible, 
 ### apt mirror pinning
 
 Identical package *versions* across builds are enforced by pinning
-`Mirror=` (and `ToolsTreeMirror=`) in `mkosi/base/mkosi.conf` and
+`Mirror=` (and `ToolsTreeMirror=`) in `mkosi/base/mkosi.conf`,
+`mkosi/base/mkosi.conf.d/tools.conf`, and
 `mkosi/kernel-builder/mkosi.conf` to a point-in-time
 `snapshot.ubuntu.com` URL. Bumping that timestamp is the deliberate act
 that picks up security updates — and changes the roothash.

--- a/mkosi/base/mkosi.conf
+++ b/mkosi/base/mkosi.conf
@@ -8,8 +8,7 @@ Release=resolute
 Repositories=universe
 # Pin apt mirror to a point-in-time snapshot for reproducible builds.
 # Bump this timestamp deliberately to pick up security updates.
-# TEMP(2026-07-06): snapshot.ubuntu.com outage — undo both mirrors to https://snapshot.ubuntu.com/ubuntu/20260430T000000Z
-Mirror=https://archive.ubuntu.com/ubuntu
+Mirror=https://snapshot.ubuntu.com/ubuntu/20260430T000000Z
 
 [Build]
 EnvironmentFiles=mkosi.env
@@ -17,7 +16,7 @@ Incremental=false
 ToolsTree=default
 ToolsTreeDistribution=ubuntu
 ToolsTreeRelease=resolute
-ToolsTreeMirror=https://archive.ubuntu.com/ubuntu
+ToolsTreeMirror=https://snapshot.ubuntu.com/ubuntu/20260430T000000Z
 
 [Content]
 Bootable=true

--- a/mkosi/base/mkosi.conf
+++ b/mkosi/base/mkosi.conf
@@ -13,10 +13,7 @@ Mirror=https://snapshot.ubuntu.com/ubuntu/20260430T000000Z
 [Build]
 EnvironmentFiles=mkosi.env
 Incremental=false
-ToolsTree=default
-ToolsTreeDistribution=ubuntu
-ToolsTreeRelease=resolute
-ToolsTreeMirror=https://snapshot.ubuntu.com/ubuntu/20260430T000000Z
+# ToolsTree settings live in mkosi.conf.d/tools.conf, which CI hashes for the tools cache key.
 
 [Content]
 Bootable=true

--- a/mkosi/base/mkosi.conf.d/tools.conf
+++ b/mkosi/base/mkosi.conf.d/tools.conf
@@ -2,5 +2,4 @@
 ToolsTree=default
 ToolsTreeDistribution=ubuntu
 ToolsTreeRelease=resolute
-# TEMP(2026-07-06): snapshot.ubuntu.com outage — undo to https://snapshot.ubuntu.com/ubuntu/20260430T000000Z
-ToolsTreeMirror=https://archive.ubuntu.com/ubuntu
+ToolsTreeMirror=https://snapshot.ubuntu.com/ubuntu/20260430T000000Z

--- a/mkosi/base/mkosi.profiles/c8s/mkosi.sync
+++ b/mkosi/base/mkosi.profiles/c8s/mkosi.sync
@@ -24,8 +24,8 @@
 # config-v3.toml.tmpl in this profile's mkosi.extra for why.
 #
 # c8s components (nri plugin binary + the CDS digest in the baked NRI floor)
-# are NOT hardcoded: both resolve from a single c8s ref (C8S_REF, default main)
-# so they always match each other and the images the chart later deploys.
+# are NOT hardcoded: both resolve from a single c8s ref (C8S_REF, default: the
+# pinned commit below) so they always match each other and the chart's images.
 #
 # Downloads are cached under mkosi.pkgcache/c8s/ — that dir survives across
 # builds; mkosi.local does NOT (the confos Rust driver wipes it on build
@@ -47,7 +47,8 @@ RKE2_IMAGES_CILIUM_SHA256="1ab41422cc16f5d030b8f62889133dff5d9dce985fbf13360c160
 # from the images the chart later deploys. C8S_REF pins a specific commit (short
 # SHA) for testing an unmerged build; it arrives via $SRCDIR/mkosi.local/c8s-ref
 # (written by bin/build-c8s — an exported var never reaches this sandbox: mkosi
-# runs under sudo, stripping the env). Empty = main. The tag must be published
+# runs under sudo, stripping the env). Empty = the pinned default below. The
+# tag must be published
 # (c8s docker.yml on main, or workflow_dispatch for a feature branch).
 # The registry the two component images resolve from. Overridable via
 # $SRCDIR/mkosi.local/c8s-registry (written by bin/build-c8s from C8S_REGISTRY)
@@ -58,7 +59,10 @@ C8S_REGISTRY="${C8S_REGISTRY:-ghcr.io/confidential-dot-ai}"
 NRI_REPO="${C8S_REGISTRY}/nri-image-policy"
 CDS_REPO="${C8S_REGISTRY}/cds"
 C8S_REF=$(cat "$SRCDIR/mkosi.local/c8s-ref" 2>/dev/null || true)
-C8S_REF="${C8S_REF:-main}"
+# Default: pinned published c8s commit (short SHA), not `main` — a local
+# build's components and measurement must not drift with c8s HEAD. c8s CI
+# overrides per build via mkosi.local/c8s-ref. Bump alongside chart pins.
+C8S_REF="${C8S_REF:-3cb601e}"
 echo "c8s sync: resolving nri-image-policy + cds at c8s ref ${C8S_REF}"
 resolve_digest() {  # <repo> <ref> -> prints sha256:... or FATALs
     local d

--- a/mkosi/base/mkosi.profiles/c8s/mkosi.sync
+++ b/mkosi/base/mkosi.profiles/c8s/mkosi.sync
@@ -48,8 +48,8 @@ RKE2_IMAGES_CILIUM_SHA256="1ab41422cc16f5d030b8f62889133dff5d9dce985fbf13360c160
 # SHA) for testing an unmerged build; it arrives via $SRCDIR/mkosi.local/c8s-ref
 # (written by bin/build-c8s — an exported var never reaches this sandbox: mkosi
 # runs under sudo, stripping the env). Empty = the pinned default below. The
-# tag must be published
-# (c8s docker.yml on main, or workflow_dispatch for a feature branch).
+# tag must be published (c8s docker.yml on main, or workflow_dispatch for a
+# feature branch).
 # The registry the two component images resolve from. Overridable via
 # $SRCDIR/mkosi.local/c8s-registry (written by bin/build-c8s from C8S_REGISTRY)
 # so an unmerged or air-gapped build can bake components from a local registry

--- a/mkosi/base/mkosi.profiles/c8s/mkosi.sync
+++ b/mkosi/base/mkosi.profiles/c8s/mkosi.sync
@@ -59,9 +59,7 @@ C8S_REGISTRY="${C8S_REGISTRY:-ghcr.io/confidential-dot-ai}"
 NRI_REPO="${C8S_REGISTRY}/nri-image-policy"
 CDS_REPO="${C8S_REGISTRY}/cds"
 C8S_REF=$(cat "$SRCDIR/mkosi.local/c8s-ref" 2>/dev/null || true)
-# Default: pinned published c8s commit (short SHA), not `main` — a local
-# build's components and measurement must not drift with c8s HEAD. c8s CI
-# overrides per build via mkosi.local/c8s-ref. Bump alongside chart pins.
+# Pinned published c8s commit, not `main` — a local build must not drift with c8s HEAD; bump alongside chart pins.
 C8S_REF="${C8S_REF:-3cb601e}"
 echo "c8s sync: resolving nri-image-policy + cds at c8s ref ${C8S_REF}"
 resolve_digest() {  # <repo> <ref> -> prints sha256:... or FATALs

--- a/mkosi/base/mkosi.profiles/c8s/mkosi.sync
+++ b/mkosi/base/mkosi.profiles/c8s/mkosi.sync
@@ -59,8 +59,8 @@ C8S_REGISTRY="${C8S_REGISTRY:-ghcr.io/confidential-dot-ai}"
 NRI_REPO="${C8S_REGISTRY}/nri-image-policy"
 CDS_REPO="${C8S_REGISTRY}/cds"
 C8S_REF=$(cat "$SRCDIR/mkosi.local/c8s-ref" 2>/dev/null || true)
-# Pinned published c8s commit, not `main` — a local build must not drift with c8s HEAD; bump alongside chart pins.
-C8S_REF="${C8S_REF:-3cb601e}"
+# Pinned published c8s commit matching the deployed CLI/node release (confidential-metal c8s_operator role, c8s#177 branch head); re-pin to main once #177 merges.
+C8S_REF="${C8S_REF:-3a2517b}"
 echo "c8s sync: resolving nri-image-policy + cds at c8s ref ${C8S_REF}"
 resolve_digest() {  # <repo> <ref> -> prints sha256:... or FATALs
     local d

--- a/mkosi/initrd/mkosi.conf
+++ b/mkosi/initrd/mkosi.conf
@@ -2,6 +2,8 @@
 Architecture=x86-64
 Distribution=ubuntu
 Release=resolute
+# Pin apt mirror to a point-in-time snapshot for reproducible builds; bump deliberately (moves the initrd bytes).
+Mirror=https://snapshot.ubuntu.com/ubuntu/20260430T000000Z
 
 [Content]
 Bootable=false

--- a/mkosi/kernel-builder/mkosi.conf
+++ b/mkosi/kernel-builder/mkosi.conf
@@ -6,15 +6,14 @@ Architecture=x86-64
 Distribution=ubuntu
 Release=resolute
 Repositories=universe
-# TEMP(2026-07-06): snapshot.ubuntu.com outage — undo both mirrors to https://snapshot.ubuntu.com/ubuntu/20260405T000000Z
-Mirror=https://archive.ubuntu.com/ubuntu
+Mirror=https://snapshot.ubuntu.com/ubuntu/20260405T000000Z
 
 [Build]
 Incremental=false
 ToolsTree=default
 ToolsTreeDistribution=ubuntu
 ToolsTreeRelease=resolute
-ToolsTreeMirror=https://archive.ubuntu.com/ubuntu
+ToolsTreeMirror=https://snapshot.ubuntu.com/ubuntu/20260405T000000Z
 
 [Content]
 Bootable=false


### PR DESCRIPTION
Reverts the TEMP(2026-07-06) outage workaround in all three mkosi configs (base + tools 20260430T000000Z, kernel-builder 20260405T000000Z; both timestamps verified serving resolute), and pins the verity initrd — which had no `Mirror=` at all and silently built from drifting archive.ubuntu.com — to the base snapshot. bin/lint now fails on any non-snapshot Mirror/ToolsTreeMirror *and* on any package-installing image dir that declares no snapshot pin (presence, not just value).

Also pins the remaining mutable references:

- c8s profile: the default `C8S_REF` is now `3a2517b` — the release the baremetal deployment runs (confidential-metal `c8s_operator` role: CLI and node image, confidential-dot-ai/c8s#177 branch head; both component images verified published) — instead of the mutable `:main` tag, so a local build's baked CDS floor matches the deployed CLI. Re-pin to a main revision once confidential-dot-ai/c8s#177 merges. CI still overrides per build via `mkosi.local/c8s-ref`.
- ci: workflow actions in `base.yml` and `test.yml` sha-pinned to the commit each `@vN` tag currently resolves to (all 10 SHAs verified against the tags they claim). `release.yml` stays as cargo-dist generates it — `dist plan` fails on hand-edits and `dist generate` would silently drop them.

Cleanup along the way: the base ToolsTree block is single-sourced in `mkosi.conf.d/tools.conf` (the file CI's tools cache key hashes — previously duplicated in `mkosi.conf`, so a one-sided bump served a stale cached tools tree), and the mirror lint uses `git grep` over tracked configs instead of a recursive grep that walked multi-GB build caches.

Note: this merge changes no published artifact by itself — every consumer pins confos by commit (c8s `c8s-image.yml` and `kata-guest-base.yml` via `CONFOS_REF`, confidential-metal's `c8s_operator` role via `confos_source_revision`), and both current c8s pins (v0.2.0 and 92a0763) predate this fix. When a consumer next bumps its pin past this merge, its build draws from the restored snapshots (plus the newly pinned initrd) and its measurement rolls once to a new value; there is no pre-outage measurement to return to, since every build after 2026-07-06 used the drifting archive mirror.
