### PR TITLE
release: v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,35 @@ build configs, since those invalidate published reference values.
 
 ## [Unreleased]
 
+## [0.3.0] — 2026-08-07
+
+### Added
+- GPU confos profile (#68)
+- `bin/lint` gates apt mirrors: every mirror must be a time-pinned
+  `snapshot.ubuntu.com` URL, and every package-installing image (and
+  configured tools tree) must declare one — an outage workaround can no
+  longer outlive the outage (#79)
+
+### Changed
+- **Changes measurements.** Apt mirrors re-pinned to `snapshot.ubuntu.com`
+  (base + tools `20260430T000000Z`, kernel-builder `20260405T000000Z`),
+  removing the TEMP(2026-07-06) `archive.ubuntu.com` outage workaround, and
+  the verity initrd — previously never mirror-pinned — now builds from the
+  base snapshot. The next build of an otherwise-unchanged config rolls its
+  measurement once, after which rebuilds stop drifting with build date (#79)
+- c8s profile: default `C8S_REF` is the pinned published c8s commit
+  `3a2517b` (the deployed release) instead of tracking `main`; CI still
+  overrides per build (#79)
+
+### Fixed
+- GPU: udev probe held until FLR completes (#76); slow or degraded GPU
+  bring-up no longer fails boot (#77)
+- attestation-api: per-GPU nvidia char devices allowed (#73)
+- c8s profile: node-image admission inventory and a reproducible GPU
+  module build (#74); nested cluster networking kept reachable (#75)
+- Boot: 120s wait-online stall from the phantom `dummy0` link (#78)
+- Build manifests record the `image.raw` checksum (#55)
+
 ## [0.2.0] — 2026-07-13
 
 **Steep is renamed to ConfidentialOS Builder**
@@ -56,7 +85,8 @@ Initial public release.
 - `steep push` / `steep pull` (OCI via oras)
 - CI publishes base image as `ghcr.io/confidential-dot-ai/steep:base`
 
-[Unreleased]: https://github.com/confidential-dot-ai/confidential-os-builder/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/confidential-dot-ai/confidential-os-builder/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/confidential-dot-ai/confidential-os-builder/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/confidential-dot-ai/confidential-os-builder/compare/v0.1.1...v0.2.0
 [0.1.1]: https://github.com/confidential-dot-ai/confidential-os-builder/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/confidential-dot-ai/confidential-os-builder/releases/tag/v0.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -245,7 +245,7 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "confos"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "confos"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "Confidential VM image builder for AMD SEV-SNP and Intel TDX"


### PR DESCRIPTION
Bumps the crate to 0.3.0 and cuts the changelog from Unreleased, covering everything since v0.2.0: the GPU confos profile (#68), GPU bring-up/FLR/attestation-api fixes (#73–#77), the dummy0 boot-stall and image.raw manifest fixes (#78, #55), c8s CI taking ownership of the node-image build (#69), and the snapshot-mirror re-pins + presence-based mirror lint (#79 — flagged in the changelog as measurement-changing, per docs/VERSIONING.md).

After merge, tagging the merge commit `v0.3.0` triggers release.yml (cargo-dist) to build and publish the release — the tag must match the crate version, which is why this PR must land first. Once the release exists, c8s can bump both its `CONFOS_REF` pins (`c8s-image.yml`, `kata-guest-base.yml`) to the release commit.