### PR TITLE
release: v0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,30 @@ build configs, since those invalidate published reference values.
 
 ## [Unreleased]
 
+## [0.4.3] — 2026-08-18
+
+### Added
+- **Changes measurements (once).** SNP arm of the initrd operator-key
+  binding (#106, c8s#331): with no runtime-extend register on SEV-SNP, the
+  initrd reads its own report via ConfigFS-TSM and fails closed unless
+  HOSTDATA equals sha256 of the staged operator pubkey. A keyless launch
+  carries all-zero HOSTDATA and is caught. The initrd change rolls both
+  platforms' measurements once
+- Per-lineage kernel config snapshots (#105, #66): fragment builds write
+  `config-x86_64-<stem>.snapshot` beside their fragment, in the caller's own
+  tree; the committed bare-baseline lockfile was regenerated from the exact
+  CI-resolved bytes (kernel bit-identical, verified `0cf18191…` before and
+  after)
+
 ### Fixed
 - CDI tarballs are byte-reproducible: tar headers no longer carry the source
   files' mtime/uid/gid, so identical artifacts produce an identical layer and
   image digest. Changes the CDI image digest once (measurements unaffected —
   the digest wraps the measured bytes, it is not itself measured)
+- attest-gpu profile serves SNP requests and can open `/dev/sev-guest`,
+  matching the attest profile (#102, #103)
+- CI base builds reuse the kernel cache instead of rebuilding every push
+  (#104; build time 13-16m to ~3m, no artifact change)
 
 ## [0.4.2] — 2026-08-15
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -245,7 +245,7 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "confos"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "confos"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "Confidential VM image builder for AMD SEV-SNP and Intel TDX"


### PR DESCRIPTION
Cut v0.4.3. Unreleased items promoted:

- **SNP operator-key initrd arm** (#106, c8s#331) — HOSTDATA verified via ConfigFS-TSM, fail-closed; **rolls both platforms' measurements once** (initrd change)
- **Per-lineage kernel config snapshots** (#105, #66 points 1-2) — lockfiles live beside their fragment; committed baseline regenerated from CI-resolved bytes, kernel verified bit-identical (`0cf18191…`)
- attest-gpu SNP request + /dev/sev-guest fixes (#102, #103)
- CDI tarball byte-reproducibility (#101); CI kernel-cache fix (#104, no artifact change)

After merge: tag `v0.4.3` (release.yml publishes on tag push), then the c8s `CONFOS_REF` bump — which carries the snapshot cache-path switch, commits the c8s lineage lockfiles, and produces the rebuilt-initrd image the #331 operator-key e2e needs — and conf-metal re-seeds digests.