### PR TITLE
fix(ci): snapshot-pin host build deps — they shape measured bytes

### DIFF
--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -29,11 +29,14 @@ jobs:
         # The snapshot pin moves the whole dep closure to snapshot versions,
         # which would re-download it from snapshot.ubuntu.com every run; warm
         # runs reinstall these debs fully offline. The key rotates with the
-        # script and the pin it reads (base mkosi.sources).
+        # runner image (the closure was resolved against its preinstalled
+        # state), the script, and the pin it reads (base mkosi.sources);
+        # host-deps validates the cached manifest and falls back to a cold
+        # snapshot install on any mismatch, so a stale entry costs time only.
         uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: apt-debs
-          key: ${{ runner.os }}-host-debs-${{ hashFiles('bin/host-deps', 'mkosi/base/mkosi.sandbox/etc/apt/sources.list.d/mkosi.sources') }}
+          key: ${{ runner.os }}-host-debs-${{ env.ImageOS }}-${{ env.ImageVersion }}-${{ hashFiles('bin/host-deps', 'mkosi/base/mkosi.sandbox/etc/apt/sources.list.d/mkosi.sources') }}
 
       - name: Install build deps (nspawn, TDVF firmware, iasl, cpio)
         # Host deps for `confos build`, snapshot-pinned and fail-closed via

--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -25,13 +25,21 @@ jobs:
       - name: Setup mkosi
         uses: systemd/mkosi@84af20892b61c8e177e391f997ded8b4cb5514f2 # v26
 
+      - name: Cache host build deps
+        # The snapshot pin moves the whole dep closure to snapshot versions,
+        # which would re-download it from snapshot.ubuntu.com every run; warm
+        # runs reinstall these debs fully offline. The key rotates with the
+        # script and the pin it reads (base mkosi.sources).
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+        with:
+          path: apt-debs
+          key: ${{ runner.os }}-host-debs-${{ hashFiles('bin/host-deps', 'mkosi/base/mkosi.sandbox/etc/apt/sources.list.d/mkosi.sources') }}
+
       - name: Install build deps (nspawn, TDVF firmware, iasl, cpio)
-        # Host deps for `confos build` — keep in lockstep with bin/setup.
-        # bin/host-deps pins them to a committed snapshot and fails closed on
-        # live-mirror fetches (#36): iasl and ovmf shape measured bytes.
-        # Bounded: a dead mirror connection otherwise hangs until the job limit.
+        # Host deps for `confos build`, snapshot-pinned and fail-closed via
+        # bin/host-deps (#36) — keep the list in lockstep with bin/setup.
         timeout-minutes: 10
-        run: bin/host-deps systemd-container ovmf cpio acpica-tools
+        run: bin/host-deps --cache-dir apt-debs systemd-container ovmf cpio acpica-tools
 
       - name: Cache kernel-builder tools tree
         # mkosi.output (image + stamp) is what ensure_tools_tree consumes;

--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -27,12 +27,11 @@ jobs:
 
       - name: Install build deps (nspawn, TDVF firmware, iasl, cpio)
         # Host deps for `confos build` — keep in lockstep with bin/setup.
+        # bin/host-deps pins them to a committed snapshot and fails closed on
+        # live-mirror fetches (#36): iasl and ovmf shape measured bytes.
         # Bounded: a dead mirror connection otherwise hangs until the job limit.
-        timeout-minutes: 5
-        run: |
-          sudo apt-get -o Acquire::http::Timeout=30 -o Acquire::Retries=3 update -y
-          sudo apt-get -o Acquire::http::Timeout=30 -o Acquire::Retries=3 install -y \
-            systemd-container ovmf cpio acpica-tools
+        timeout-minutes: 10
+        run: bin/host-deps systemd-container ovmf cpio acpica-tools
 
       - name: Cache kernel-builder tools tree
         # mkosi.output (image + stamp) is what ensure_tools_tree consumes;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ build configs, since those invalidate published reference values.
 
 ## [Unreleased]
 
+### Fixed
+- **Changes measurements (once).** Host build deps are snapshot-pinned
+  (#36): `bin/host-deps` installs them from snapshot.ubuntu.com at a
+  committed timestamp with a fail-closed live-mirror guard, closing the
+  last unpinned measured input (iasl compiles the trusted DSDT; ovmf is
+  the published SNP firmware). Pinning moves the published OVMF.fd from
+  the live archive's ovmf (2024.02-2ubuntu0.9 today) to the snapshot's
+  (2024.02-2ubuntu0.8), rolling the SNP launch measurement once; the
+  DSDT toolchain (acpica-tools 20230628-1) is unchanged. Bumping
+  `SNAPSHOT` in `bin/host-deps` is now the deliberate act that picks up
+  host-toolchain updates — and can move measurements
+
 ## [0.4.3] — 2026-08-18
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,9 @@ build configs, since those invalidate published reference values.
   the published SNP firmware). Pinning moves the published OVMF.fd from
   the live archive's ovmf (2024.02-2ubuntu0.9 today) to the snapshot's
   (2024.02-2ubuntu0.8), rolling the SNP launch measurement once; the
-  DSDT toolchain (acpica-tools 20230628-1) is unchanged. Bumping
-  `SNAPSHOT` in `bin/host-deps` is now the deliberate act that picks up
+  DSDT toolchain (acpica-tools 20230628-1) is unchanged. The host pin
+  is the base image's `mkosi.sources` timestamp, so bumping that one
+  committed value is the deliberate act that picks up image and
   host-toolchain updates — and can move measurements
 
 ## [0.4.3] — 2026-08-18

--- a/bin/confos-fetch-gpu
+++ b/bin/confos-fetch-gpu
@@ -107,8 +107,8 @@ cert_pub="$(openssl x509 -in "$MODULE_SIG_CERT" -pubkey -noout 2>/dev/null)" || 
   die "signing key does not match $MODULE_SIG_CERT — modules signed with it would be rejected at boot."
 [[ -x "$KTREE/scripts/sign-file" ]] || die "$KTREE/scripts/sign-file missing — cannot sign modules."
 [[ -d "$TOOLS_TREE" ]] || die "kernel-builder tools tree $TOOLS_TREE missing — run 'confos kernel' first."
-command -v systemd-nspawn >/dev/null || die "systemd-nspawn required (apt install systemd-container)."
-command -v depmod >/dev/null || die "depmod required (apt install kmod)."
+command -v systemd-nspawn >/dev/null || die "systemd-nspawn required (systemd-container package; bin/host-deps installs it)."
+command -v depmod >/dev/null || die "depmod required (kmod package; bin/host-deps installs it)."
 
 mkdir -p "$CACHE" "$WORK"
 

--- a/bin/host-deps
+++ b/bin/host-deps
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Install host build deps from snapshot.ubuntu.com at a committed timestamp.
+#
+# The host toolchain shapes measured bytes (#36): iasl (acpica-tools) compiles
+# the trusted DSDT prepended to the initrd, and ovmf is the published SNP
+# firmware. Installing them from the live archive lets a rebuild weeks later
+# miss a published measurement even with every image input pinned.
+#
+# Fail-closed in two layers, like confos's run_mkosi mirror guard (#96):
+# apt is confined to a snapshot-only source list for this transaction (live
+# mirrors are unconfigured, not merely unpreferred), and the apt transcript
+# is still scanned for live ubuntu.com fetches — config presence alone has
+# failed open before.
+set -euo pipefail
+
+# INVARIANT: every deb this script installs resolves from this snapshot.
+# Bump deliberately: a new timestamp changes the host toolchain and can move
+# the measurement — refresh downstream pinned digests with it.
+SNAPSHOT=20260430T000000Z
+
+[ "$#" -gt 0 ] || { echo "usage: host-deps <package>..." >&2; exit 1; }
+
+codename=$(. /etc/os-release && echo "${VERSION_CODENAME:?}")
+
+sources=$(mktemp --suffix=.list)
+prefs=$(mktemp)
+log=$(mktemp)
+trap 'rm -f "$sources" "$prefs" "$log"' EXIT
+# One-line format: apt only parses deb822 from Dir::Etc::sourceparts.
+for pocket in "$codename" "$codename-updates" "$codename-security"; do
+    echo "deb [signed-by=/usr/share/keyrings/ubuntu-archive-keyring.gpg] https://snapshot.ubuntu.com/ubuntu/${SNAPSHOT} ${pocket} main universe" >> "$sources"
+done
+# Priority > 1000: the host image tracks the live archive, so its installed
+# debs run ahead of any fixed snapshot; without this, apt keeps the newer
+# installed version as candidate and a strict = dependency (systemd-container
+# on libsystemd-shared) is unsatisfiable. Above 1000, the snapshot version
+# wins even when that is a downgrade — the dep closure moves to the snapshot.
+cat > "$prefs" <<EOF
+Package: *
+Pin: origin "snapshot.ubuntu.com"
+Pin-Priority: 1001
+EOF
+
+# Bounded fetches: a dead mirror otherwise hangs until the caller's job limit.
+# Non-interactive dpkg: downgrades would otherwise stop on conffile prompts.
+apt_snapshot() {
+    sudo DEBIAN_FRONTEND=noninteractive apt-get \
+        -o Dir::Etc::sourcelist="$sources" \
+        -o Dir::Etc::sourceparts=/dev/null \
+        -o Dir::Etc::preferences="$prefs" \
+        -o Dir::Etc::preferencesparts=/dev/null \
+        -o Acquire::http::Timeout=30 \
+        -o Acquire::https::Timeout=30 \
+        -o Acquire::Retries=3 \
+        -o Dpkg::Options::=--force-confdef \
+        -o Dpkg::Options::=--force-confold \
+        "$@" 2>&1 | tee -a "$log"
+}
+
+apt_snapshot update
+apt_snapshot install -y --allow-downgrades "$@"
+
+# Backstop, kept in parity with confos's is_live_mirror_fetch: an apt
+# fetch-progress line hitting any ubuntu.com host other than snapshot is a
+# live, drifting mirror. Non-Ubuntu (third-party) hosts are out of scope.
+allow='^[[:space:]]*(Get|Hit|Ign|Err):[0-9]+ https?://snapshot\.ubuntu\.com([:/ ]|$)'
+live=$(grep -iE '^[[:space:]]*(Get|Hit|Ign|Err):[0-9]+ https?://([a-z0-9.-]*\.)?ubuntu\.com([:/ ]|$)' "$log" \
+    | grep -ivE "$allow" || true)
+if [ -n "$live" ]; then
+    echo "host-deps: fetched from live (unpinned) Ubuntu mirrors — the measurement would drift with the archive (#36):" >&2
+    echo "$live" >&2
+    exit 1
+fi
+
+# The resolved deb set, for auditing a published measurement's toolchain.
+echo "host-deps: installed from snapshot ${SNAPSHOT}:"
+dpkg-query -W "$@"

--- a/bin/host-deps
+++ b/bin/host-deps
@@ -13,50 +13,46 @@
 # failed open before.
 #
 # Usage: host-deps [--cache-dir DIR] <package>...
-#   --cache-dir DIR  Reinstall DIR's debs fully offline when present (warm),
-#                    else fill DIR with the transaction's debs (cold). CI
-#                    keys DIR's cache on this script + the base mkosi.sources.
-#   --self-test      Run the transcript scanner against the vector set of
-#                    src/tools.rs's is_live_mirror_fetch tests and exit.
+#   --cache-dir DIR  Reinstall DIR's debs fully offline when DIR's manifest
+#                    still matches this pin, host release, package list, and
+#                    deb hashes AND the reinstall lands every requested
+#                    package on its manifest version — any mismatch falls
+#                    back to a fresh snapshot install that rewrites DIR.
+#   --self-test      Run the transcript scanner over the shared vector file
+#                    (tests/fixtures/live-mirror-vectors.txt, also consumed
+#                    by src/tools.rs's is_live_mirror_fetch test) and exit.
 set -euo pipefail
 
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
 # Transcript scanner, kept in parity with confos's is_live_mirror_fetch by
-# --self-test (bin/lint runs it): an apt fetch-progress line hitting any
-# ubuntu.com host other than snapshot is a live, drifting mirror. Non-Ubuntu
-# (third-party) hosts are out of scope.
-LIVE_RE='^[[:space:]]*(Get|Hit|Ign|Err):[0-9]+ https?://([a-z0-9.-]*\.)?ubuntu\.com([:/ ]|$)'
-ALLOW_RE='^[[:space:]]*(Get|Hit|Ign|Err):[0-9]+ https?://snapshot\.ubuntu\.com([:/ ]|$)'
+# the shared vector fixture (--self-test, run by bin/lint): an apt
+# fetch-progress line hitting any ubuntu.com host other than snapshot is a
+# live, drifting mirror. Non-Ubuntu (third-party) hosts are out of scope.
+LIVE_RE='^[[:space:]]*(Get|Hit|Ign|Err):[0-9]+[[:space:]]+https?://([^/[:space:]]*\.)?ubuntu\.com(:[0-9]+)?([/[:space:]]|$)'
+ALLOW_RE='^[[:space:]]*(Get|Hit|Ign|Err):[0-9]+[[:space:]]+https?://snapshot\.ubuntu\.com(:[0-9]+)?([/[:space:]]|$)'
 scan_live() {
     grep -iE "$LIVE_RE" | grep -ivE "$ALLOW_RE"
 }
 
 if [ "${1:-}" = --self-test ]; then
-    # INVARIANT: same verdicts as src/tools.rs's is_live_mirror_fetch tests.
-    flagged=(
-        'Get:1 http://archive.ubuntu.com/ubuntu resolute InRelease [136 kB]'
-        'Hit:3 http://security.ubuntu.com/ubuntu resolute-security InRelease'
-        'Err:12 https://ports.ubuntu.com resolute/main arm64 Packages'
-        'Get:7 http://azure.archive.ubuntu.com/ubuntu resolute/main amd64 tar 1.35 [258 kB]'
-        'Ign:2 https://esm.ubuntu.com/apps/ubuntu resolute-apps-security InRelease'
-        'Get:4 http://old-releases.ubuntu.com/ubuntu resolute InRelease'
-        'Get:5 http://Archive.Ubuntu.com/ubuntu resolute InRelease'
-        'Get:6 http://archive.ubuntu.com:80/ubuntu resolute InRelease'
-    )
-    clean=(
-        'Get:1 https://snapshot.ubuntu.com/ubuntu/20260405T000000Z/dists/resolute/InRelease [136 kB]'
-        'URIs: http://archive.ubuntu.com/ubuntu'
-        'mkosi: falling back to archive.ubuntu.com'
-        'Get:x http://archive.ubuntu.com/ubuntu resolute InRelease'
-        'Get:1 http://packages.microsoft.com/repos/azure-cli resolute InRelease'
-    )
-    for line in "${flagged[@]}"; do
-        [ -n "$(printf '%s\n' "$line" | scan_live || true)" ] \
-            || { echo "host-deps --self-test: live-mirror line not flagged: $line" >&2; exit 1; }
-    done
-    for line in "${clean[@]}"; do
-        [ -z "$(printf '%s\n' "$line" | scan_live || true)" ] \
-            || { echo "host-deps --self-test: benign line flagged: $line" >&2; exit 1; }
-    done
+    while IFS=$'\t' read -r expect vector; do
+        case "$expect" in
+            '' | '#'*) continue ;;
+            flag)
+                [ -n "$(printf '%s\n' "$vector" | scan_live || true)" ] \
+                    || { echo "host-deps --self-test: live-mirror line not flagged: $vector" >&2; exit 1; }
+                ;;
+            pass)
+                [ -z "$(printf '%s\n' "$vector" | scan_live || true)" ] \
+                    || { echo "host-deps --self-test: benign line flagged: $vector" >&2; exit 1; }
+                ;;
+            *)
+                echo "host-deps --self-test: bad vector line: $expect" >&2
+                exit 1
+                ;;
+        esac
+    done < "$ROOT/tests/fixtures/live-mirror-vectors.txt"
     echo "host-deps --self-test: ok"
     exit 0
 fi
@@ -74,7 +70,6 @@ fi
 
 # The pin is the base image's committed snapshot — one bump moves the image
 # and the host toolchain together, and can move measurements (#36).
-ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 BASE_SOURCES="$ROOT/mkosi/base/mkosi.sandbox/etc/apt/sources.list.d/mkosi.sources"
 SNAPSHOT=$(sed -n 's#^URIs: https://snapshot\.ubuntu\.com/ubuntu/##p' "$BASE_SOURCES")
 if ! [[ "$SNAPSHOT" =~ ^[0-9]{8}T[0-9]{6}Z$ ]]; then
@@ -82,50 +77,84 @@ if ! [[ "$SNAPSHOT" =~ ^[0-9]{8}T[0-9]{6}Z$ ]]; then
     exit 1
 fi
 
-log=$(mktemp)
-trap 'rm -f "$log"' EXIT
+# Suites must match the running host (not the image's Release=): these debs
+# execute here, and only the runner knows its own release.
+codename=$(. /etc/os-release && echo "${VERSION_CODENAME:?}")
 
-if [ -n "$cachedir" ] && compgen -G "$cachedir/*.deb" >/dev/null; then
-    # Warm: reinstall the cached transaction with apt sources nulled — fully
-    # offline, so a deb set that no longer resolves fails instead of drifting.
+log=$(mktemp)
+scratch=$(mktemp -d)
+trap 'rm -rf "$log" "$scratch"' EXIT
+
+apt_offline() {
     sudo DEBIAN_FRONTEND=noninteractive apt-get \
         -o Dir::Etc::sourcelist=/dev/null \
         -o Dir::Etc::sourceparts=/dev/null \
         -o Dpkg::Options::=--force-confdef \
         -o Dpkg::Options::=--force-confold \
-        install -y --allow-downgrades "$cachedir"/*.deb 2>&1 | tee -a "$log"
-else
-    # Suites must match the running host (not the image's Release=): these
-    # debs execute here, and only the runner knows its own release.
-    codename=$(. /etc/os-release && echo "${VERSION_CODENAME:?}")
-    sources=$(mktemp --suffix=.list)
-    prefs=$(mktemp)
-    trap 'rm -f "$sources" "$prefs" "$log"' EXIT
+        "$@" 2>&1 | tee -a "$log"
+}
+
+# INVARIANT: the cache is an optimization, never an authority — it is trusted
+# only while its manifest matches this pin, host release, package list, and
+# deb hashes, and only until the post-install version check agrees.
+manifest_ok() {
+    local sums
+    [ -n "$cachedir" ] && [ -f "$cachedir/manifest" ] || return 1
+    grep -qxF "snapshot $SNAPSHOT" "$cachedir/manifest" || return 1
+    grep -qxF "codename $codename" "$cachedir/manifest" || return 1
+    grep -qxF "packages $*" "$cachedir/manifest" || return 1
+    sums=$(sed -n 's/^sha256 //p' "$cachedir/manifest")
+    # A zero-deb manifest (everything was already at snapshot versions) is
+    # legal; sha256sum -c rejects an empty list.
+    [ -z "$sums" ] \
+        || printf '%s\n' "$sums" | (cd "$cachedir" && sha256sum -c --quiet -) >/dev/null 2>&1
+}
+
+# Every requested package sits at the version the manifest's cold run
+# resolved from the snapshot. Catches what the deb set alone cannot: a
+# package the cold run never downloaded (already at the snapshot version
+# then) that a newer runner image has since moved (#36).
+versions_match() {
+    local pkg want have
+    for pkg in "$@"; do
+        want=$(awk -v p="$pkg" '$1 == "resolved" && $2 == p { print $3 }' "$cachedir/manifest")
+        have=$(dpkg-query -W -f '${Version}' "$pkg" 2>/dev/null) || return 1
+        [ "$want" = "$have" ] || return 1
+    done
+}
+
+install_cold() {
+    local sources="$scratch/snapshot.list" prefs="$scratch/prefs" archives="$scratch/archives"
     # One-line format: apt only parses deb822 from Dir::Etc::sourceparts.
     for pocket in "$codename" "$codename-updates" "$codename-security"; do
-        echo "deb [signed-by=/usr/share/keyrings/ubuntu-archive-keyring.gpg] https://snapshot.ubuntu.com/ubuntu/${SNAPSHOT} ${pocket} main universe" >> "$sources"
-    done
+        echo "deb [signed-by=/usr/share/keyrings/ubuntu-archive-keyring.gpg] https://snapshot.ubuntu.com/ubuntu/${SNAPSHOT} ${pocket} main universe"
+    done > "$sources"
     # Priority > 1000: the host image tracks the live archive, so its
-    # installed debs run ahead of any fixed snapshot; without this, apt keeps
-    # the newer installed version as candidate and a strict = dependency
-    # (systemd-container on libsystemd-shared) is unsatisfiable. Above 1000,
-    # the snapshot version wins even when that is a downgrade — the dep
-    # closure moves to the snapshot.
-    cat > "$prefs" <<EOF
-Package: *
-Pin: origin "snapshot.ubuntu.com"
-Pin-Priority: 1001
-EOF
+    # installed debs run ahead of any fixed snapshot; without this, apt
+    # keeps the newer installed version as candidate and a strict =
+    # dependency (systemd-container on libsystemd-shared) is unsatisfiable.
+    # Above 1000, the snapshot version wins even when that is a downgrade —
+    # the dep closure moves to the snapshot.
+    printf 'Package: *\nPin: origin "snapshot.ubuntu.com"\nPin-Priority: 1001\n' > "$prefs"
+    # A private archives dir so the cache below holds exactly this
+    # transaction's debs — the shared /var/cache/apt/archives carries debs
+    # from whatever else ran on the host (live-mirror ones included).
+    mkdir -p "$archives"
+    chmod 755 "$scratch" "$archives"
 
     # Bounded fetches: a dead mirror otherwise hangs until the caller's job
     # limit. Non-interactive dpkg: downgrades would otherwise stop on
-    # conffile prompts. Kept archives feed the --cache-dir copy below.
+    # conffile prompts. List-Cleanup off: the confined update must not
+    # delete the host's own live package lists (#36 pins our debs, not the
+    # dev machine's apt).
     apt_snapshot() {
         sudo DEBIAN_FRONTEND=noninteractive apt-get \
             -o Dir::Etc::sourcelist="$sources" \
             -o Dir::Etc::sourceparts=/dev/null \
             -o Dir::Etc::preferences="$prefs" \
             -o Dir::Etc::preferencesparts=/dev/null \
+            -o Dir::Cache::archives="$archives" \
+            -o APT::Get::List-Cleanup=0 \
             -o Acquire::http::Timeout=30 \
             -o Acquire::https::Timeout=30 \
             -o Acquire::Retries=3 \
@@ -140,8 +169,33 @@ EOF
 
     if [ -n "$cachedir" ]; then
         mkdir -p "$cachedir"
-        cp /var/cache/apt/archives/*.deb "$cachedir"/
+        rm -f "$cachedir"/*.deb "$cachedir/manifest"
+        if compgen -G "$archives/*.deb" >/dev/null; then
+            cp "$archives"/*.deb "$cachedir"/
+        fi
+        {
+            echo "snapshot $SNAPSHOT"
+            echo "codename $codename"
+            echo "packages $*"
+            dpkg-query -W -f 'resolved ${Package} ${Version}\n' "$@"
+            if compgen -G "$cachedir/*.deb" >/dev/null; then
+                (cd "$cachedir" && sha256sum -- *.deb | sed 's/^/sha256 /')
+            fi
+        } > "$cachedir/manifest"
     fi
+}
+
+warm=false
+if manifest_ok "$@"; then
+    # Warm: reinstall the cached transaction with apt sources nulled — fully
+    # offline, so nothing can drift; any failure falls back to a cold run.
+    if ! compgen -G "$cachedir/*.deb" >/dev/null \
+        || apt_offline install -y --allow-downgrades "$cachedir"/*.deb; then
+        versions_match "$@" && warm=true
+    fi
+fi
+if [ "$warm" != true ]; then
+    install_cold "$@"
 fi
 
 live=$(scan_live < "$log" || true)

--- a/bin/host-deps
+++ b/bin/host-deps
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Install host build deps from snapshot.ubuntu.com at a committed timestamp.
+# Install host build deps from snapshot.ubuntu.com at the committed base pin.
 #
 # The host toolchain shapes measured bytes (#36): iasl (acpica-tools) compiles
 # the trusted DSDT prepended to the initrd, and ovmf is the published SNP
@@ -11,70 +11,147 @@
 # mirrors are unconfigured, not merely unpreferred), and the apt transcript
 # is still scanned for live ubuntu.com fetches — config presence alone has
 # failed open before.
+#
+# Usage: host-deps [--cache-dir DIR] <package>...
+#   --cache-dir DIR  Reinstall DIR's debs fully offline when present (warm),
+#                    else fill DIR with the transaction's debs (cold). CI
+#                    keys DIR's cache on this script + the base mkosi.sources.
+#   --self-test      Run the transcript scanner against the vector set of
+#                    src/tools.rs's is_live_mirror_fetch tests and exit.
 set -euo pipefail
 
-# INVARIANT: every deb this script installs resolves from this snapshot.
-# Bump deliberately: a new timestamp changes the host toolchain and can move
-# the measurement — refresh downstream pinned digests with it.
-SNAPSHOT=20260430T000000Z
+# Transcript scanner, kept in parity with confos's is_live_mirror_fetch by
+# --self-test (bin/lint runs it): an apt fetch-progress line hitting any
+# ubuntu.com host other than snapshot is a live, drifting mirror. Non-Ubuntu
+# (third-party) hosts are out of scope.
+LIVE_RE='^[[:space:]]*(Get|Hit|Ign|Err):[0-9]+ https?://([a-z0-9.-]*\.)?ubuntu\.com([:/ ]|$)'
+ALLOW_RE='^[[:space:]]*(Get|Hit|Ign|Err):[0-9]+ https?://snapshot\.ubuntu\.com([:/ ]|$)'
+scan_live() {
+    grep -iE "$LIVE_RE" | grep -ivE "$ALLOW_RE"
+}
 
-[ "$#" -gt 0 ] || { echo "usage: host-deps <package>..." >&2; exit 1; }
+if [ "${1:-}" = --self-test ]; then
+    # INVARIANT: same verdicts as src/tools.rs's is_live_mirror_fetch tests.
+    flagged=(
+        'Get:1 http://archive.ubuntu.com/ubuntu resolute InRelease [136 kB]'
+        'Hit:3 http://security.ubuntu.com/ubuntu resolute-security InRelease'
+        'Err:12 https://ports.ubuntu.com resolute/main arm64 Packages'
+        'Get:7 http://azure.archive.ubuntu.com/ubuntu resolute/main amd64 tar 1.35 [258 kB]'
+        'Ign:2 https://esm.ubuntu.com/apps/ubuntu resolute-apps-security InRelease'
+        'Get:4 http://old-releases.ubuntu.com/ubuntu resolute InRelease'
+        'Get:5 http://Archive.Ubuntu.com/ubuntu resolute InRelease'
+        'Get:6 http://archive.ubuntu.com:80/ubuntu resolute InRelease'
+    )
+    clean=(
+        'Get:1 https://snapshot.ubuntu.com/ubuntu/20260405T000000Z/dists/resolute/InRelease [136 kB]'
+        'URIs: http://archive.ubuntu.com/ubuntu'
+        'mkosi: falling back to archive.ubuntu.com'
+        'Get:x http://archive.ubuntu.com/ubuntu resolute InRelease'
+        'Get:1 http://packages.microsoft.com/repos/azure-cli resolute InRelease'
+    )
+    for line in "${flagged[@]}"; do
+        [ -n "$(printf '%s\n' "$line" | scan_live || true)" ] \
+            || { echo "host-deps --self-test: live-mirror line not flagged: $line" >&2; exit 1; }
+    done
+    for line in "${clean[@]}"; do
+        [ -z "$(printf '%s\n' "$line" | scan_live || true)" ] \
+            || { echo "host-deps --self-test: benign line flagged: $line" >&2; exit 1; }
+    done
+    echo "host-deps --self-test: ok"
+    exit 0
+fi
 
-codename=$(. /etc/os-release && echo "${VERSION_CODENAME:?}")
+cachedir=""
+if [ "${1:-}" = --cache-dir ]; then
+    # ./-prefix a relative dir: apt reads a bare foo/x.deb as pkg/release.
+    case "$2" in
+        /*) cachedir=$2 ;;
+        *) cachedir="./$2" ;;
+    esac
+    shift 2
+fi
+[ "$#" -gt 0 ] || { echo "usage: host-deps [--cache-dir DIR] <package>..." >&2; exit 1; }
 
-sources=$(mktemp --suffix=.list)
-prefs=$(mktemp)
+# The pin is the base image's committed snapshot — one bump moves the image
+# and the host toolchain together, and can move measurements (#36).
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BASE_SOURCES="$ROOT/mkosi/base/mkosi.sandbox/etc/apt/sources.list.d/mkosi.sources"
+SNAPSHOT=$(sed -n 's#^URIs: https://snapshot\.ubuntu\.com/ubuntu/##p' "$BASE_SOURCES")
+if ! [[ "$SNAPSHOT" =~ ^[0-9]{8}T[0-9]{6}Z$ ]]; then
+    echo "host-deps: no snapshot pin readable from $BASE_SOURCES" >&2
+    exit 1
+fi
+
 log=$(mktemp)
-trap 'rm -f "$sources" "$prefs" "$log"' EXIT
-# One-line format: apt only parses deb822 from Dir::Etc::sourceparts.
-for pocket in "$codename" "$codename-updates" "$codename-security"; do
-    echo "deb [signed-by=/usr/share/keyrings/ubuntu-archive-keyring.gpg] https://snapshot.ubuntu.com/ubuntu/${SNAPSHOT} ${pocket} main universe" >> "$sources"
-done
-# Priority > 1000: the host image tracks the live archive, so its installed
-# debs run ahead of any fixed snapshot; without this, apt keeps the newer
-# installed version as candidate and a strict = dependency (systemd-container
-# on libsystemd-shared) is unsatisfiable. Above 1000, the snapshot version
-# wins even when that is a downgrade — the dep closure moves to the snapshot.
-cat > "$prefs" <<EOF
+trap 'rm -f "$log"' EXIT
+
+if [ -n "$cachedir" ] && compgen -G "$cachedir/*.deb" >/dev/null; then
+    # Warm: reinstall the cached transaction with apt sources nulled — fully
+    # offline, so a deb set that no longer resolves fails instead of drifting.
+    sudo DEBIAN_FRONTEND=noninteractive apt-get \
+        -o Dir::Etc::sourcelist=/dev/null \
+        -o Dir::Etc::sourceparts=/dev/null \
+        -o Dpkg::Options::=--force-confdef \
+        -o Dpkg::Options::=--force-confold \
+        install -y --allow-downgrades "$cachedir"/*.deb 2>&1 | tee -a "$log"
+else
+    # Suites must match the running host (not the image's Release=): these
+    # debs execute here, and only the runner knows its own release.
+    codename=$(. /etc/os-release && echo "${VERSION_CODENAME:?}")
+    sources=$(mktemp --suffix=.list)
+    prefs=$(mktemp)
+    trap 'rm -f "$sources" "$prefs" "$log"' EXIT
+    # One-line format: apt only parses deb822 from Dir::Etc::sourceparts.
+    for pocket in "$codename" "$codename-updates" "$codename-security"; do
+        echo "deb [signed-by=/usr/share/keyrings/ubuntu-archive-keyring.gpg] https://snapshot.ubuntu.com/ubuntu/${SNAPSHOT} ${pocket} main universe" >> "$sources"
+    done
+    # Priority > 1000: the host image tracks the live archive, so its
+    # installed debs run ahead of any fixed snapshot; without this, apt keeps
+    # the newer installed version as candidate and a strict = dependency
+    # (systemd-container on libsystemd-shared) is unsatisfiable. Above 1000,
+    # the snapshot version wins even when that is a downgrade — the dep
+    # closure moves to the snapshot.
+    cat > "$prefs" <<EOF
 Package: *
 Pin: origin "snapshot.ubuntu.com"
 Pin-Priority: 1001
 EOF
 
-# Bounded fetches: a dead mirror otherwise hangs until the caller's job limit.
-# Non-interactive dpkg: downgrades would otherwise stop on conffile prompts.
-# Keep downloaded archives: CI callers cache the resolved debs for offline
-# warm reinstalls (c8s's apt-debs cache).
-apt_snapshot() {
-    sudo DEBIAN_FRONTEND=noninteractive apt-get \
-        -o Dir::Etc::sourcelist="$sources" \
-        -o Dir::Etc::sourceparts=/dev/null \
-        -o Dir::Etc::preferences="$prefs" \
-        -o Dir::Etc::preferencesparts=/dev/null \
-        -o Acquire::http::Timeout=30 \
-        -o Acquire::https::Timeout=30 \
-        -o Acquire::Retries=3 \
-        -o Dpkg::Options::=--force-confdef \
-        -o Dpkg::Options::=--force-confold \
-        -o APT::Keep-Downloaded-Packages=true \
-        "$@" 2>&1 | tee -a "$log"
-}
+    # Bounded fetches: a dead mirror otherwise hangs until the caller's job
+    # limit. Non-interactive dpkg: downgrades would otherwise stop on
+    # conffile prompts. Kept archives feed the --cache-dir copy below.
+    apt_snapshot() {
+        sudo DEBIAN_FRONTEND=noninteractive apt-get \
+            -o Dir::Etc::sourcelist="$sources" \
+            -o Dir::Etc::sourceparts=/dev/null \
+            -o Dir::Etc::preferences="$prefs" \
+            -o Dir::Etc::preferencesparts=/dev/null \
+            -o Acquire::http::Timeout=30 \
+            -o Acquire::https::Timeout=30 \
+            -o Acquire::Retries=3 \
+            -o Dpkg::Options::=--force-confdef \
+            -o Dpkg::Options::=--force-confold \
+            -o APT::Keep-Downloaded-Packages=true \
+            "$@" 2>&1 | tee -a "$log"
+    }
 
-apt_snapshot update
-apt_snapshot install -y --allow-downgrades "$@"
+    apt_snapshot update
+    apt_snapshot install -y --allow-downgrades "$@"
 
-# Backstop, kept in parity with confos's is_live_mirror_fetch: an apt
-# fetch-progress line hitting any ubuntu.com host other than snapshot is a
-# live, drifting mirror. Non-Ubuntu (third-party) hosts are out of scope.
-allow='^[[:space:]]*(Get|Hit|Ign|Err):[0-9]+ https?://snapshot\.ubuntu\.com([:/ ]|$)'
-live=$(grep -iE '^[[:space:]]*(Get|Hit|Ign|Err):[0-9]+ https?://([a-z0-9.-]*\.)?ubuntu\.com([:/ ]|$)' "$log" \
-    | grep -ivE "$allow" || true)
+    if [ -n "$cachedir" ]; then
+        mkdir -p "$cachedir"
+        cp /var/cache/apt/archives/*.deb "$cachedir"/
+    fi
+fi
+
+live=$(scan_live < "$log" || true)
 if [ -n "$live" ]; then
     echo "host-deps: fetched from live (unpinned) Ubuntu mirrors — the measurement would drift with the archive (#36):" >&2
     echo "$live" >&2
     exit 1
 fi
 
-# The resolved deb set, for auditing a published measurement's toolchain.
+# The requested packages' resolved versions, for auditing a published
+# measurement's toolchain; --cache-dir callers hold the full deb closure.
 echo "host-deps: installed from snapshot ${SNAPSHOT}:"
 dpkg-query -W "$@"

--- a/bin/host-deps
+++ b/bin/host-deps
@@ -43,6 +43,8 @@ EOF
 
 # Bounded fetches: a dead mirror otherwise hangs until the caller's job limit.
 # Non-interactive dpkg: downgrades would otherwise stop on conffile prompts.
+# Keep downloaded archives: CI callers cache the resolved debs for offline
+# warm reinstalls (c8s's apt-debs cache).
 apt_snapshot() {
     sudo DEBIAN_FRONTEND=noninteractive apt-get \
         -o Dir::Etc::sourcelist="$sources" \
@@ -54,6 +56,7 @@ apt_snapshot() {
         -o Acquire::Retries=3 \
         -o Dpkg::Options::=--force-confdef \
         -o Dpkg::Options::=--force-confold \
+        -o APT::Keep-Downloaded-Packages=true \
         "$@" 2>&1 | tee -a "$log"
 }
 

--- a/bin/lint
+++ b/bin/lint
@@ -61,6 +61,20 @@ if [ -n "$failopen" ]; then
     echo "$failopen" >&2
     exit 1
 fi
+# Host toolchain debs shape measured bytes too (iasl compiles the trusted
+# DSDT; ovmf is the published SNP firmware), so host installs must ride
+# bin/host-deps' committed snapshot, not the live archive (#36).
+if ! grep -qE '^SNAPSHOT=[0-9]{8}T[0-9]{6}Z$' bin/host-deps; then
+    echo "bin/lint: bin/host-deps must pin SNAPSHOT to a snapshot.ubuntu.com timestamp (#36)" >&2
+    exit 1
+fi
+rawinstall=$(git grep -nE '\bapt(-get)?\b.*\binstall\b' -- '.github/workflows/' bin/setup || true)
+if [ -n "$rawinstall" ]; then
+    echo "bin/lint: host debs must install via bin/host-deps (snapshot-pinned, fail-closed, #36), not raw apt:" >&2
+    echo "$rawinstall" >&2
+    exit 1
+fi
+
 pin='^URIs: https://snapshot\.ubuntu\.com/ubuntu/[0-9]{8}T[0-9]{6}Z$'
 for conf in mkosi/*/mkosi.conf; do
     dir=$(dirname "$conf")

--- a/bin/lint
+++ b/bin/lint
@@ -64,9 +64,12 @@ fi
 # Host toolchain debs shape measured bytes too (iasl compiles the trusted
 # DSDT; ovmf is the published SNP firmware), so bin/host-deps is the only
 # permitted apt caller in bin/ and .github/ (#36), and its transcript
-# scanner must keep parity with src/tools.rs's is_live_mirror_fetch vectors.
+# scanner must keep parity with the shared is_live_mirror_fetch vectors.
+# The apt pattern is deliberately broad (no sudo/\b anchors: sudo-less
+# container jobs count, and \b is a no-op in macOS git grep) — reword prose
+# that trips it rather than narrowing it.
 bin/host-deps --self-test >/dev/null
-rawinstall=$(git grep -nE 'sudo +(DEBIAN_FRONTEND=[^ ]+ +)?apt(-get)?\b.*\binstall\b' -- '.github/' 'bin/' ':!bin/host-deps' || true)
+rawinstall=$(git grep -nE 'apt(-get)?[[:space:]].*install' -- '.github/' 'bin/' ':!bin/host-deps' || true)
 if [ -n "$rawinstall" ]; then
     echo "bin/lint: host debs must install via bin/host-deps (snapshot-pinned, fail-closed, #36), not raw apt:" >&2
     echo "$rawinstall" >&2

--- a/bin/lint
+++ b/bin/lint
@@ -62,13 +62,11 @@ if [ -n "$failopen" ]; then
     exit 1
 fi
 # Host toolchain debs shape measured bytes too (iasl compiles the trusted
-# DSDT; ovmf is the published SNP firmware), so host installs must ride
-# bin/host-deps' committed snapshot, not the live archive (#36).
-if ! grep -qE '^SNAPSHOT=[0-9]{8}T[0-9]{6}Z$' bin/host-deps; then
-    echo "bin/lint: bin/host-deps must pin SNAPSHOT to a snapshot.ubuntu.com timestamp (#36)" >&2
-    exit 1
-fi
-rawinstall=$(git grep -nE '\bapt(-get)?\b.*\binstall\b' -- '.github/workflows/' bin/setup || true)
+# DSDT; ovmf is the published SNP firmware), so bin/host-deps is the only
+# permitted apt caller in bin/ and .github/ (#36), and its transcript
+# scanner must keep parity with src/tools.rs's is_live_mirror_fetch vectors.
+bin/host-deps --self-test >/dev/null
+rawinstall=$(git grep -nE 'sudo +(DEBIAN_FRONTEND=[^ ]+ +)?apt(-get)?\b.*\binstall\b' -- '.github/' 'bin/' ':!bin/host-deps' || true)
 if [ -n "$rawinstall" ]; then
     echo "bin/lint: host debs must install via bin/host-deps (snapshot-pinned, fail-closed, #36), not raw apt:" >&2
     echo "$rawinstall" >&2

--- a/bin/setup
+++ b/bin/setup
@@ -13,8 +13,7 @@ echo "==> Installing system packages..."
 # firmware (OVMF.inteltdx.fd, -bios-bootable) is vendored at firmware/ — see
 # firmware/README, #82 — not apt-installed. Keep host deps in lockstep with
 # .github/workflows/base.yml.
-# host-deps pins every deb to a committed snapshot (#36): iasl and ovmf shape
-# measured bytes, so a live-archive install can miss published measurements.
+# host-deps pins every deb to the base image's committed snapshot (#36).
 "$DIR/host-deps" build-essential systemd-repart systemd-container qemu-utils genisoimage swtpm cpio acpica-tools ovmf
 
 echo "==> Installing uv..."

--- a/bin/setup
+++ b/bin/setup
@@ -5,7 +5,6 @@ DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 set -x
 
 echo "==> Installing system packages..."
-sudo apt-get update
 # acpica-tools provides iasl, used at build time to compile the trusted
 # DSDT (mkosi/base/acpi-tables/dsdt.asl) that gets injected into the
 # initrd so the kernel's CONFIG_ACPI_TABLE_UPGRADE replaces the
@@ -14,7 +13,9 @@ sudo apt-get update
 # firmware (OVMF.inteltdx.fd, -bios-bootable) is vendored at firmware/ — see
 # firmware/README, #82 — not apt-installed. Keep host deps in lockstep with
 # .github/workflows/base.yml.
-sudo apt install -y build-essential systemd-repart systemd-container qemu-utils genisoimage swtpm cpio acpica-tools ovmf
+# host-deps pins every deb to a committed snapshot (#36): iasl and ovmf shape
+# measured bytes, so a live-archive install can miss published measurements.
+"$DIR/host-deps" build-essential systemd-repart systemd-container qemu-utils genisoimage swtpm cpio acpica-tools ovmf
 
 echo "==> Installing uv..."
 which uv || curl -LsSf https://astral.sh/uv/install.sh | sh

--- a/docs/REPRODUCIBILITY.md
+++ b/docs/REPRODUCIBILITY.md
@@ -71,8 +71,12 @@ pin (read from its `mkosi.sources`, so one bump moves image and host
 toolchain together), confining apt to a snapshot-only source list
 (pinned above priority 1000, so the dep closure moves to the snapshot's
 versions even when the runner image is ahead) and scanning the apt
-transcript for live-mirror fetches, with the scanner's parity to
-`is_live_mirror_fetch` enforced by a vector self-test in `bin/lint`.
+transcript for live-mirror fetches, with the shell scanner and
+`is_live_mirror_fetch` tested against one shared vector fixture
+(`tests/fixtures/live-mirror-vectors.txt`) so they cannot drift apart.
+Its CI deb cache is an optimization, never an authority: a manifest
+records the pin, host release, package list, resolved versions, and
+deb hashes, and any mismatch falls back to a fresh snapshot install.
 CI and `bin/setup` install host deps only through it, and `bin/lint`
 rejects raw apt installs elsewhere in `bin/` and `.github/`.
 

--- a/docs/REPRODUCIBILITY.md
+++ b/docs/REPRODUCIBILITY.md
@@ -48,16 +48,30 @@ We use several techniques to ensure the results of our builds are reproducible, 
 
 ### apt mirror pinning
 
-Identical package *versions* across builds are enforced by pinning
-`Mirror=` (and `ToolsTreeMirror=`) in `mkosi/base/mkosi.conf`,
-`mkosi/base/mkosi.conf.d/tools.conf`, and
-`mkosi/kernel-builder/mkosi.conf` to a point-in-time
-`snapshot.ubuntu.com` URL. Bumping that timestamp is the deliberate act
-that picks up security updates — and changes the roothash.
+Identical package *versions* across builds are enforced by pinning every
+apt pocket to a point-in-time `snapshot.ubuntu.com` URL via each image
+dir's `mkosi.sandbox/etc/apt/sources.list.d/mkosi.sources` (#96 — the
+older `Mirror=`/`ToolsTreeMirror=` mechanism left the security pocket
+live and is rejected by `bin/lint`). Bumping that timestamp is the
+deliberate act that picks up security updates — and changes the roothash.
 
-`bin/lint` fails on any `Mirror=`/`ToolsTreeMirror=` that does not point
-at `snapshot.ubuntu.com`, so an outage workaround cannot outlive the
-outage.
+Two guards keep this fail-closed: `bin/lint` asserts the config shape
+(pinned `URIs:` lines, no `Mirror=`/`Snapshot=`), and confos's
+`run_mkosi` scans the apt transcript of every build and fails on any
+fetch from a live ubuntu.com mirror — config presence alone has failed
+open before.
+
+### Host toolchain pinning
+
+The build host's own toolchain shapes measured bytes too (#36): `iasl`
+(acpica-tools) compiles the trusted DSDT prepended to the initrd, and
+`ovmf` is the published SNP firmware. `bin/host-deps` installs all host
+build deps from `snapshot.ubuntu.com` at its own committed timestamp,
+confining apt to a snapshot-only source list (pinned above priority
+1000, so the dep closure moves to the snapshot's versions even when the
+runner image is ahead) and scanning the apt transcript for live-mirror
+fetches. CI and `bin/setup` install host deps only through it, and
+`bin/lint` rejects raw apt installs there.
 
 mkosi itself is pinned to v26 — `bin/setup` and CI install exactly
 `mkosi.git@v26`, and `mkosi.conf` enforces `MinimumVersion=26` as a

--- a/docs/REPRODUCIBILITY.md
+++ b/docs/REPRODUCIBILITY.md
@@ -66,12 +66,15 @@ open before.
 The build host's own toolchain shapes measured bytes too (#36): `iasl`
 (acpica-tools) compiles the trusted DSDT prepended to the initrd, and
 `ovmf` is the published SNP firmware. `bin/host-deps` installs all host
-build deps from `snapshot.ubuntu.com` at its own committed timestamp,
-confining apt to a snapshot-only source list (pinned above priority
-1000, so the dep closure moves to the snapshot's versions even when the
-runner image is ahead) and scanning the apt transcript for live-mirror
-fetches. CI and `bin/setup` install host deps only through it, and
-`bin/lint` rejects raw apt installs there.
+build deps from `snapshot.ubuntu.com` at the base image's committed
+pin (read from its `mkosi.sources`, so one bump moves image and host
+toolchain together), confining apt to a snapshot-only source list
+(pinned above priority 1000, so the dep closure moves to the snapshot's
+versions even when the runner image is ahead) and scanning the apt
+transcript for live-mirror fetches, with the scanner's parity to
+`is_live_mirror_fetch` enforced by a vector self-test in `bin/lint`.
+CI and `bin/setup` install host deps only through it, and `bin/lint`
+rejects raw apt installs elsewhere in `bin/` and `.github/`.
 
 mkosi itself is pinned to v26 — `bin/setup` and CI install exactly
 `mkosi.git@v26`, and `mkosi.conf` enforces `MinimumVersion=26` as a

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -45,18 +45,14 @@ pub fn run(args: &RunArgs) -> anyhow::Result<()> {
         }
     }
 
-    // Resolve artifacts based on tier
-    let igvm_path;
-    let uki_path;
-    let firmware_path;
-
     // Default to the first variant (smallest SMP after sort, or the build-time
     // default if `confos igvm` was never run). A future change can add a `--smp`
     // selector to `confos run`; for now this matches v1 behaviour of "one IGVM
     // per output dir."
     let variant = manifest.snp_variants.first();
 
-    match tier {
+    // Resolve artifacts based on tier
+    let (igvm_path, uki_path, firmware_path) = match tier {
         QemuTier::SevSnp => {
             let v = variant.ok_or_else(|| {
                 anyhow::anyhow!(
@@ -73,9 +69,7 @@ pub fn run(args: &RunArgs) -> anyhow::Result<()> {
                     v.smp,
                 );
             }
-            igvm_path = Some(path);
-            uki_path = None;
-            firmware_path = None;
+            (Some(path), None, None)
         }
         QemuTier::Kvm | QemuTier::Emulated => {
             let uki = args.dir.join("uki.efi");
@@ -101,11 +95,9 @@ pub fn run(args: &RunArgs) -> anyhow::Result<()> {
                     "no firmware available — image was built with --skip-igvm. Pass --firmware <path> to run on KVM."
                 );
             };
-            igvm_path = None;
-            uki_path = Some(uki);
-            firmware_path = Some(fw);
+            (None, Some(uki), Some(fw))
         }
-    }
+    };
 
     // Find disk image
     let disk_path = args.dir.join(format!("disk.{}", manifest.build.format));

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -353,39 +353,26 @@ mod tests {
         force_remove_dir_all(&missing).unwrap();
     }
 
+    // The vectors are shared with bin/host-deps --self-test (run by
+    // bin/lint), so the Rust and shell scanners cannot drift apart silently:
+    // a new case added here fails the shell side until its pattern learns it.
     #[test]
-    fn is_live_mirror_fetch_flags_any_nonsnapshot_ubuntu_host() {
-        for line in [
-            "Get:1 http://archive.ubuntu.com/ubuntu resolute InRelease [136 kB]",
-            "Hit:3 http://security.ubuntu.com/ubuntu resolute-security InRelease",
-            "Err:12 https://ports.ubuntu.com resolute/main arm64 Packages",
-            "Get:7 http://azure.archive.ubuntu.com/ubuntu resolute/main amd64 tar 1.35 [258 kB]",
-            "Ign:2 https://esm.ubuntu.com/apps/ubuntu resolute-apps-security InRelease",
-            // Allowlist, not blocklist: hosts we never enumerated still flag.
-            "Get:4 http://old-releases.ubuntu.com/ubuntu resolute InRelease",
-            // Spelling variants cannot slip past normalization.
-            "Get:5 http://Archive.Ubuntu.com/ubuntu resolute InRelease",
-            "Get:6 http://archive.ubuntu.com:80/ubuntu resolute InRelease",
-        ] {
-            assert!(is_live_mirror_fetch(line), "{line}");
+    fn is_live_mirror_fetch_matches_shared_vectors() {
+        let vectors = include_str!("../tests/fixtures/live-mirror-vectors.txt");
+        let mut checked = 0;
+        for line in vectors.lines() {
+            if line.is_empty() || line.starts_with('#') {
+                continue;
+            }
+            let (expect, vector) = line.split_once('\t').expect("expect<TAB>line");
+            let want = match expect {
+                "flag" => true,
+                "pass" => false,
+                other => panic!("bad vector expectation: {other}"),
+            };
+            assert_eq!(is_live_mirror_fetch(vector), want, "{vector}");
+            checked += 1;
         }
-    }
-
-    #[test]
-    fn is_live_mirror_fetch_ignores_pinned_and_non_fetch_lines() {
-        for line in [
-            // The pin working as intended.
-            "Get:1 https://snapshot.ubuntu.com/ubuntu/20260405T000000Z/dists/resolute/InRelease [136 kB]",
-            // deb822 config echo names the live host by design; not a fetch.
-            "URIs: http://archive.ubuntu.com/ubuntu",
-            // Prose mentioning a live host.
-            "mkosi: falling back to archive.ubuntu.com",
-            // Malformed sequence number — not an apt progress line.
-            "Get:x http://archive.ubuntu.com/ubuntu resolute InRelease",
-            // Non-Ubuntu third-party hosts are out of scope.
-            "Get:1 http://packages.microsoft.com/repos/azure-cli resolute InRelease",
-        ] {
-            assert!(!is_live_mirror_fetch(line), "{line}");
-        }
+        assert!(checked >= 15, "vector fixture went missing or empty");
     }
 }

--- a/tests/fixtures/live-mirror-vectors.txt
+++ b/tests/fixtures/live-mirror-vectors.txt
@@ -1,0 +1,28 @@
+# Shared vectors for the live-mirror fetch predicate: src/tools.rs's
+# is_live_mirror_fetch test and bin/host-deps --self-test both consume this
+# file, so the Rust and shell scanners cannot drift apart silently (#36).
+# Format: flag|pass<TAB>line. flag = live-mirror fetch, must be caught.
+flag	Get:1 http://archive.ubuntu.com/ubuntu resolute InRelease [136 kB]
+flag	Hit:3 http://security.ubuntu.com/ubuntu resolute-security InRelease
+flag	Err:12 https://ports.ubuntu.com resolute/main arm64 Packages
+flag	Get:7 http://azure.archive.ubuntu.com/ubuntu resolute/main amd64 tar 1.35 [258 kB]
+flag	Ign:2 https://esm.ubuntu.com/apps/ubuntu resolute-apps-security InRelease
+# Allowlist, not blocklist: hosts we never enumerated still flag.
+flag	Get:4 http://old-releases.ubuntu.com/ubuntu resolute InRelease
+# Spelling variants cannot slip past normalization.
+flag	Get:5 http://Archive.Ubuntu.com/ubuntu resolute InRelease
+flag	Get:6 http://archive.ubuntu.com:80/ubuntu resolute InRelease
+# Whitespace runs between the tag and the URL still parse as a fetch line.
+flag	Get:8  http://archive.ubuntu.com/ubuntu resolute InRelease
+# Userinfo does not hide the host.
+flag	Get:9 http://user@archive.ubuntu.com/ubuntu resolute InRelease
+# The pin working as intended.
+pass	Get:1 https://snapshot.ubuntu.com/ubuntu/20260405T000000Z/dists/resolute/InRelease [136 kB]
+# deb822 config echo names the live host by design; not a fetch.
+pass	URIs: http://archive.ubuntu.com/ubuntu
+# Prose mentioning a live host.
+pass	mkosi: falling back to archive.ubuntu.com
+# Malformed sequence number — not an apt progress line.
+pass	Get:x http://archive.ubuntu.com/ubuntu resolute InRelease
+# Non-Ubuntu third-party hosts are out of scope.
+pass	Get:1 http://packages.microsoft.com/repos/azure-cli resolute InRelease


### PR DESCRIPTION
## What problem does this change solve?

Closes the remaining scope of #36: the build host's own toolchain was the last unpinned measured input. `iasl` (acpica-tools) compiles the trusted DSDT prepended to the initrd and `ovmf` is the published SNP firmware, yet both installed from the **live** Ubuntu archive on every runner — a rebuild weeks later could miss a published measurement even with all image inputs pinned.

## Why is this solution the best option to solve that problem?

It is #96's proven design applied to the host: a committed snapshot.ubuntu.com timestamp, fail-closed in two layers. Alternatives considered: caching host debs per runner image (c8s-side) is a freeze with an unreviewed refresh on runner rotation, not a pin; pinning only `acpica-tools`/`ovmf` by explicit version leaves their dep closures live and still drifts.

`bin/host-deps` installs host build deps from the snapshot at `SNAPSHOT=20260430T000000Z` (same timestamp as the base/initrd image pin):

- **Preventive**: apt is confined to a snapshot-only source list for the transaction (live mirrors are unconfigured, not merely unpreferred), pinned above priority 1000 — the runner image tracks the live archive, so its installed debs run ahead of any fixed snapshot, and strict `=` deps (`systemd-container` → `libsystemd-shared`) are unsatisfiable unless the dep closure moves back to the snapshot's versions.
- **Detective**: the apt transcript is scanned for fetch-progress lines hitting any ubuntu.com host other than snapshot, in parity with `is_live_mirror_fetch` — config presence alone has failed open before (#96).

It ends by logging the resolved deb set, so a published measurement's toolchain is auditable from the run log. `base.yml` and `bin/setup` install host deps only through it; `bin/lint` asserts the pin shape and rejects raw apt installs in those files. `docs/REPRODUCIBILITY.md`'s stale `Mirror=`-era section is brought current alongside.

**Verification**
- Guard grep tested against the exact case set of `is_live_mirror_fetch`'s unit tests: all 8 live-mirror lines flagged, all 5 benign lines pass.
- End-to-end in `ubuntu:24.04` amd64 (the runner's release): the full `bin/setup` package list installs with **zero** non-snapshot fetches; with live `systemd` 255.4-1ubuntu8.17 preinstalled (ahead of the snapshot's 8.15), the closure downgrades cleanly to the snapshot's versions.
- Failure paths propagate (apt resolution failure and unknown package both exit 100, before the guard can be skipped).

**Notes**
- Downgrading the runner's systemd closure to the snapshot is the pin working as intended; the runner is ephemeral. On dev machines, `bin/setup` now also moves the host toolchain to the snapshot — required for reproducing published measurements locally; apt prints each downgrade.
- The c8s-side consumer (`clang`/`libclang-dev` for the attestation-api bindgen in `c8s-image.yml`) can call this same script once its `CONFOS_REF` advances past this change.

## Checklist

- [x] `bin/test` passes (191 passed, 5 skipped)
- [x] `bin/lint` is warning-free
- [x] `cargo deny check` passes (`Cargo.toml`/`Cargo.lock` unchanged; CI gates on it regardless)
- [x] Commit messages follow conventional commits
- [x] CLI flag changes are reflected in the README's matching table (no CLI flag changes)
- [x] Changes what a build produces: **rolls the SNP measurement once** — the published OVMF.fd moves from the live archive's ovmf (2024.02-2ubuntu0.9 today) to the snapshot's (2024.02-2ubuntu0.8); the DSDT toolchain (acpica-tools 20230628-1) is version-identical. Noted in `CHANGELOG.md`
- [x] Touches the build pipeline: output stays deterministic — strictly more so (host deb versions become a function of the committed timestamp)
- [x] No kernel config changes
- [x] No `kernel/version` bump