### PR TITLE
fix(attest-gpu): DeviceAllow /dev/sev-guest, matching the attest profile

### DIFF
--- a/mkosi/base/mkosi.profiles/attest-gpu/mkosi.extra/etc/systemd/system/attestation-api.service
+++ b/mkosi/base/mkosi.profiles/attest-gpu/mkosi.extra/etc/systemd/system/attestation-api.service
@@ -12,6 +12,7 @@ ExecStart=/usr/local/bin/attestation-api -c /etc/attestation-api/config.toml
 Restart=on-failure
 RestartSec=3
 # TDX quote device.
+DeviceAllow=/dev/sev-guest rwm
 DeviceAllow=/dev/tdx_guest rwm
 # NVIDIA nodes the libnvat/NVML collector opens for SPDM evidence. The
 # per-GPU /dev/nvidiaN nodes register major 195 as "nvidia" in /proc/devices,


### PR DESCRIPTION
## Problem

Sibling of #102. With the platforms list fixed, SNP requests on an attest-gpu-based node still fail: the unit's hardening allows `/dev/tdx_guest` and the nvidia devices but not `/dev/sev-guest`, so the API answers 422 `Firmware::open failed: Operation not permitted`. CDS's self-attestation fails and the c8s install stays deadlocked.

## Fix

`DeviceAllow=/dev/sev-guest rwm`, matching the non-GPU attest profile. Verified live on the two-CVM SNP multinode pair: with a drop-in adding exactly this line (plus #102's platforms fix), CDS attests, the allowlist serves, and the full c8s stack converges Running on both nodes.