### PR TITLE
refactor(cli): one KernelInputs group instead of per-subcommand copies

### DIFF
--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -171,12 +171,7 @@ pub fn run(args: &BuildArgs) -> anyhow::Result<()> {
 
     // Phase 1: ensure custom kernel artifact is current
     println!("\n=== Step 1/4: Ensuring custom kernel ===");
-    let kernel = kernel_cache::ensure_kernel(
-        false,
-        args.kernel_config_fragment.clone(),
-        args.module_signing_cert.clone(),
-        args.kernel_builder_package.clone(),
-    )?;
+    let kernel = kernel_cache::ensure_kernel(false, args.kernel_inputs.clone())?;
     println!(
         "kernel: {} (linux {})",
         kernel.vmlinuz_path.display(),

--- a/src/commands/kernel.rs
+++ b/src/commands/kernel.rs
@@ -40,13 +40,17 @@ pub fn run(args: &KernelArgs) -> Result<()> {
 
     // Optional caller-supplied config fragment merged after required +
     // hardening. No flag = confos's bare required + hardening baseline.
-    let fragment = args.kernel_config_fragment.as_deref();
+    let fragment = args.kernel_inputs.kernel_config_fragment.as_deref();
     // Caller's certificate, else the committed default (see
     // DEFAULT_SIGNING_CERT). Always resolves to something, so every build
     // that enables module signing has a trust anchor without the caller
     // arranging one.
     let default_cert = PathBuf::from(DEFAULT_SIGNING_CERT);
-    let signing_cert = args.module_signing_cert.as_deref().unwrap_or(&default_cert);
+    let signing_cert = args
+        .kernel_inputs
+        .module_signing_cert
+        .as_deref()
+        .unwrap_or(&default_cert);
     let snapshot = Path::new(SNAPSHOT_PATH);
 
     fs_err::create_dir_all(&args.output)?;
@@ -85,7 +89,7 @@ pub fn run(args: &KernelArgs) -> Result<()> {
 
     // Phase 0a: ensure tools tree
     println!("\n=== Step 0a: Ensuring kernel-builder tools tree (mkosi) ===");
-    let tools_tree = ensure_tools_tree(args.force, &args.kernel_builder_package)?;
+    let tools_tree = ensure_tools_tree(args.force, &args.kernel_inputs.kernel_builder_package)?;
 
     // Phase 0b: fetch tarball
     println!("\n=== Step 0b: Fetching kernel tarball ===");

--- a/src/kernel_cache.rs
+++ b/src/kernel_cache.rs
@@ -10,7 +10,7 @@ use anyhow::{anyhow, Result};
 
 use crate::commands;
 use crate::kernel::manifest as km;
-use crate::KernelArgs;
+use crate::{KernelArgs, KernelInputs};
 
 const KERNEL_OUT_DIR: &str = "output/kernel";
 
@@ -25,20 +25,13 @@ pub struct KernelArtifact {
 ///
 /// `fragment` is the caller-supplied `--kernel-config-fragment`, threaded
 /// from `confos build`.
-pub fn ensure_kernel(
-    force: bool,
-    fragment: Option<PathBuf>,
-    module_signing_cert: Option<PathBuf>,
-    kernel_builder_package: Vec<String>,
-) -> Result<KernelArtifact> {
-    require_inputs_exist(fragment.as_deref(), module_signing_cert.as_deref())?;
+pub fn ensure_kernel(force: bool, inputs: KernelInputs) -> Result<KernelArtifact> {
+    require_inputs_exist(&inputs)?;
 
     commands::kernel::run(&KernelArgs {
         force,
         output: PathBuf::from(KERNEL_OUT_DIR),
-        kernel_config_fragment: fragment,
-        module_signing_cert,
-        kernel_builder_package,
+        kernel_inputs: inputs,
     })?;
 
     let manifest_path = Path::new(KERNEL_OUT_DIR).join("manifest.json");
@@ -51,8 +44,9 @@ pub fn ensure_kernel(
     })
 }
 
-fn require_inputs_exist(fragment: Option<&Path>, signing_cert: Option<&Path>) -> Result<()> {
-    if let Some(c) = signing_cert {
+fn require_inputs_exist(inputs: &KernelInputs) -> Result<()> {
+    let fragment = inputs.kernel_config_fragment.as_deref();
+    if let Some(c) = inputs.module_signing_cert.as_deref() {
         if !c.is_file() {
             anyhow::bail!("--module-signing-cert path not found: {}", c.display());
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,16 +30,11 @@ impl BuildPlatform {
     }
 }
 
-#[derive(clap::Args)]
-pub struct KernelArgs {
-    /// Force rebuild even if cache is current
-    #[arg(short, long)]
-    pub force: bool,
-
-    /// Output directory.
-    #[arg(short, long, default_value = "output/kernel")]
-    pub output: PathBuf,
-
+/// Inputs to the kernel build, shared by `confos kernel` and `confos build`
+/// (which runs the kernel step itself). One struct so a new kernel input is
+/// declared once instead of in both subcommands.
+#[derive(clap::Args, Clone, Default)]
+pub struct KernelInputs {
     /// Optional kernel config fragment, merged after required + hardening.
     /// Omitted: confos builds only its hardened required + hardening baseline.
     /// Lets a project enable extra kernel symbols without modifying confos.
@@ -64,6 +59,20 @@ pub struct KernelArgs {
         value_delimiter = ','
     )]
     pub kernel_builder_package: Vec<String>,
+}
+
+#[derive(clap::Args)]
+pub struct KernelArgs {
+    /// Force rebuild even if cache is current
+    #[arg(short, long)]
+    pub force: bool,
+
+    /// Output directory.
+    #[arg(short, long, default_value = "output/kernel")]
+    pub output: PathBuf,
+
+    #[command(flatten)]
+    pub kernel_inputs: KernelInputs,
 }
 
 #[derive(clap::Args)]
@@ -122,26 +131,8 @@ pub struct BuildArgs {
     /// comma-separated. Use for build-time tools a fragment needs — e.g.
     /// `dwarves` (pahole) when the fragment enables CONFIG_DEBUG_INFO_BTF.
     /// Twin of `--package`, routed to the kernel-builder mkosi run.
-    #[arg(
-        long = "kernel-builder-package",
-        value_name = "PKG",
-        value_delimiter = ','
-    )]
-    pub kernel_builder_package: Vec<String>,
-
-    /// Optional kernel config fragment, merged after required + hardening
-    /// when building the custom kernel. Omitted: confos's hardened baseline.
-    #[arg(long, value_name = "PATH")]
-    pub kernel_config_fragment: Option<PathBuf>,
-
-    /// X.509 certificate (PEM) of the key that will sign out-of-tree
-    /// modules, overriding the committed default
-    /// (`kernel/module-signing.crt`). Built into the kernel's system
-    /// keyring, so modules signed with the matching private key load under
-    /// lockdown — and so changing it changes the measurement. Pass this only
-    /// to sign with your own key. See docs/module-signing.md.
-    #[arg(long, value_name = "PATH")]
-    pub module_signing_cert: Option<PathBuf>,
+    #[command(flatten)]
+    pub kernel_inputs: KernelInputs,
 
     /// Path to a post-install script to run during the build. Passed through
     /// to mkosi as --postinst-script, with --with-network=yes so the script


### PR DESCRIPTION
Follow-up to #86, **based on that branch** (retarget to `main` once it merges).

`confos kernel` and `confos build` are separate clap subcommands, and `build` runs the kernel step itself, so every kernel input has to be declared on both. `kernel_config_fragment` and `kernel_builder_package` already carried that duplication; `--module-signing-cert` made it three, and `ensure_kernel` had grown to four positional args threading them through.

This flattens the three into a shared `KernelInputs` (`#[command(flatten)]` on both structs) and passes the group as one value. Cost of the next kernel input drops from five edits — two arg declarations, a positional parameter, two call sites — to one field.

**No behaviour change, and specifically no CLI change:** verified `confos kernel --help` and `confos build --help` still expose `--kernel-config-fragment`, `--module-signing-cert`, and `--kernel-builder-package` exactly as before. 95 tests + lint green.

Kept deliberately narrow: this is the internal-plumbing half of what the cleanup review raised. The larger idea it also floated — a `--kernel-input-dir` that carries the fragment, certificate, and future inputs as one consumer-owned directory — is a genuine interface change and belongs after c8s#264's migration settles, not stacked under it.