### PR TITLE
fix(ci): compute the runner-image cache-key term at runtime

### DIFF
--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -25,6 +25,12 @@ jobs:
       - name: Setup mkosi
         uses: systemd/mkosi@84af20892b61c8e177e391f997ded8b4cb5514f2 # v26
 
+      - name: Compute runner-image cache term
+        # ImageOS/ImageVersion are runner-process env vars, not workflow env
+        # context — ${{ env.ImageOS }} silently renders empty in a key.
+        id: image
+        run: echo "key=${ImageOS:-unknown}-${ImageVersion:-unknown}" >> "$GITHUB_OUTPUT"
+
       - name: Cache host build deps
         # The snapshot pin moves the whole dep closure to snapshot versions,
         # which would re-download it from snapshot.ubuntu.com every run; warm
@@ -36,7 +42,7 @@ jobs:
         uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: apt-debs
-          key: ${{ runner.os }}-host-debs-${{ env.ImageOS }}-${{ env.ImageVersion }}-${{ hashFiles('bin/host-deps', 'mkosi/base/mkosi.sandbox/etc/apt/sources.list.d/mkosi.sources') }}
+          key: ${{ runner.os }}-host-debs-${{ steps.image.outputs.key }}-${{ hashFiles('bin/host-deps', 'mkosi/base/mkosi.sandbox/etc/apt/sources.list.d/mkosi.sources') }}
 
       - name: Install build deps (nspawn, TDVF firmware, iasl, cpio)
         # Host deps for `confos build`, snapshot-pinned and fail-closed via


### PR DESCRIPTION
## What problem does this change solve?

#111's host-deb cache key interpolates `${{ env.ImageOS }}`/`${{ env.ImageVersion }}`, which are runner-process env vars, not workflow `env` context — the first warm run keyed `Linux-host-debs---<hash>` (both empty). Correctness is unaffected (host-deps' manifest falls back to a cold snapshot install on codename/version mismatch), but after a runner-image rotation the stale entry pins the stable key and every subsequent run goes cold forever.

## Why is this solution the best option to solve that problem?

A one-line id step reads the real values from the runner process env and the key uses its output — the smallest change that makes the key actually rotate with the image. Verified against run 32608171901's log where the empty interpolation is visible.

## Checklist

- [x] `bin/test` passes (workflow-only change; suite unchanged from #111's green run)
- [x] `bin/lint` is warning-free
- [x] `cargo deny check` passes (no Cargo changes; CI gates regardless)
- [x] Commit messages follow conventional commits
- [x] No CLI flag changes
- [x] Does not change what a build produces (cache-key only; the manifest validation already guaranteed contents)
- [x] Build pipeline determinism unaffected
- [x] No kernel config changes
- [x] No kernel/version bump