### PR TITLE
fix(attest-gpu): allow snp requests, matching the attest profile

### DIFF
--- a/mkosi/base/mkosi.profiles/attest-gpu/mkosi.extra/etc/attestation-api/config.toml
+++ b/mkosi/base/mkosi.profiles/attest-gpu/mkosi.extra/etc/attestation-api/config.toml
@@ -35,4 +35,7 @@ enabled = true
 # KubeVirt: autoattachVSOCK) and run QGS on the host.
 tdx_quote_method = "vsock"
 # GPU is NOT a platform here — it is a per-request add-on (see header).
-platforms = ["tdx"]
+# Both CPU TEEs, matching the attest profile: this rootfs also backs SNP
+# node-CVMs, whose CDS self-attests via /dev/sev-guest against this API.
+# tdx_quote_method above only applies to tdx requests.
+platforms = ["snp", "tdx"]


### PR DESCRIPTION
## Problem

The `attest-gpu` profile's attestation-api config allows `platforms = ["tdx"]` only — correct when the profile was born for the TDX GPU CVM flow (#68), wrong now that the SNP node image reuses it. On an SNP node-CVM, CDS's self-attestation against the local API is refused with `platform 'snp' is not allowed by attestation.platforms`, and the whole `c8s install` deadlocks behind it (CDS crashloops; every other component stays CreateContainerError waiting on the allowlist CDS serves). Found live on the two-CVM SNP multinode bring-up; confirmed by live-editing the guest config to `["snp", "tdx"]`, after which the install proceeds.

## Fix

`platforms = ["snp", "tdx"]`, matching the non-GPU `attest` profile, with a comment noting `tdx_quote_method` applies only to tdx requests. The config is in the measured rootfs, so consumers pick this up via their pinned confos ref bump + measurement refresh.