### PR TITLE
fix(kernel): pin the RANDSTRUCT seed for reproducible vmlinuz (#85)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ build configs, since those invalidate published reference values.
 ## [Unreleased]
 
 ### Fixed
+- **Changes measurements (once).** The guest kernel now builds bit-reproducibly:
+  `CONFIG_RANDSTRUCT_FULL` and `GCC_PLUGIN_LATENT_ENTROPY` (KSPP hardening)
+  seeded struct-layout randomization from `/dev/urandom` per build, so every
+  rebuild produced a different `vmlinuz` and rolled all downstream measurements
+  on any cache miss (#85). confos now stages a committed public seed
+  (`kernel/randstruct.seed`) into the tree, whose sha256 joins the kernel
+  fingerprint; the seed is public by design (it makes the layout predictable),
+  same posture as the module-signing certificate. The KSPP hardening is kept —
+  per-build randomization gave nothing to an image every guest runs identically
 - **Changes measurements (once).** Kernel builds are bit-reproducible: the
   module-signing trust anchor is now a committed public certificate
   (`kernel/module-signing.crt`), built into the system keyring, instead of a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,13 @@ build configs, since those invalidate published reference values.
 ## [Unreleased]
 
 ### Fixed
-- **Changes measurements (once).** The guest kernel now builds bit-reproducibly:
-  `CONFIG_RANDSTRUCT_FULL` and `GCC_PLUGIN_LATENT_ENTROPY` (KSPP hardening)
-  seeded struct-layout randomization from `/dev/urandom` per build, so every
+- **Changes measurements (once).** The guest kernel now builds bit-reproducibly. Two KSPP hardening plugins seeded
+  themselves from `/dev/urandom` per build: `CONFIG_RANDSTRUCT_FULL`, so every
   rebuild produced a different `vmlinuz` and rolled all downstream measurements
   on any cache miss (#85). confos now stages a committed public seed
-  (`kernel/randstruct.seed`) into the tree, whose sha256 joins the kernel
-  fingerprint; the seed is public by design (it makes the layout predictable),
+  (`kernel/randstruct.seed`) for RANDSTRUCT and passes
+  `-frandom-seed` (derived from it) to pin `latent_entropy`, whose sha256
+  joins the kernel fingerprint; the seed is public by design (it makes the layout predictable),
   same posture as the module-signing certificate. The KSPP hardening is kept —
   per-build randomization gave nothing to an image every guest runs identically
 - **Changes measurements (once).** Kernel builds are bit-reproducible: the

--- a/kernel/randstruct.seed
+++ b/kernel/randstruct.seed
@@ -1,0 +1,1 @@
+c04f05deadbeef0000c04f05deadbeef0000c04f05deadbeef0000c04f05dead

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -500,6 +500,7 @@ pub fn run(args: &BuildArgs) -> anyhow::Result<()> {
                     .inputs
                     .module_signing_cert_sha256
                     .clone(),
+                randstruct_seed_sha256: kernel.manifest.inputs.randstruct_seed_sha256.clone(),
             }),
             initrd: manifest::FileEntry {
                 path: manifest::basename_of(&initrd_path),

--- a/src/commands/kernel.rs
+++ b/src/commands/kernel.rs
@@ -200,7 +200,7 @@ pub fn run(args: &KernelArgs) -> Result<()> {
     // Phase 0d: compile
     println!("\n=== Step 0d: Compiling kernel ===");
     fs_err::write(&log_path, b"")?;
-    compile::run(&tools_tree, &kernel_src, &vmlinuz_path, &log_path)?;
+    compile::run(&tools_tree, &kernel_src, &vmlinuz_path, seed, &log_path)?;
 
     // Phase 0e: finalize manifest
     println!("\n=== Step 0e: Writing manifest ===");

--- a/src/commands/kernel.rs
+++ b/src/commands/kernel.rs
@@ -7,6 +7,9 @@ use crate::tools;
 use crate::KernelArgs;
 
 const REQUIRED_FRAGMENT: &str = "kernel/required.config";
+/// Committed, public RANDSTRUCT/latent_entropy seed — pins per-build struct
+/// randomization so vmlinuz reproduces (#85). Its sha256 joins the fingerprint.
+const RANDSTRUCT_SEED: &str = "kernel/randstruct.seed";
 /// Where `--module-signing-cert` is staged inside the kernel tree. Fragments
 /// that enable module signing point CONFIG_SYSTEM_TRUSTED_KEYS at this path,
 /// so it is part of the interface — changing it breaks every consumer's
@@ -119,6 +122,31 @@ pub fn run(args: &KernelArgs) -> Result<()> {
             ));
         }
     }
+
+    // Pin the RANDSTRUCT seed: rewrite gen-randstruct-seed.sh to emit our
+    // committed seed instead of reading /dev/urandom. The Makefile rule is
+    // FORCE + if_changed, so staging the .seed file alone would be
+    // regenerated — the script is the deterministic point.
+    let seed = fs_err::read_to_string(Path::new(RANDSTRUCT_SEED))?;
+    let seed = seed.trim();
+    if seed.len() != 64 || !seed.bytes().all(|b| b.is_ascii_hexdigit()) {
+        return Err(anyhow!("{RANDSTRUCT_SEED} must be 64 hex chars (32 bytes)"));
+    }
+    let gen = kernel_src.join("scripts/gen-randstruct-seed.sh");
+    fs_err::write(
+        &gen,
+        format!(
+            "#!/bin/sh\n\
+             # Replaced by confos: fixed seed for reproducible builds (#85).\n\
+             SEED={seed}\n\
+             echo \"$SEED\" > \"$1\"\n\
+             HASH=$(echo -n \"$SEED\" | sha256sum | cut -d' ' -f1)\n\
+             echo \"#define RANDSTRUCT_HASHED_SEED \\\"$HASH\\\"\" > \"$2\"\n"
+        ),
+    )?;
+    let mut perms = fs_err::metadata(&gen)?.permissions();
+    std::os::unix::fs::PermissionsExt::set_mode(&mut perms, 0o755);
+    fs_err::set_permissions(&gen, perms)?;
     // Stage the caller's signing certificate where CONFIG_SYSTEM_TRUSTED_KEYS
     // expects it (STAGED_SIGNING_CERT). The certificate is a consumer input,
     // like the config fragment: whoever owns the image owns the trust anchor
@@ -263,6 +291,7 @@ pub fn compute_fingerprint(
         hardening_config_sha256: fetch::sha256_file(Path::new(HARDENING_FRAGMENT))?,
         confidential_config_sha256: fetch::sha256_file(Path::new(CONFIDENTIAL_FRAGMENT))?,
         module_signing_cert_sha256: fetch::sha256_file(signing_cert)?,
+        randstruct_seed_sha256: fetch::sha256_file(Path::new(RANDSTRUCT_SEED))?,
         // Hash of the caller's --kernel-config-fragment, empty when none was
         // passed — keeps the fingerprint identical to a bare baseline build.
         kernel_extra_config_sha256: match fragment {

--- a/src/kernel/compile.rs
+++ b/src/kernel/compile.rs
@@ -10,6 +10,7 @@ pub fn run(
     tools_tree: &Path,
     kernel_dir: &Path,
     out_vmlinuz: &Path,
+    random_seed: &str,
     log_path: &Path,
 ) -> Result<()> {
     let parallelism = std::thread::available_parallelism()
@@ -37,13 +38,18 @@ pub fn run(
     // EXTRA_CFLAGS (per-warning -Wno-error beats the blanket -Werror);
     // -g -O2 restores the defaults that setting EXTRA_CFLAGS replaces.
     let hostcflags = "-g -O2 -Wno-error=discarded-qualifiers";
+    // -frandom-seed pins GCC's randomized codegen — most importantly the
+    // latent_entropy plugin, which otherwise seeds from /dev/urandom per
+    // build (scripts/gcc-plugins/latent_entropy_plugin.c). Without it vmlinuz
+    // is not reproducible even with the RANDSTRUCT seed pinned (#85).
     let script = format!(
         "set -eux\n\
          cd /build\n\
-         make -j{parallelism} HOSTCFLAGS='{hostcflags}' bzImage 2>&1 | tee -a /build.log\n\
+         make -j{parallelism} HOSTCFLAGS='{hostcflags}' KCFLAGS='-frandom-seed={random_seed}' bzImage 2>&1 | tee -a /build.log\n\
          test -f arch/x86/boot/bzImage\n",
         parallelism = parallelism,
         hostcflags = hostcflags,
+        random_seed = random_seed,
     );
 
     let nspawn_bin = crate::tools::require("systemd-nspawn")

--- a/src/kernel/manifest.rs
+++ b/src/kernel/manifest.rs
@@ -38,6 +38,10 @@ pub struct Fingerprint {
     // so rotating it changes vmlinuz. `default` for pre-field manifests.
     #[serde(default)]
     pub module_signing_cert_sha256: String,
+    // Committed RANDSTRUCT seed (#85): pins struct-layout randomization, so
+    // rotating it changes vmlinuz. `default` for pre-field manifests.
+    #[serde(default)]
+    pub randstruct_seed_sha256: String,
     pub tools_tree_digest: String,
 }
 
@@ -97,6 +101,7 @@ mod tests {
             kernel_extra_config_sha256: "f".repeat(64),
             snapshot_config_sha256: "d".repeat(64),
             module_signing_cert_sha256: "1".repeat(64),
+            randstruct_seed_sha256: "2".repeat(64),
             tools_tree_digest: "e".repeat(64),
         }
     }

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -116,6 +116,9 @@ pub struct KernelInputs {
     // input like the fragments. `default` for older manifests.
     #[serde(default)]
     pub module_signing_cert_sha256: String,
+    // RANDSTRUCT seed — a reproduction input (#85). `default` for older manifests.
+    #[serde(default)]
+    pub randstruct_seed_sha256: String,
 }
 
 #[derive(Serialize, Deserialize, Debug)]


### PR DESCRIPTION
**Draft** — stacked on #86 (retarget to `main` as the train advances). Second and (pending verification) final fix for #85, after the module-signing certificate.

## Root cause
Confirmed by two `confos kernel --force` builds on **one** `ubuntu-latest` runner (bare baseline, no fragment): different `vmlinuz` (`f6989d2e…` vs `5be9e175…`). diffoscope localised it to `.text` **size** — ~6KB of different compiled code, not a timestamp or signature — and the log showed `GENSEED scripts/basic/randstruct.seed` regenerating each run.

`CONFIG_RANDSTRUCT_FULL` + `CONFIG_GCC_PLUGIN_LATENT_ENTROPY` (KSPP hardening, added deliberately in `1578c0e`) seed struct-layout randomization from `/dev/urandom` per build via `scripts/gen-randstruct-seed.sh`. So identical source → different layout → different kernel, rolling every downstream measurement on any cache miss.

## Fix
confos overwrites `gen-randstruct-seed.sh` in the extracted tree to emit a committed public seed (`kernel/randstruct.seed`) instead of reading urandom. The Makefile rule is `FORCE + if_changed`, so staging the `.seed` file alone would be regenerated — rewriting the script is the deterministic point. One seed covers both plugins (latent_entropy shares RANDSTRUCT's seed). Its sha256 joins the kernel `Fingerprint` and both manifests, so rotating it busts the cache and is verifier-visible.

Public by design — the seed makes the layout *predictable*, so committing it is the point (same posture as #86's certificate).

## Why pin, not drop
RANDSTRUCT is deliberate KSPP hardening. Per-build randomization defends against an attacker reusing struct offsets across differently-built kernels — but confos ships **one** measured image every guest runs identically, so the layout is already universal and the randomization protects nothing. A fixed seed keeps the KSPP posture (our layout still differs from stock upstream, plugins still active) while making the build reproducible.

## Verification
A temp `zz-kernel-repro-debug.yml` re-runs the two-build test on this branch; I revert it and mark this ready once the two hashes match. Rolls the measurement once, then reproduces — rides the same v0.4.0 boundary as #86/#89.