### PR TITLE
release: v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ build configs, since those invalidate published reference values.
 
 ## [Unreleased]
 
+## [0.4.1] — 2026-08-13
+
 ### Fixed
 - **Changes measurements of module-signing kernels (once).** The #85 fix in
   v0.4.0 was incomplete: with `CONFIG_MODULE_SIG=y`, leaving
@@ -174,7 +176,8 @@ Initial public release.
 - `steep push` / `steep pull` (OCI via oras)
 - CI publishes base image as `ghcr.io/confidential-dot-ai/steep:base`
 
-[Unreleased]: https://github.com/confidential-dot-ai/confidential-os-builder/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/confidential-dot-ai/confidential-os-builder/compare/v0.4.1...HEAD
+[0.4.1]: https://github.com/confidential-dot-ai/confidential-os-builder/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/confidential-dot-ai/confidential-os-builder/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/confidential-dot-ai/confidential-os-builder/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/confidential-dot-ai/confidential-os-builder/compare/v0.1.1...v0.2.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -245,7 +245,7 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "confos"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "confos"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "Confidential VM image builder for AMD SEV-SNP and Intel TDX"


### PR DESCRIPTION
Cut v0.4.1. Everything in the Unreleased block, headlined by:

- **Fragment kernels (module signing + BTF) are bit-reproducible** (#85, completed by #95): `CONFIG_MODULE_SIG_KEY=""` stops the per-build GENKEY certificate; the builder rejects any resolved config that enables module signing without it. Verified: two back-to-back c8s-fragment builds produce identical vmlinuz (`2c6ae0ab…`).
- pahole `-j1` BTF pin (hardening, fail-loud on kernel bumps) and apt `Acquire::Retries` drop-ins.

**Changes measurements of module-signing kernels once** — the autogenerated certificate leaves the keyring on the first v0.4.1 build; every rebuild after is bit-identical. (The live security pocket remains a known cross-time gap: #96.)

After merge: tag `v0.4.1` on the merge commit (release.yml publishes on tag push), then c8s#294 re-pins `CONFOS_REF` to it and re-runs the idempotence gate.
