### PR TITLE
fix(push): deterministic CDI tarball — no source metadata in layer headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ build configs, since those invalidate published reference values.
 
 ## [Unreleased]
 
+### Fixed
+- CDI tarballs are byte-reproducible: tar headers no longer carry the source
+  files' mtime/uid/gid, so identical artifacts produce an identical layer and
+  image digest. Changes the CDI image digest once (measurements unaffected —
+  the digest wraps the measured bytes, it is not itself measured)
+
 ## [0.4.2] — 2026-08-15
 
 ### Fixed

--- a/src/commands/push.rs
+++ b/src/commands/push.rs
@@ -178,8 +178,16 @@ pub(crate) fn build_cdi_tarball(
         } else {
             name.into_owned()
         };
+        // Explicit headers, not append_file: real mtime/uid/gid would make
+        // the layer digest differ per build for identical bytes (#85).
         let mut file = fs_err::File::open(&src)?;
-        tar.append_file(&arcname, file.file_mut())?;
+        let mut header = tar::Header::new_gnu();
+        header.set_size(file.metadata()?.len());
+        header.set_mode(0o644);
+        header.set_mtime(0);
+        header.set_uid(0);
+        header.set_gid(0);
+        tar.append_data(&mut header, &arcname, file.file_mut())?;
     }
 
     let gz = tar.into_inner()?;
@@ -246,6 +254,32 @@ mod tests {
         )
         .unwrap_err();
         assert!(err.to_string().contains("--tag"), "got: {err}");
+    }
+
+    #[test]
+    fn cdi_tarball_is_byte_identical_for_identical_content() {
+        let out = TempDir::new().unwrap();
+        let mut tarballs = Vec::new();
+        for i in 0..2 {
+            let src = TempDir::new().unwrap();
+            write(src.path(), "disk.raw", b"RAWDISK-CONTENT");
+            write(src.path(), "manifest.json", b"{}");
+            // Source metadata must not leak into the layer (#85): age one copy.
+            let old = std::time::SystemTime::now() - std::time::Duration::from_secs(86400 * i);
+            fs_err::File::open(src.path().join("disk.raw"))
+                .unwrap()
+                .set_modified(old)
+                .unwrap();
+            let path = out.path().join(format!("cdi-{i}.tar.gz"));
+            build_cdi_tarball(
+                src.path(),
+                &["disk.raw".into(), "manifest.json".into()],
+                &path,
+            )
+            .unwrap();
+            tarballs.push(fs_err::read(&path).unwrap());
+        }
+        assert_eq!(tarballs[0], tarballs[1]);
     }
 
     #[test]


### PR DESCRIPTION
The last nondeterministic artifact: identical `disk.raw` bytes still produced a different CDI layer digest every build, because `tar::Builder::append_file` copies the source file's mtime/uid/gid into the tar header. Explicit headers (mtime 0, uid/gid 0, mode 0644) fix it; the new test ages one copy's mtime a day and asserts the two tarballs are byte-identical.

Measured values were never affected — this is the OCI wrapper around them — but the CDI image digest now changes once and then holds, which lets consumers pin `node_image_digest` without it drifting on republish. Closes the `.raw` container gap tracked on c8s#264 and confidential-dot-ai/confidential-os-builder#85's known-gaps list.