### PR TITLE
refactor(gpu)!: finish the steep rename — scripts, stamps, prose (#88)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ build configs, since those invalidate published reference values.
 
 ## [Unreleased]
 
+### Changed
+- **Changes measurements (once, GPU images).** The steep → confos rename is
+  finished (#88): `bin/steep-fetch-{gpu,attest-gpu}` are now
+  `bin/confos-fetch-{gpu,attest-gpu}`, and the NVIDIA module build stamps
+  `KBUILD_BUILD_USER`/`KBUILD_BUILD_HOST` change `steep` → `confos`, matching
+  the kernel's own stamps at last — the stamps are baked into the module
+  bytes, so the rootfs and RTMR[2] roll once alongside this release's other
+  measurement changes. Historical changelog entries keep the old name
+
 ### Removed
 - The `c8s` mkosi profile, `bin/build-c8s`, and the `c8s`/`c8s-dev`
   kernel fragments: the node-image definition now lives in the c8s repo

--- a/bin/confos-fetch-attest-gpu
+++ b/bin/confos-fetch-attest-gpu
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# steep-fetch-attest-gpu — stage the GPU-capable attestation-api binary +
+# confos-fetch-attest-gpu — stage the GPU-capable attestation-api binary +
 # NVIDIA libnvat (and libnvat's versioned ICU deps) into mkosi.local for the
 # `attest-gpu` profile, WITHOUT going through GHCR.
 #
@@ -7,12 +7,12 @@
 # attestation-rs `-gpu` OCI image is published. The production path is the
 # profile's mkosi.sync pulling that pinned image by digest; this helper just
 # pre-stages the same content so mkosi.sync's pre-staged escape hatch skips the
-# pull. Run it AFTER steep-fetch-gpu and BEFORE `steep build ... --profile
+# pull. Run it AFTER confos-fetch-gpu and BEFORE `confos build ... --profile
 # gpu --profile attest-gpu` (build.rs wipes mkosi.local on exit, so all staging
 # must precede one build).
 #
 # Why we bundle libnvat's ICU: libnvat dynamically links a *versioned* libicu
-# soname (e.g. libicuuc.so.74) fixed at ITS build time. steep's guest base may
+# soname (e.g. libicuuc.so.74) fixed at ITS build time. confos's guest base may
 # ship a different ICU major (resolute → 76). Bundling the exact libicu*.so.NN
 # libnvat needs lets it load regardless of the base's ICU; the sonames differ so
 # they coexist. libxml2.so.2 / libstdc++.so.6 have stable sonames and come from
@@ -29,7 +29,7 @@ ATTEST_GPU_BIN="${ATTEST_GPU_BIN:-../attestation-rs/target/release/attestation-a
 LIBNVAT="${LIBNVAT:-/usr/lib/x86_64-linux-gnu/libnvat.so.1.2.0}"
 STAGE="mkosi/base/mkosi.local/mkosi.extra"
 
-die() { printf 'steep-fetch-attest-gpu: %s\n' "$*" >&2; exit 1; }
+die() { printf 'confos-fetch-attest-gpu: %s\n' "$*" >&2; exit 1; }
 
 [[ -f "$ATTEST_GPU_BIN" ]] || die "attestation-api-gpu binary not found at $ATTEST_GPU_BIN (set ATTEST_GPU_BIN)."
 [[ -f "$LIBNVAT" ]] || die "libnvat not found at $LIBNVAT (set LIBNVAT; build per tdx-checkpoints/026)."
@@ -48,7 +48,7 @@ install -m0755 "$LIBNVAT" "$LIBDIR/$soname"
 ln -sf "$soname" "$LIBDIR/libnvat.so.1"
 ln -sf "libnvat.so.1" "$LIBDIR/libnvat.so"
 
-# Bundle libnvat's deps that the steep base doesn't ship at a matching soname:
+# Bundle libnvat's deps that the confos base doesn't ship at a matching soname:
 # libicu*.so.NN (versioned major differs across distros) and libxml2.so.2
 # (resolute has no `libxml2` apt package, and its own build drags the same
 # versioned ICU). Everything else libnvat needs — libz, liblzma, libstdc++,
@@ -62,4 +62,4 @@ for lib in $(ldd "$LIBNVAT" 2>/dev/null | awk '/libicu|libxml2/{print $3}'); do
     echo "  bundled $b"
 done
 
-echo "steep-fetch-attest-gpu done — staged under $STAGE"
+echo "confos-fetch-attest-gpu done — staged under $STAGE"

--- a/bin/confos-fetch-gpu
+++ b/bin/confos-fetch-gpu
@@ -1,21 +1,21 @@
 #!/usr/bin/env bash
-# steep-fetch-gpu — build + sign the NVIDIA kernel modules and stage the
+# confos-fetch-gpu — build + sign the NVIDIA kernel modules and stage the
 # GPU userspace into mkosi.local/ for the `gpu` profile.
 #
-# Runs on the HOST, AFTER `steep kernel --kernel-config-fragment kernel/gpu.config`
-# and BEFORE `steep build ... --profile gpu`. The `build-gpu` Make target
+# Runs on the HOST, AFTER `confos kernel --kernel-config-fragment kernel/gpu.config`
+# and BEFORE `confos build ... --profile gpu`. The `build-gpu` Make target
 # chains all three. See docs/GPU-IMAGE-PLAN.md ("Build sequencing").
 #
 # Why a separate host-side step and not a mkosi.sync hook (like `attest`):
 # the NVIDIA modules must be compiled against the *built* kernel tree with the
-# *same toolchain* steep used to build the kernel — that tree
+# *same toolchain* confos used to build the kernel — that tree
 # (output/kernel/build/linux-<ver>, with Module.symvers + certs/signing_key.*)
 # and that toolchain (the kernel-builder mkosi tools tree) only exist here,
 # not inside the base-image mkosi sandbox. Downloads are cached under
 # output/gpu/cache so repeat builds don't re-pull the 400 MB driver.
 #
 # Everything this stages lands in mkosi/base/mkosi.local/mkosi.extra/, which
-# steep's build.rs deliberately does NOT wipe at build start, so it survives
+# confos's build.rs deliberately does NOT wipe at build start, so it survives
 # into the mkosi run and gets copied into the dm-verity root (measured).
 
 set -euo pipefail
@@ -56,7 +56,7 @@ readonly WORK="output/gpu/work"
 readonly WANT_MODULES=(nvidia.ko nvidia-uvm.ko)
 
 log() { printf '\n=== %s ===\n' "$*"; }
-die() { printf 'steep-fetch-gpu: %s\n' "$*" >&2; exit 1; }
+die() { printf 'confos-fetch-gpu: %s\n' "$*" >&2; exit 1; }
 
 # --- Preconditions ------------------------------------------------------------
 [[ "$OGKM_SHA256" == FILL_* || "$RUN_SHA256" == FILL_* ]] && \
@@ -66,7 +66,7 @@ KVER="$(sed -n 's/^LINUX_VERSION=//p' kernel/version)"
 [[ -n "$KVER" ]] || die "could not read LINUX_VERSION from kernel/version"
 readonly KTREE="${KERNEL_OUT}/build/linux-${KVER}"
 
-[[ -d "$KTREE" ]] || die "kernel tree $KTREE missing — run 'steep kernel --kernel-config-fragment kernel/gpu.config' first."
+[[ -d "$KTREE" ]] || die "kernel tree $KTREE missing — run 'confos kernel --kernel-config-fragment kernel/gpu.config' first."
 grep -qx 'CONFIG_MODULES=y' "$KTREE/.config" || \
   die "kernel at $KTREE was built WITHOUT CONFIG_MODULES=y — rebuild with --kernel-config-fragment kernel/gpu.config."
 # `make bzImage` emits vmlinux.symvers; Module.symvers is only created by
@@ -106,7 +106,7 @@ cert_pub="$(openssl x509 -in "$MODULE_SIG_CERT" -pubkey -noout 2>/dev/null)" || 
 [[ "$key_pub" == "$cert_pub" ]] || \
   die "signing key does not match $MODULE_SIG_CERT — modules signed with it would be rejected at boot."
 [[ -x "$KTREE/scripts/sign-file" ]] || die "$KTREE/scripts/sign-file missing — cannot sign modules."
-[[ -d "$TOOLS_TREE" ]] || die "kernel-builder tools tree $TOOLS_TREE missing — run 'steep kernel' first."
+[[ -d "$TOOLS_TREE" ]] || die "kernel-builder tools tree $TOOLS_TREE missing — run 'confos kernel' first."
 command -v systemd-nspawn >/dev/null || die "systemd-nspawn required (apt install systemd-container)."
 command -v depmod >/dev/null || die "depmod required (apt install kmod)."
 
@@ -137,7 +137,7 @@ rm -rf "$WORK/ogkm" 2>/dev/null || sudo rm -rf "$WORK/ogkm"
 mkdir -p "$WORK/ogkm"
 tar -xzf "$CACHE/ogkm-${NV_VERSION}.tar.gz" -C "$WORK/ogkm" --strip-components=1
 
-# Build inside the SAME nspawn tools tree steep compiled the kernel in, so the
+# Build inside the SAME nspawn tools tree confos compiled the kernel in, so the
 # module objects are ABI-compatible (gcc/binutils versions match). Pin the
 # reproducibility env exactly as src/kernel/compile.rs does.
 KTREE_ABS="$(cd "$KTREE" && pwd)"
@@ -153,8 +153,8 @@ sudo systemd-nspawn --quiet --register=no --keep-unit --ephemeral \
   --bind "${OGKM_ABS}:/nv" \
   --setenv SOURCE_DATE_EPOCH=0 \
   --setenv KBUILD_BUILD_TIMESTAMP=@0 \
-  --setenv KBUILD_BUILD_USER=steep \
-  --setenv KBUILD_BUILD_HOST=steep \
+  --setenv KBUILD_BUILD_USER=confos \
+  --setenv KBUILD_BUILD_HOST=confos \
   /bin/bash -c "set -eux
     # OOT module builds read Module.symvers; \`make bzImage\` only left
     # vmlinux.symvers. MODVERSIONS is off, so derive the former from the latter.
@@ -201,7 +201,7 @@ done
 # (offline) using the kernel tree's own module ordering.
 log "Running depmod over the staged module tree"
 # depmod -b searches <basedir>/lib/modules, but we stage under usr/lib/modules
-# (matching where steep's build.rs puts vmlinuz). Bridge with a temporary
+# (matching where confos's build.rs puts vmlinuz). Bridge with a temporary
 # lib -> usr/lib symlink (which mirrors the image's own usrmerge), run depmod
 # so modules.dep lands in usr/lib/modules/<ver>, then drop the symlink so we
 # don't ship a /lib symlink via mkosi.extra.
@@ -293,4 +293,4 @@ for b in nvidia-ctk nvidia-cdi-hook; do
 done
 rm -rf "$WORK/tk"
 
-log "steep-fetch-gpu done — modules + userspace staged under $STAGE"
+log "confos-fetch-gpu done — modules + userspace staged under $STAGE"

--- a/docs/GPU-CC-OPERATIONS.md
+++ b/docs/GPU-CC-OPERATIONS.md
@@ -46,7 +46,7 @@ found`. It is **silent at 1 GPU and racy at 8** (the old modules-load ordering
 recovered 5/8 and left 3 stuck) — which is why it slipped past single-GPU
 validation. Enforced in `etc/modprobe.d/nvidia-flr-first.conf` +
 `usr/local/bin/nvidia-gpu-flr` + `nvidia-persistenced.service` +
-`bin/steep-fetch-gpu` (stages libnvidia-cfg).
+`bin/confos-fetch-gpu` (stages libnvidia-cfg).
 
 The host-side FLR that vfio does at VM-open does NOT satisfy this by the time
 the guest driver attaches — the reset must happen *inside* the guest.
@@ -54,7 +54,7 @@ the guest driver attaches — the reset must happen *inside* the guest.
 ## 2. SPDM needs the kernel crypto API (LKCA)
 
 The driver's SPDM stack links the Linux Kernel Crypto API (ECC/ECDH/ECDSA/KPP).
-steep's minimal kernel lacked them, so the driver built libspdm against *stubs*
+confos's minimal kernel lacked them, so the driver built libspdm against *stubs*
 and CC init failed: `libspdm expects LKCA but found stubs!`. Fixed by
 `CONFIG_CRYPTO_ECC/ECDH/ECDSA/KPP=y` in `kernel/gpu.config`. Only visible with a
 real GPU (the GPU-less boot never reaches SPDM).
@@ -85,7 +85,7 @@ Also: guest RAM must avoid the low PCI window — `-m 32G` collides at exactly
 
 ## 4. Quote path — vsock (fast), not ConfigFS-TSM (slow)
 
-steep's kernel dropped vsock for hardening; ConfigFS-TSM
+confos's kernel dropped vsock for hardening; ConfigFS-TSM
 (`/sys/kernel/config/tsm/report`) works but is ~1 s+/quote. Re-enabled
 `CONFIG_VSOCKETS + CONFIG_VIRTIO_VSOCKETS` (`kernel/gpu.config`) and set
 `tdx_quote_method = "vsock"`: the attestation service reaches the host QGS at
@@ -144,5 +144,5 @@ teardown. Aperture is NOT the limiter at 8 — KubeVirt's virt-launcher maps 8×
 - [x] vsock — `autoattachVSOCK` (confai) + `VSOCK` gate (KubeVirt CR).
 - [x] 8-GPU FLR ordering + session retention — fixed (FLR-before-modprobe + wait-for-all-bound); all 8 attest.
 - [ ] Publish `attestation-api-gpu` (Dockerfile.gpu) + pin its digest in
-      `attest-gpu/mkosi.sync` (currently pre-staged via `steep-fetch-attest-gpu`).
+      `attest-gpu/mkosi.sync` (currently pre-staged via `confos-fetch-attest-gpu`).
 - [ ] Guest time source (NTP or host-time) so in-guest `/verify` isn't skewed.

--- a/docs/GPU-IMAGE-PLAN.md
+++ b/docs/GPU-IMAGE-PLAN.md
@@ -1,12 +1,12 @@
 # GPU base image plan (`gpu` profile)
 
 Status: **in progress** on `feat/gpu-profile`. This document is the design of
-record for baking an attestable NVIDIA GPU confidential-VM image with steep.
+record for baking an attestable NVIDIA GPU confidential-VM image with confos.
 
 ## Goal
 
 One published, measured, attestable TDX GPU base image —
-`ghcr.io/confidential-dot-ai/steep/gpu-base` — that:
+`ghcr.io/confidential-dot-ai/confidential-os-builder/gpu-base` — that:
 
 - confai/KubeVirt imports via CDI (the same `--cdi` single-layer path the
   CPU-only `tdx-cpu-image-cdi` already uses),
@@ -15,9 +15,9 @@ One published, measured, attestable TDX GPU base image —
   (no in-guest driver install, no DKMS, no network),
 - serves nonce-bound TDX **and** per-GPU SPDM attestation evidence on `:8400`.
 
-The whole thing rides steep's existing extension points — a kernel config
+The whole thing rides confos's existing extension points — a kernel config
 fragment plus mkosi profiles — with the single genuinely new piece being an
-out-of-tree kernel-module build step (`bin/steep-fetch-gpu`).
+out-of-tree kernel-module build step (`bin/confos-fetch-gpu`).
 
 ## Why baked, not runtime-installed
 
@@ -40,10 +40,10 @@ aggregate time.
 
 | # | Decision | Rationale |
 |---|----------|-----------|
-| D1 | Ship **`kernel/gpu.config`** as a steep in-repo fragment, wired through the `build-gpu` Make target via `--kernel-config-fragment`. | GPU is a first-class steep product; one kernel lineage, one auditable fragment diff. |
+| D1 | Ship **`kernel/gpu.config`** as a confos in-repo fragment, wired through the `build-gpu` Make target via `--kernel-config-fragment`. | GPU is a first-class confos product; one kernel lineage, one auditable fragment diff. |
 | D2 | **Bump the guest kernel 6.12.94 → 6.16.12** (already validated on `feat/kernel-6.16-tdx-rtmr`, folded into this branch). | 6.16 exposes the TDX RTMR-extend sysfs (`/sys/.../tdx_guest/measurements/rtmrN`) for runtime per-workload measurement, and the working B200 CC guest runs 6.17-generic with driver 595.71.05 — so 595 builds cleanly at ≤6.17. 6.16.12 is comfortably inside that window; going to 6.18 risks NVIDIA-595 driver-build breakage for no benefit a regularly-rebuilt base image needs. |
-| D3 | `gpu.config` = **`CONFIG_MODULES=y` + `MODULE_SIG*`** and nothing more (the symbols NVIDIA needs — `MMU_NOTIFIER`, `X86_PAT`, `MTRR`, `FW_LOADER`, `DMA_SHARED_BUFFER` — already resolve `=y`). steep's `mod2yesconfig` keeps every in-tree driver built-in, so the **only** loadable modules in the system are the two signed NVIDIA ones. | Minimal, auditable hardening delta; monolithic posture preserved. |
-| D4 | **Integrity = dm-verity, not a signing PKI.** Modules are signed only because lockdown-confidentiality refuses to load unsigned modules. The kernel builds in a **public certificate** — confos's committed default, or the caller's via `--module-signing-cert` — through `SYSTEM_TRUSTED_KEYS`; the **private key never enters this repo or the kernel build** — `MODULE_SIG_ALL` is off (nothing in-tree needs signing after `mod2yesconfig`), and `steep-fetch-gpu` signs the two NVIDIA modules with a key supplied at image-build time from a CI secret. *(Amended per #85: originally a per-build auto-generated key, whose certificate landed in vmlinux and rolled every measurement on a kernel cache miss.)* | The module bytes are already measured by dm-verity; the signature is a lockdown formality, not the trust root. Splitting cert from key gets bit-reproducible kernels (the trust anchor is a fixed repo input) with no private key at rest in git; shipping a default certificate keeps public images reproducible from a fresh clone. Rotating the certificate is a measurement change; see docs/module-signing.md. |
+| D3 | `gpu.config` = **`CONFIG_MODULES=y` + `MODULE_SIG*`** and nothing more (the symbols NVIDIA needs — `MMU_NOTIFIER`, `X86_PAT`, `MTRR`, `FW_LOADER`, `DMA_SHARED_BUFFER` — already resolve `=y`). confos's `mod2yesconfig` keeps every in-tree driver built-in, so the **only** loadable modules in the system are the two signed NVIDIA ones. | Minimal, auditable hardening delta; monolithic posture preserved. |
+| D4 | **Integrity = dm-verity, not a signing PKI.** Modules are signed only because lockdown-confidentiality refuses to load unsigned modules. The kernel builds in a **public certificate** — confos's committed default, or the caller's via `--module-signing-cert` — through `SYSTEM_TRUSTED_KEYS`; the **private key never enters this repo or the kernel build** — `MODULE_SIG_ALL` is off (nothing in-tree needs signing after `mod2yesconfig`), and `confos-fetch-gpu` signs the two NVIDIA modules with a key supplied at image-build time from a CI secret. *(Amended per #85: originally a per-build auto-generated key, whose certificate landed in vmlinux and rolled every measurement on a kernel cache miss.)* | The module bytes are already measured by dm-verity; the signature is a lockdown formality, not the trust root. Splitting cert from key gets bit-reproducible kernels (the trust anchor is a fixed repo input) with no private key at rest in git; shipping a default certificate keeps public images reproducible from a fresh clone. Rotating the certificate is a measurement change; see docs/module-signing.md. |
 | D5 | After the driver loads at boot, latch **`kernel.modules_disabled=1`**. | Restores the no-further-modules posture once NVIDIA is in. |
 | D6 | Kernel modules: **open-gpu-kernel-modules `595.71.05`** (tag verified, commit `095de56d`), built out-of-tree, **only `nvidia.ko` + `nvidia-uvm.ko`**. | Open modules are mandatory for Blackwell CC; drm/modeset/peermem excluded — headless compute needs neither and it keeps `CONFIG_DRM` off. |
 | D7 | Userspace from the **`.run` installer** (`NVIDIA-Linux-x86_64-595.71.05.run`, 403 MB, verified live, pinned by sha256), extracted and cherry-picked: `libnvidia-ml`, `nvidia-smi`, `nvidia-persistenced`, `nvidia-modprobe`, and the GSP firmware blobs → `/lib/firmware/nvidia/595.71.05/`. | Exact version-lock to the modules; sidesteps the distro mismatch (base is Ubuntu resolute/26.04; NVIDIA's apt repo targets ubuntu2404). |
@@ -55,7 +55,7 @@ aggregate time.
 ```
 kernel/gpu.config                          MODULES + MODULE_SIG fragment
 kernel/version                             6.16.12 (folded in from feat/kernel-6.16-tdx-rtmr)
-bin/steep-fetch-gpu                        fetch(pinned sha)→build in kernel-builder nspawn→sign→depmod→stage
+bin/confos-fetch-gpu                        fetch(pinned sha)→build in kernel-builder nspawn→sign→depmod→stage
 mkosi/base/mkosi.profiles/gpu/
   mkosi.conf                               apt: kmod, pciutils; doc header
   mkosi.extra/etc/modprobe.d/nvidia-flr-first.conf                  (blocks udev autoprobe until FLR)
@@ -73,24 +73,24 @@ docs/GPU-IMAGE-PLAN.md                     this file
 Build sequencing (the one non-obvious bit): NVIDIA modules must compile against
 the *built* kernel tree, which persists at `output/kernel/build/linux-6.16.12/`
 (with `Module.symvers` + `certs/signing_key.*`). So `build-gpu` runs
-`steep kernel --kernel-config-fragment kernel/gpu.config` first, then
-`bin/steep-fetch-gpu` (builds/signs/stages modules + userspace into
-`mkosi.local/mkosi.extra/`), then `steep build … --kernel-config-fragment
-kernel/gpu.config --profile gpu`. That final `steep build` hits the kernel
+`confos kernel --kernel-config-fragment kernel/gpu.config` first, then
+`bin/confos-fetch-gpu` (builds/signs/stages modules + userspace into
+`mkosi.local/mkosi.extra/`), then `confos build … --kernel-config-fragment
+kernel/gpu.config --profile gpu`. That final `confos build` hits the kernel
 **cache** (same fragment fingerprint) so it does not rebuild and clobber the
 tree, and `mkosi.local/` survives into the mkosi run (build.rs deliberately
 does not wipe it).
 
 ## Stages & exit criteria
 
-- **Stage 0 — baseline.** steep builds on b200-dev-1 (needs `bin/setup`:
+- **Stage 0 — baseline.** confos builds on b200-dev-1 (needs `bin/setup`:
   mkosi/oras/iasl — the only host mutation in the plan, all benign apt/uv
-  packages). Exit: clean `steep build --platform tdx` of the plain base.
+  packages). Exit: clean `confos build --platform tdx` of the plain base.
 - **Stage 1a — kernel bump.** ✅ config folded in (6.16.12). Validation: build
   the **plain base** on 6.16.12 and boot it end-to-end *before* any GPU changes,
   so kernel-bump breakage and NVIDIA-symbol breakage never get conflated.
   Expected: all measured values (MRTD/RTMR references) change.
-- **Stage 1 — gpu.config.** Fragment resolves; snapshot diff reviewed; steep's
+- **Stage 1 — gpu.config.** Fragment resolves; snapshot diff reviewed; confos's
   fragment-verification guardrail confirms no requested symbol silently dropped.
 - **Stage 2 — modules.** `nvidia.ko` + `nvidia-uvm.ko` build + sign against the
   tree in the kernel-builder nspawn (same toolchain → no compiler mismatch).
@@ -105,7 +105,7 @@ does not wipe it).
   serve evidence.)
 - **Stage 5 — scale + publish.** 8-GPU and 4×2 partition boots; `h2d-multithread`
   sanity vs. checkpoint baselines; settle the in-guest-FM question empirically;
-  `steep push --cdi` → GHCR; CI workflow; checkpoint 030; PRs on both repos.
+  `confos push --cdi` → GHCR; CI workflow; checkpoint 030; PRs on both repos.
 
 ## Risks / open questions
 
@@ -124,10 +124,10 @@ does not wipe it).
 6. **Stretch (perf):** fold the SWIOTLB max-segment 256K→2M rebuild (HANDOVER
    open question #5) into `gpu.config` — our custom kernel is exactly where that
    fix belongs.
-7. **Snapshot lockfile churn:** steep hardcodes a single
+7. **Snapshot lockfile churn:** confos hardcodes a single
    `kernel/config-x86_64.snapshot`, but we now have two kernel lineages (base
    and modules-enabled gpu). `make build-gpu` rewrites the snapshot to the gpu
-   config — expected per steep's documented behavior (`git checkout` it if the
+   config — expected per confos's documented behavior (`git checkout` it if the
    gpu build was a one-off; CI never commits it). If this becomes annoying, a
    small Rust change to key the snapshot path on the fragment name would give
    each lineage its own lockfile. Not doing that yet.

--- a/docs/module-signing.md
+++ b/docs/module-signing.md
@@ -14,13 +14,13 @@ lockdown plumbing.
 | | Where | Notes |
 |---|---|---|
 | Public certificate | `kernel/module-signing.crt`, committed | The default. Built into the system keyring and shipped inside every image, so it is public by construction. Measured — its sha256 is a kernel fingerprint input, so replacing it changes the image measurement. |
-| Private key | `MODULE_SIG_KEY_PEM` (contents) or `MODULE_SIG_KEY` (path) in `bin/steep-fetch-gpu`'s environment | Signs the out-of-tree modules via `scripts/sign-file`. Never committed; lives in the org-level Actions secret. |
+| Private key | `MODULE_SIG_KEY_PEM` (contents) or `MODULE_SIG_KEY` (path) in `bin/confos-fetch-gpu`'s environment | Signs the out-of-tree modules via `scripts/sign-file`. Never committed; lives in the org-level Actions secret. |
 
 A fresh clone builds a reproducible image with no setup: the default
 certificate is already here, and only *signing* new modules needs the key.
 
 To sign with your own key instead, pass `confos build --module-signing-cert
-<path>` and set `MODULE_SIG_CERT` to the same file for `steep-fetch-gpu`.
+<path>` and set `MODULE_SIG_CERT` to the same file for `confos-fetch-gpu`.
 Consumers that own their image's trust anchor do this — see the c8s repo's
 `node-guest-image/`.
 
@@ -29,7 +29,7 @@ in-tree modules to sign, and enabling it makes the kernel build generate its
 own key, which is what broke reproducibility in #85. `confos` enforces this
 against the resolved `.config` — it is not just a convention.
 
-`steep-fetch-gpu` refuses to sign if the key's public half does not match the
+`confos-fetch-gpu` refuses to sign if the key's public half does not match the
 certificate, since that mismatch would otherwise appear as a node booting
 without its GPU driver.
 

--- a/kernel/gpu.config
+++ b/kernel/gpu.config
@@ -1,14 +1,14 @@
 # GPU kernel config fragment — enable loadable modules for the NVIDIA driver.
 #
 # Applied ONLY for the GPU base image, via
-#   steep kernel  --kernel-config-fragment kernel/gpu.config
-#   steep build   --kernel-config-fragment kernel/gpu.config --profile gpu
-# (wired through the `build-gpu` Make target). steep's bare base image never
+#   confos kernel  --kernel-config-fragment kernel/gpu.config
+#   confos build   --kernel-config-fragment kernel/gpu.config --profile gpu
+# (wired through the `build-gpu` Make target). confos's bare base image never
 # sees this fragment, so the default hardened kernel stays module-free.
 #
 # WHY THIS EXISTS
 # ---------------
-# steep's hardening.config sets `# CONFIG_MODULES is not set` — a monolithic,
+# confos's hardening.config sets `# CONFIG_MODULES is not set` — a monolithic,
 # module-free kernel is a deliberate attack-surface choice. But the NVIDIA
 # open GPU kernel modules (nvidia.ko, nvidia-uvm.ko) are out-of-tree LOADABLE
 # modules; there is no supported way to build them into vmlinux. So the GPU
@@ -17,7 +17,7 @@
 #
 # WHAT THIS DOES *NOT* WEAKEN
 # ---------------------------
-# steep's configure phase runs `make mod2yesconfig` after merging fragments,
+# confos's configure phase runs `make mod2yesconfig` after merging fragments,
 # which flips every in-tree tristate (=m) to built-in (=y). So even with
 # CONFIG_MODULES=y, the kernel ships ZERO in-tree loadable modules — the only
 # loadable modules in the running system are the two signed NVIDIA ones we
@@ -38,7 +38,7 @@
 # load time); it does not need the private key, because nothing in-tree is
 # signed during the build — mod2yesconfig flattens every in-tree tristate to
 # =y, so the NVIDIA pair are the only modules in the system and
-# bin/steep-fetch-gpu signs them out-of-tree with scripts/sign-file. So we
+# bin/confos-fetch-gpu signs them out-of-tree with scripts/sign-file. So we
 # build in the caller's --module-signing-cert via SYSTEM_TRUSTED_KEYS and
 # turn MODULE_SIG_ALL off. No private key is ever present at kernel-build
 # time, and vmlinuz stops depending on a per-build GENKEY certificate (#85).
@@ -52,7 +52,7 @@ CONFIG_MODULES=y
 
 # Module signature enforcement — required for module loading to work at all
 # under lockdown-confidentiality. FORCE rejects any unsigned/badly-signed
-# module. SHA512 matches what bin/steep-fetch-gpu passes to sign-file.
+# module. SHA512 matches what bin/confos-fetch-gpu passes to sign-file.
 # MODULE_SIG_ALL is off because mod2yesconfig leaves no in-tree modules to
 # sign, and enabling it would force a private key into the kernel build.
 # SYSTEM_TRUSTED_KEYS names where confos stages --module-signing-cert.
@@ -67,7 +67,7 @@ CONFIG_SYSTEM_TRUSTED_KEYS="certs/confos-module-signing.crt"
 # (LKCA) backend for its GPU<->GSP session (ECDH key exchange + ECDSA/akcipher
 # signatures over an elliptic curve). The driver's `crypto` conftest gates
 # NV_CRYPTO_PRESENT on being able to include <crypto/ecc_curve.h>,
-# <crypto/ecdh.h>, <crypto/internal/ecc.h> and <crypto/kpp.h>. steep's minimal
+# <crypto/ecdh.h>, <crypto/internal/ecc.h> and <crypto/kpp.h>. confos's minimal
 # kernel ships only the crypto dm-verity needs (SHA/AKCIPHER/GCM), so without
 # these the driver builds libspdm against STUBS and CC init fails at runtime:
 #   "libspdm expects LKCA but found stubs! SPDM cannot boot ... RmInitAdapter

--- a/mkosi/base/mkosi.profiles/attest-gpu/mkosi.conf
+++ b/mkosi/base/mkosi.profiles/attest-gpu/mkosi.conf
@@ -8,7 +8,7 @@
 #
 # Only meaningful composed WITH the `gpu` profile (it needs the baked NVIDIA
 # driver + NVML + /dev/nvidia* nodes at runtime):
-#   bin/steep build --profile gpu --profile attest-gpu \
+#   bin/confos build --profile gpu --profile attest-gpu \
 #       --kernel-config-fragment kernel/gpu.config
 #
 # HOW THIS DIFFERS FROM `attest`
@@ -37,7 +37,7 @@ Packages=
     # versioned ICU *and* libxml2.so.2 are NOT apt-installed here: resolute has
     # no plain `libxml2` package and its ICU major may not match what libnvat
     # was built against, so both are bundled alongside libnvat instead (see
-    # bin/steep-fetch-attest-gpu). z/lzma/gcc_s come from the base.
+    # bin/confos-fetch-attest-gpu). z/lzma/gcc_s come from the base.
     libstdc++6
 
 [Build]

--- a/mkosi/base/mkosi.profiles/attest-gpu/mkosi.extra/etc/attestation-api/config.toml
+++ b/mkosi/base/mkosi.profiles/attest-gpu/mkosi.extra/etc/attestation-api/config.toml
@@ -1,4 +1,4 @@
-# attestation-api config baked by `steep build --profile attest-gpu`.
+# attestation-api config baked by `confos build --profile attest-gpu`.
 # Identical in shape to the `attest` profile's config — there is NO GPU flag
 # here. GPU evidence is requested per-call: POST /attest with
 # {"nvidia_gpu": true, "report_data": "<>=16-byte base64 nonce>"}. The one

--- a/mkosi/base/mkosi.profiles/attest-gpu/mkosi.sync
+++ b/mkosi/base/mkosi.profiles/attest-gpu/mkosi.sync
@@ -15,7 +15,7 @@ set -euo pipefail
 STAGE_DIR="$SRCDIR/mkosi.local/mkosi.extra"
 
 # Pre-staged escape hatch: if a host-side step already dropped the binary +
-# libnvat into mkosi.local (e.g. `bin/steep-fetch-attest-gpu` building against a
+# libnvat into mkosi.local (e.g. `bin/confos-fetch-attest-gpu` building against a
 # local libnvat, before the GHCR image is published), trust it and skip the
 # pull. This is how the profile is validated ahead of the first publish.
 if [ -f "$STAGE_DIR/usr/local/bin/attestation-api" ] && \
@@ -31,7 +31,7 @@ IMAGE="ghcr.io/confidential-dot-ai/attestation-api-gpu@sha256:FILL_AT_STAGE_4_at
 case "$IMAGE" in
   *FILL_AT_STAGE_4*)
     echo "attest-gpu: no pre-staged binary and the image digest is still a" >&2
-    echo "  Stage-4 sentinel. Either pre-stage via bin/steep-fetch-attest-gpu," >&2
+    echo "  Stage-4 sentinel. Either pre-stage via bin/confos-fetch-attest-gpu," >&2
     echo "  or publish the attestation-rs -gpu image (Dockerfile.gpu) and pin" >&2
     echo "  its digest. The 'gpu' profile builds and runs without attest-gpu." >&2
     exit 1 ;;

--- a/mkosi/base/mkosi.profiles/gpu/mkosi.conf
+++ b/mkosi/base/mkosi.profiles/gpu/mkosi.conf
@@ -10,13 +10,13 @@
 # them. The heavy artifacts — the signed nvidia.ko/nvidia-uvm.ko modules, the
 # NVIDIA userspace (libnvidia-ml, nvidia-smi, nvidia-persistenced,
 # nvidia-modprobe) and the GSP firmware — are staged into mkosi.local by
-# `bin/steep-fetch-gpu`, which MUST run before `steep build --profile gpu`
+# `bin/confos-fetch-gpu`, which MUST run before `confos build --profile gpu`
 # (the `build-gpu` Make target chains them). Building those here is impossible:
 # the modules need the kernel tree + toolchain that only exist outside this
 # sandbox.
 #
 # Compose with `attest-gpu` to also serve GPU attestation evidence:
-#   bin/steep build --profile gpu --profile attest-gpu \
+#   bin/confos build --profile gpu --profile attest-gpu \
 #       --kernel-config-fragment kernel/gpu.config
 #
 # MEASUREMENT NOTE: this profile requires the modules-enabled kernel built with

--- a/mkosi/base/mkosi.profiles/ssh/mkosi.extra/etc/systemd/system/ssh.service.d/no-vsock.conf
+++ b/mkosi/base/mkosi.profiles/ssh/mkosi.extra/etc/systemd/system/ssh.service.d/no-vsock.conf
@@ -1,5 +1,5 @@
 # vsock fence: on GPU images the kernel enables AF_VSOCK solely for the
-# attestation service's TDX GetQuote path (see steep kernel/gpu.config).
+# attestation service's TDX GetQuote path (see confos kernel/gpu.config).
 # sshd has no business on the host<->guest channel — deny the family.
 # Harmless on non-vsock kernels (the family is simply already absent).
 [Service]


### PR DESCRIPTION
Closes #88. **Stacked on #84** (retarget to `main` as the train advances); deliberately timed to ride the v0.4.0 measurement roll so downstream re-seeds reference values once.

- `bin/steep-fetch-gpu` → `bin/confos-fetch-gpu`, `bin/steep-fetch-attest-gpu` → `bin/confos-fetch-attest-gpu` (git mv, internal self-references and `die()` prefixes updated).
- **Measured change**: the NVIDIA module build's `KBUILD_BUILD_USER`/`KBUILD_BUILD_HOST` stamps go `steep` → `confos`, finally matching the kernel's own stamps — until now the modules and the kernel they load into carried different build identities. Stamps are baked into the module bytes, so rootfs/RTMR[2] roll once. `NV_BUILD_USER=c8s`/`NV_BUILD_HOST=confos` are untouched: already deliberate post-rename values, and changing them would be a gratuitous extra roll.
- ~40 prose references updated across docs, `kernel/gpu.config`, and the profile configs — including `GPU-IMAGE-PLAN.md`'s stale pre-v0.2.0 registry path (`…/steep/gpu-base` → the real registry). `build.rs`'s comments already said `bin/confos-fetch-<NAME>`; they're true now.
- Historical `CHANGELOG.md` entries keep `steep` deliberately — they describe what the tool was called at the time.

Zero `steep` references remain outside the changelog (verified by grep).

**Cross-repo follow-through** (goes in the consolidated c8s flip PR, not here): `node-guest-image/build` invokes both scripts by name, and `c8s-image.yml`'s gpu-artifacts cache key hashes `bin/steep-fetch-gpu` — both need the new names when `CONFOS_REF` bumps to a release containing this.