### PR TITLE
feat(initrd): SNP operator-key arm — verify HOSTDATA via ConfigFS-TSM

### DIFF
--- a/mkosi/initrd/mkosi.extra/init
+++ b/mkosi/initrd/mkosi.extra/init
@@ -124,23 +124,36 @@ mkdir -p /sysroot/run/dbus /sysroot/var/log/journal
 # Generate unique machine-id for this boot
 cat /proc/sys/kernel/random/uuid | tr -d '-' > /sysroot/etc/machine-id
 
-# --- Operator-key binding: extend RTMR[3] before switch_root ---------------
-# Bind a launch-supplied operator public key into the TDX measurement so an
-# external operator can attest that THIS node will only trust THEIR key, with
-# no console, no pre-shared cluster secret, and no trust in the (untrusted)
-# host that delivered the key. The launcher attaches a KubeVirt secret disk
-# labelled "opkeydata" (an ISO9660 filesystem, same mechanism as cloud-init's
-# "cidata") containing one file, `pubkey` — the raw operator public key. We
-# hash it here (SHA-384) and extend that into RTMR[3] — the one
-# guest-controllable measurement register (mrconfigid/mrowner are TD-init
-# fields KubeVirt does not set) — via the tdx_guest sysfs. Extend semantics:
-# RTMR_new = SHA384(RTMR_old || data48), so the operator verifies
-# rtmr3 == SHA384(0x00*48 || SHA384(op_pub)) offline against their own key.
+# --- Operator-key binding: verify before switch_root -----------------------
+# Bind a launch-supplied operator public key into the platform's launch
+# identity so an external operator can attest that THIS node will only trust
+# THEIR key, with no console, no pre-shared cluster secret, and no trust in
+# the (untrusted) host that delivered the key. The launcher attaches a
+# KubeVirt secret disk labelled "opkeydata" (an ISO9660 filesystem, same
+# mechanism as cloud-init's "cidata") containing one file, `pubkey` — the raw
+# operator public key. Two per-platform arms (c8s#331):
 #
-# The initrd is the single place the key is hashed (it has sha384sum), so the
-# credential-release service can later trust the pubkey off this same disk
-# without a separate digest to cross-check: this initrd is measured, and it
-# only extends the hash of the exact bytes it reads.
+#   TDX: hash the key (SHA-384) and extend into RTMR[3] — the one
+#   guest-controllable measurement register — via the tdx_guest sysfs.
+#   Extend semantics: RTMR_new = SHA384(RTMR_old || data48), so the operator
+#   verifies rtmr3 == SHA384(0x00*48 || SHA384(op_pub)) offline.
+#
+#   SNP: no runtime-extend register exists, so the binding is inverted — the
+#   launcher committed sha256(pubkey) into the report's immutable HOSTDATA
+#   field at launch, and we VERIFY here: read our own report via ConfigFS-TSM
+#   (/sys/kernel/config/tsm/report, the sev-guest driver's file interface —
+#   no ioctl binary needed; ~1s, fine for a one-shot check) and fail closed
+#   unless HOSTDATA equals sha256 of the staged key. The report comes from
+#   the PSP through the measured kernel — the same trust class as the TDX
+#   sysfs. A keyless launch carries all-zero HOSTDATA, which no sha256
+#   output equals, so a host that stripped the launcher-side binding is
+#   caught here. HOSTDATA is 32 bytes at offset 192 in every accepted
+#   report version.
+#
+# The initrd is the single place the key is hashed, so the credential-release
+# service can later trust the pubkey off this same disk without a separate
+# digest to cross-check: this initrd is measured, and it only binds the hash
+# of the exact bytes it reads.
 #
 # Why a labelled secret disk and not a raw serial-tagged block device: the
 # secret arrives as a file inside an ISO filesystem (KubeVirt's SecretVolume
@@ -149,62 +162,93 @@ cat /proc/sys/kernel/random/uuid | tr -d '-' > /sysroot/etc/machine-id
 # labelled mount here. Guest kernel has ISO9660 (CONFIG_ISO9660_FS=y).
 #
 # This runs BEFORE switch_root: nothing in the measured root or the (host-
-# writable) overlay executes first, so the value is fixed for the TD's life
-# and reflects only the launch-supplied key.
+# writable) overlay executes first, so the binding is fixed for the guest's
+# life and reflects only the launch-supplied key.
 #
 # Fail-closed asymmetry (security-critical):
-#   - no opkey disk               -> skip (unbound node; a non-operator boot)
-#   - disk present, extend FAILS  -> FATAL. Booting on with RTMR[3] unextended
-#     when a key was supplied would let the host strip the binding undetected.
+#   - no opkey disk                 -> skip (unbound node; a non-operator boot)
+#   - disk present, binding FAILS   -> FATAL. Booting on with the key unbound
+#     (TDX: RTMR[3] unextended; SNP: HOSTDATA not matching) when a key was
+#     supplied would let the host strip or substitute the binding undetected.
 RTMR3=/sys/devices/virtual/misc/tdx_guest/measurements/rtmr3:sha384
 OPKEY_DEV=$(blkid -L opkeydata 2>/dev/null || true)
 
 if [ -n "$OPKEY_DEV" ]; then
-    echo "initrd: found opkeydata disk at $OPKEY_DEV — binding operator key into RTMR[3]"
+    echo "initrd: found opkeydata disk at $OPKEY_DEV — binding operator key"
     fail_opkey() {
-        echo "FATAL: operator key supplied but RTMR[3] extend failed: $1" >&2
+        echo "FATAL: operator key supplied but binding failed: $1" >&2
         echo b > /proc/sysrq-trigger
         exit 1  # fallback if sysrq disabled
     }
-    [ -w "$RTMR3" ] || fail_opkey "no writable $RTMR3 (guest kernel lacks TDX runtime measurement?)"
     mkdir -p /opkey
     mount -o ro "$OPKEY_DEV" /opkey 2>/dev/null || fail_opkey "mount $OPKEY_DEV failed"
-    [ -s /opkey/pubkey ] || { umount /opkey 2>/dev/null; fail_opkey "no /opkey/pubkey on disk"; }
-    # SHA-384 of the exact pubkey bytes -> 96 hex chars (sha384sum prints
-    # "<hex>  -"). This is the sole place the key is hashed.
-    DIGEST_HEX=$(sha384sum < /opkey/pubkey | cut -d' ' -f1)
+    [ -s /opkey/pubkey ] || fail_opkey "no /opkey/pubkey on disk"
     # Stage the pubkey into the (post-switch_root) rootfs so the cred-release
     # service reads a plain file — it can't mount the ISO itself under systemd
-    # hardening. The initrd is the single reader of the disk; what it stages is
-    # exactly the bytes it hashed into RTMR[3], and the service re-checks
-    # SHA-384(file) against RTMR[3] before trusting it.
+    # hardening. The initrd is the single reader of the disk; what it stages
+    # is exactly the bytes it binds, and the service re-checks the platform
+    # binding against this file before trusting it.
     mkdir -p /sysroot/etc/confai
-    cp /opkey/pubkey /sysroot/etc/confai/operator-pubkey || { umount /opkey 2>/dev/null; fail_opkey "stage pubkey failed"; }
+    cp /opkey/pubkey /sysroot/etc/confai/operator-pubkey || fail_opkey "stage pubkey failed"
     chmod 0644 /sysroot/etc/confai/operator-pubkey
+
+    if [ -w "$RTMR3" ]; then
+        # --- TDX arm: extend SHA-384(pubkey) into RTMR[3] ---
+        # sha384sum prints "<hex>  -" -> 96 hex chars. Sole hash site.
+        DIGEST_HEX=$(sha384sum < /opkey/pubkey | cut -d' ' -f1)
+        case "$DIGEST_HEX" in
+            *[!0-9a-f]* | "") fail_opkey "sha384sum produced non-hex" ;;
+        esac
+        [ "${#DIGEST_HEX}" = "96" ] || fail_opkey "digest is ${#DIGEST_HEX} hex chars, want 96"
+        # Convert 96 hex chars -> 48 raw bytes in a tmpfs file, then write to
+        # the extend node with dd in ONE 48-byte write(2): the node rejects any
+        # other size, and bash printf splits its output at 0x0a bytes (~17% of
+        # digests), so redirecting printf at the node fails for those keys.
+        # sed turns "ab" into "\xab"; printf interprets the escapes.
+        esc=$(printf '%s' "$DIGEST_HEX" | sed 's/../\\x&/g')
+        # Intentional: $esc IS the format string — that's what interprets the
+        # \x escapes into raw bytes. DIGEST_HEX is validated [0-9a-f]{96}
+        # above, so $esc contains only \xNN sequences, no user-controlled
+        # format directives.
+        # shellcheck disable=SC2059
+        printf "$esc" > /opkey-digest.bin
+        n=$(wc -c < /opkey-digest.bin)
+        [ "$n" = "48" ] || fail_opkey "digest converted to $n bytes, want 48"
+        dd if=/opkey-digest.bin of="$RTMR3" bs=48 count=1 2>/dev/null \
+            || fail_opkey "write to $RTMR3 rejected"
+        rm -f /opkey-digest.bin
+        echo "initrd: RTMR[3] extended with operator key digest $DIGEST_HEX"
+    elif [ -c /dev/sev-guest ]; then
+        # --- SNP arm: verify sha256(pubkey) == report.HOSTDATA ---
+        WANT=$(sha256sum < /opkey/pubkey | cut -d' ' -f1)
+        case "$WANT" in
+            *[!0-9a-f]* | "") fail_opkey "sha256sum produced non-hex" ;;
+        esac
+        [ "${#WANT}" = "64" ] || fail_opkey "digest is ${#WANT} hex chars, want 64"
+        mount -t configfs configfs /sys/kernel/config 2>/dev/null || true
+        TSM=/sys/kernel/config/tsm/report/opkey
+        mkdir -p "$TSM" 2>/dev/null || fail_opkey "no ConfigFS-TSM report dir (kernel lacks CONFIG_TSM_REPORTS?)"
+        # 64 zero bytes of REPORTDATA: freshness is irrelevant here — HOSTDATA
+        # is immutable and we read our own report through the kernel.
+        dd if=/dev/zero bs=64 count=1 2>/dev/null > "$TSM/inblob" \
+            || fail_opkey "TSM inblob write failed"
+        # ONE read: outblob is generated per inblob write; a second read
+        # returns nothing.
+        cat "$TSM/outblob" > /opkey-report.bin || fail_opkey "TSM outblob read failed"
+        n=$(wc -c < /opkey-report.bin)
+        [ "$n" -ge 224 ] || fail_opkey "SNP report is $n bytes, want >= 224"
+        GOT=$(dd if=/opkey-report.bin bs=1 skip=192 count=32 2>/dev/null | od -v -An -tx1 | tr -d ' \n')
+        rm -f /opkey-report.bin
+        rmdir "$TSM" 2>/dev/null || true
+        [ "${#GOT}" = "64" ] || fail_opkey "HOSTDATA extraction got ${#GOT} hex chars, want 64"
+        [ "$GOT" = "$WANT" ] || fail_opkey "HOSTDATA is $GOT but staged key implies $WANT (launcher stripped or substituted the binding)"
+        echo "initrd: HOSTDATA verified against operator key digest $WANT"
+    else
+        fail_opkey "no binding mechanism: neither writable $RTMR3 nor /dev/sev-guest"
+    fi
     umount /opkey 2>/dev/null || true
-    case "$DIGEST_HEX" in
-        *[!0-9a-f]* | "") fail_opkey "sha384sum produced non-hex" ;;
-    esac
-    [ "${#DIGEST_HEX}" = "96" ] || fail_opkey "digest is ${#DIGEST_HEX} hex chars, want 96"
-    # Convert 96 hex chars -> 48 raw bytes in a tmpfs file, then write to the
-    # extend node with dd in ONE 48-byte write(2): the node rejects any other
-    # size, and bash printf splits its output at 0x0a bytes (~17% of digests),
-    # so redirecting printf at the node fails for those keys. sed turns "ab"
-    # into "\xab"; printf interprets the escapes.
-    esc=$(printf '%s' "$DIGEST_HEX" | sed 's/../\\x&/g')
-    # Intentional: $esc IS the format string — that's what interprets the \x
-    # escapes into raw bytes. DIGEST_HEX is validated [0-9a-f]{96} above, so
-    # $esc contains only \xNN sequences, no user-controlled format directives.
-    # shellcheck disable=SC2059
-    printf "$esc" > /opkey-digest.bin
-    n=$(wc -c < /opkey-digest.bin)
-    [ "$n" = "48" ] || fail_opkey "digest converted to $n bytes, want 48"
-    dd if=/opkey-digest.bin of="$RTMR3" bs=48 count=1 2>/dev/null \
-        || fail_opkey "write to $RTMR3 rejected"
-    rm -f /opkey-digest.bin
-    echo "initrd: RTMR[3] extended with operator key digest $DIGEST_HEX"
 else
-    echo "initrd: no opkeydata disk — RTMR[3] left unbound"
+    echo "initrd: no opkeydata disk — node boots unbound"
 fi
 
 echo "initrd: switching root..."


### PR DESCRIPTION
## Problem

The initrd's operator-key block is TDX-only: an SNP guest launched with an opkeydata disk hits the RTMR3-writability check and reboot-loops — the intended interim fail-closed (c8s#331), but it means SNP operator access has no guest leg.

## Fix

A per-platform split with staging hoisted to run once. The TDX arm is unchanged (SHA-384 extend into RTMR[3]). The SNP arm **verifies instead of extending**: the launcher committed `sha256(pubkey)` as the report's immutable HOSTDATA, so the initrd reads its own report through **ConfigFS-TSM** (`/sys/kernel/config/tsm/report` — the sev-guest driver's file interface) and fails closed unless HOSTDATA equals sha256 of the staged key bytes. A keyless launch carries all-zero HOSTDATA, which no sha256 output equals, so a host that stripped the launcher-side binding is caught. A guest with neither mechanism also fails closed.

Why ConfigFS-TSM and not a report-reader binary (`snpguest` or in-tree): the interface is pure shell — matching the TDX arm's character — needs no vendored or compiled tool in the initrd, `CONFIG_TSM_REPORTS=y` is already pinned in the kernel snapshot config, and its known ~1s latency is irrelevant for a one-shot boot check.

## Evidence

Live on an SNP node-CVM (kernel 6.16.12, report v5): the TSM read returns the 1184-byte report in one `cat`; HOSTDATA extracted at offset 192; the exact arm logic run against the keyless guest fails with the intended mismatch message (`HOSTDATA is 00…00 but staged key implies 4e6e80cb…`). One real bug found only by the live run: `od` line-compression turned the all-zero HOSTDATA into `0…0*` — the length guard caught it (fail-closed either way) but `od -v` is required for a faithful value. Positive-path e2e (matching HOSTDATA on an operator-key launch) needs this initrd baked and is the post-merge hardware step.