### PR TITLE
release: v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ build configs, since those invalidate published reference values.
 
 ## [Unreleased]
 
+## [0.4.0] — 2026-08-13
+
 ### Changed
 - **Changes measurements (once, GPU images).** The steep → confos rename is
   finished (#88): `bin/steep-fetch-{gpu,attest-gpu}` are now
@@ -156,7 +158,8 @@ Initial public release.
 - `steep push` / `steep pull` (OCI via oras)
 - CI publishes base image as `ghcr.io/confidential-dot-ai/steep:base`
 
-[Unreleased]: https://github.com/confidential-dot-ai/confidential-os-builder/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/confidential-dot-ai/confidential-os-builder/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/confidential-dot-ai/confidential-os-builder/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/confidential-dot-ai/confidential-os-builder/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/confidential-dot-ai/confidential-os-builder/compare/v0.1.1...v0.2.0
 [0.1.1]: https://github.com/confidential-dot-ai/confidential-os-builder/compare/v0.1.0...v0.1.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -245,7 +245,7 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "confos"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "confos"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "Confidential VM image builder for AMD SEV-SNP and Intel TDX"


### PR DESCRIPTION
Cut v0.4.0. Everything in the Unreleased block, headlined by:

- **Kernel builds are bit-reproducible** (#85): committed public signing certificate (#86), pinned RANDSTRUCT + latent_entropy seeds (#92). Verified: back-to-back and cross-host builds produce identical vmlinuz.
- **The c8s profile moved to the c8s repo** (#84, c8s#264): confos is a pure builder; `--profile-dir`/`--sync-input` (#81) are the consumer interface.
- **steep → confos rename finished** (#88/#89), including the module build stamps.
- Build locking + staged-input cleanup hardening; GPU-IMAGE-PLAN.md retired (#93).

**Changes measurements once** — certificate, seeds, and stamps all roll on the first v0.4.0 build; every rebuild after is bit-identical. Downstream re-seeds reference values once at this boundary (the point of batching all of this).

After merge: tag `v0.4.0` on the merge commit (release.yml publishes on tag push), then c8s#294 pins `CONFOS_REF` to it.