### PR TITLE
fix(kernel): retry the tarball fetch on any curl error

### DIFF
--- a/src/kernel/fetch.rs
+++ b/src/kernel/fetch.rs
@@ -29,6 +29,9 @@ pub fn fetch(version: &str, expected_sha256: &str, cache_dir: &Path) -> Result<P
     }
 
     tracing::info!(%url, "fetching kernel tarball");
+    // --retry-all-errors: bare --retry skips protocol errors, and cdn.kernel.org
+    // has failed CI twice with HTTP/2 PROTOCOL_ERROR (curl exit 92); the SHA
+    // check below still gates whatever a retry produces.
     tools::run_command_streaming(
         "curl",
         &[
@@ -36,6 +39,11 @@ pub fn fetch(version: &str, expected_sha256: &str, cache_dir: &Path) -> Result<P
             "--show-error",
             "--silent",
             "--location",
+            "--retry",
+            "5",
+            "--retry-all-errors",
+            "--retry-delay",
+            "5",
             "--output",
             &dest.to_string_lossy(),
             &url,


### PR DESCRIPTION
## What problem does this change solve?

cdn.kernel.org failed CI twice today with `curl: (92) HTTP/2 stream 1 was not closed cleanly: PROTOCOL_ERROR` on kernel-cache misses (c8s repro-gate run 32608439758 build-b/tdx; c8s-image-publish run 32617455671 tdx leg). The fetch in `src/kernel/fetch.rs` runs curl with no retries, so one flaky stream kills a multi-hour build.

## Why is this solution the best option to solve that problem?

curl's own retry is the smallest correct fix: bare `--retry` does not consider protocol errors transient, so `--retry-all-errors` is required to cover exit 92; 5 attempts with a 5s delay bounds the wait. Integrity is unaffected — the existing SHA256 check gates whatever a retry produces.

## Checklist

- [x] `bin/test` passes (190 passed, 5 skipped)
- [x] `bin/lint` is warning-free
- [x] `cargo deny check` passes (no dependency changes; CI gates regardless)
- [x] Commit messages follow conventional commits
- [x] No CLI flag changes
- [x] Does not change what a build produces (fetch resilience only; SHA-gated)
- [x] Build pipeline determinism unaffected
- [x] No kernel config changes
- [x] No kernel/version bump