### PR TITLE
fix(attest-gpu): enable GPU evidence collection

### DIFF
--- a/bin/confos-fetch-attest-gpu
+++ b/bin/confos-fetch-attest-gpu
@@ -28,13 +28,18 @@ cd "$DIR"
 ATTEST_GPU_BIN="${ATTEST_GPU_BIN:-../attestation-rs/target/release/attestation-api}"
 LIBNVAT="${LIBNVAT:-/usr/lib/x86_64-linux-gnu/libnvat.so.1.2.0}"
 STAGE="mkosi/base/mkosi.local/mkosi.extra"
+CONFIG="mkosi/base/mkosi.profiles/attest-gpu/mkosi.extra/etc/attestation-api/config.toml"
 
 die() { printf 'confos-fetch-attest-gpu: %s\n' "$*" >&2; exit 1; }
 
 [[ -f "$ATTEST_GPU_BIN" ]] || die "attestation-api-gpu binary not found at $ATTEST_GPU_BIN (set ATTEST_GPU_BIN)."
 [[ -f "$LIBNVAT" ]] || die "libnvat not found at $LIBNVAT (set LIBNVAT; build per tdx-checkpoints/026)."
-# Sanity: the binary must actually be the GPU-collector build.
-ldd "$ATTEST_GPU_BIN" 2>/dev/null | grep -q libnvat || die "$ATTEST_GPU_BIN does not link libnvat — is it the --features nvidia-gpu-attest build?"
+# The binary must declare libnvat as a direct runtime dependency.
+readelf -d "$ATTEST_GPU_BIN" 2>/dev/null | \
+    grep 'Shared library: \[libnvat\.so' >/dev/null || \
+    die "$ATTEST_GPU_BIN does not require libnvat — use --features nvidia-gpu-attest."
+[[ "$(grep -Ec '^gpu_attestation_evidence_enabled = true$' "$CONFIG")" = 1 ]] || \
+    die "$CONFIG must enable GPU evidence collection exactly once."
 
 LIBDIR="$STAGE/usr/lib/x86_64-linux-gnu"
 mkdir -p "$STAGE/usr/local/bin" "$LIBDIR"

--- a/mkosi/base/mkosi.profiles/attest-gpu/mkosi.conf
+++ b/mkosi/base/mkosi.profiles/attest-gpu/mkosi.conf
@@ -40,6 +40,5 @@ Packages=
     libstdc++6
 
 [Build]
-# oras + jq: the sync hook pulls the -gpu OCI image and extracts both the
-# attestation-api binary and libnvat.so from its layers (see attest/mkosi.sync).
-ToolsTreePackages=oras,jq
+# The sync hook uses oras and jq to extract the image. It uses readelf to check the binary.
+ToolsTreePackages=oras,jq,binutils

--- a/mkosi/base/mkosi.profiles/attest-gpu/mkosi.extra/etc/attestation-api/config.toml
+++ b/mkosi/base/mkosi.profiles/attest-gpu/mkosi.extra/etc/attestation-api/config.toml
@@ -1,10 +1,6 @@
-# attestation-api config baked by `confos build --profile attest-gpu`.
-# Identical in shape to the `attest` profile's config — there is NO GPU flag
-# here. GPU evidence is requested per-call: POST /attest with
-# {"nvidia_gpu": true, "report_data": "<>=16-byte base64 nonce>"}. The one
-# caller nonce binds the TDX quote AND every GPU. Override at runtime by
-# writing /etc/attestation-api/config.toml (persists on the overlay, does not
-# change the measurement).
+# The measured attest-gpu profile installs this configuration.
+# The flag permits evidence collection when a request sets `nvidia_gpu: true`.
+# The attestation-rs verifier verifies the returned CPU and GPU evidence bundle.
 
 [server]
 bind = "0.0.0.0:8400"
@@ -27,6 +23,7 @@ enabled = false
 
 [attestation]
 enabled = true
+gpu_attestation_evidence_enabled = true
 # vsock: fetch quotes from the host's QGS over AF_VSOCK (CID 2, port 4050) —
 # the GPU-image kernel enables vsock for exactly this (kernel/gpu.config).
 # The ConfigFS-TSM path also works but is far too slow for a serving endpoint

--- a/mkosi/base/mkosi.profiles/attest-gpu/mkosi.sync
+++ b/mkosi/base/mkosi.profiles/attest-gpu/mkosi.sync
@@ -13,6 +13,20 @@
 set -euo pipefail
 
 STAGE_DIR="$SRCDIR/mkosi.local/mkosi.extra"
+PROFILE_CONFIG="$SRCDIR/mkosi.profiles/attest-gpu/mkosi.extra/etc/attestation-api/config.toml"
+
+require_gpu_binary() {
+    readelf -d "$1" 2>/dev/null | \
+        grep 'Shared library: \[libnvat\.so' >/dev/null || {
+        echo "attest-gpu: $1 does not require libnvat; use --features nvidia-gpu-attest" >&2
+        exit 1
+    }
+}
+
+[ "$(grep -Ec '^gpu_attestation_evidence_enabled = true$' "$PROFILE_CONFIG")" = 1 ] || {
+    echo "attest-gpu: $PROFILE_CONFIG must enable GPU evidence collection exactly once" >&2
+    exit 1
+}
 
 # Pre-staged escape hatch: if a host-side step already dropped the binary +
 # libnvat into mkosi.local (e.g. `bin/confos-fetch-attest-gpu` building against a
@@ -20,6 +34,7 @@ STAGE_DIR="$SRCDIR/mkosi.local/mkosi.extra"
 # pull. This is how the profile is validated ahead of the first publish.
 if [ -f "$STAGE_DIR/usr/local/bin/attestation-api" ] && \
    ls "$STAGE_DIR"/usr/lib/x86_64-linux-gnu/libnvat.so* >/dev/null 2>&1; then
+    require_gpu_binary "$STAGE_DIR/usr/local/bin/attestation-api"
     echo "attest-gpu: binary + libnvat already staged in mkosi.local — skipping pull."
     exit 0
 fi
@@ -56,6 +71,7 @@ for c in "$EXTRACT/attestation-api" "$EXTRACT/usr/local/bin/attestation-api"; do
     [ -f "$c" ] && { BIN="$c"; break; }
 done
 [ -n "$BIN" ] || { echo "attest-gpu: attestation-api not found in image" >&2; exit 1; }
+require_gpu_binary "$BIN"
 install -D -m0755 "$BIN" "$STAGE_DIR/usr/local/bin/attestation-api"
 
 # libnvat.so — NVIDIA's evidence collector the -gpu build links.

--- a/tests/attest_gpu_profile.rs
+++ b/tests/attest_gpu_profile.rs
@@ -1,0 +1,41 @@
+use std::path::PathBuf;
+
+fn repository_file(path: &str) -> String {
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    fs_err::read_to_string(root.join(path)).unwrap()
+}
+
+#[test]
+fn attest_gpu_profile_enables_gpu_collection() {
+    let config = repository_file(
+        "mkosi/base/mkosi.profiles/attest-gpu/mkosi.extra/etc/attestation-api/config.toml",
+    );
+    assert_eq!(
+        config
+            .lines()
+            .filter(|line| *line == "gpu_attestation_evidence_enabled = true")
+            .count(),
+        1
+    );
+    assert!(config.contains("platforms = [\"snp\", \"tdx\"]"));
+
+    let service = repository_file(
+        "mkosi/base/mkosi.profiles/attest-gpu/mkosi.extra/etc/systemd/system/attestation-api.service",
+    );
+    assert!(service.contains("-c /etc/attestation-api/config.toml"));
+}
+
+#[test]
+fn gpu_image_paths_require_a_libnvat_binary() {
+    let helper = repository_file("bin/confos-fetch-attest-gpu");
+    assert!(helper.contains("readelf -d \"$ATTEST_GPU_BIN\""));
+    assert!(helper.contains("Shared library: \\[libnvat\\.so"));
+
+    let sync = repository_file("mkosi/base/mkosi.profiles/attest-gpu/mkosi.sync");
+    assert!(sync.contains("readelf -d \"$1\""));
+    assert!(sync.contains("Shared library: \\[libnvat\\.so"));
+    assert_eq!(sync.matches("require_gpu_binary \"").count(), 2);
+
+    let profile = repository_file("mkosi/base/mkosi.profiles/attest-gpu/mkosi.conf");
+    assert!(profile.contains("ToolsTreePackages=oras,jq,binutils"));
+}


### PR DESCRIPTION
Enables the attestation-api GPU evidence gate in the measured node profile. Requires staged binaries to link directly to libnvat. Adds profile tests and the readelf build dependency. Validation: lint, all Rust targets, shell syntax, and diff checks pass.