### PR TITLE
release: v0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ build configs, since those invalidate published reference values.
 
 ## [Unreleased]
 
+## [0.4.2] — 2026-08-15
+
 ### Fixed
 - **Changes measurements (once).** The apt security pocket was live and
   unpinned (#96): `Mirror=` snapshot URLs pin only main/updates — mkosi
@@ -189,7 +191,8 @@ Initial public release.
 - `steep push` / `steep pull` (OCI via oras)
 - CI publishes base image as `ghcr.io/confidential-dot-ai/steep:base`
 
-[Unreleased]: https://github.com/confidential-dot-ai/confidential-os-builder/compare/v0.4.1...HEAD
+[Unreleased]: https://github.com/confidential-dot-ai/confidential-os-builder/compare/v0.4.2...HEAD
+[0.4.2]: https://github.com/confidential-dot-ai/confidential-os-builder/compare/v0.4.1...v0.4.2
 [0.4.1]: https://github.com/confidential-dot-ai/confidential-os-builder/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/confidential-dot-ai/confidential-os-builder/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/confidential-dot-ai/confidential-os-builder/compare/v0.2.0...v0.3.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -245,7 +245,7 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "confos"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "confos"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "Confidential VM image builder for AMD SEV-SNP and Intel TDX"


### PR DESCRIPTION
Cut v0.4.2. One item in the Unreleased block, and it's the #96 closure (#98):

- **Every apt pocket pinned by URI** — build-time sources ship whole as `mkosi.sandbox` deb822 files (release/-updates/**-security** all at snapshot.ubuntu.com), handed to the tools tree via `ToolsTreeSandboxTrees=`; no apt snapshot support needed anywhere. A fail-closed mirror guard scans every mkosi run's apt log and errors on any live-mirror fetch. Verified: guarded double build, 0 live fetches, identical kernels (`9ed733d5…`).

**Changes measurements once** — security-pocket packages move to the snapshot timestamps on the first v0.4.2 build; every rebuild after is bit-identical. Cross-time drift via the live security pocket is closed.

After merge: tag `v0.4.2` (release.yml publishes on tag push), then the c8s `CONFOS_REF` bump + idempotence gate re-run, and conf-metal re-seeds digests (tracked on c8s#264's epilogue).
