### PR TITLE
lint: ban mkosi v27's ToolsTreeSnapshot= — same fail-open deb822 field (#96)

### DIFF
--- a/bin/lint
+++ b/bin/lint
@@ -49,15 +49,16 @@ fi
 
 # Every apt source must point at snapshot.ubuntu.com by URI (#96): Mirror=
 # leaves the security pocket live, and both mkosi's Snapshot= and apt's
-# deb822 Snapshot: field keep live repos reachable — all fail open. The pin
+# deb822 Snapshot: field keep live repos reachable — all fail open, v27's
+# ToolsTreeSnapshot= included (same deb822 field, wider scope). The pin
 # is a full sandbox-tree sources file per image dir, handed to the tools
 # tree via ToolsTreeSandboxTrees= (it inherits nothing from [Distribution]).
 # This lint asserts the config shape; confos's mirror guard asserts the apt
 # logs at build time — config presence alone has failed open twice.
 git rev-parse --is-inside-work-tree >/dev/null
-failopen=$(git grep -nE '^(Mirror|ToolsTreeMirror|Snapshot)=' -- 'mkosi/' || true)
+failopen=$(git grep -nE '^(Mirror|ToolsTreeMirror|Snapshot|ToolsTreeSnapshot)=' -- 'mkosi/' || true)
 if [ -n "$failopen" ]; then
-    echo "bin/lint: Mirror=/ToolsTreeMirror=/Snapshot= all leave live pockets reachable (#96) — pin via mkosi.sandbox sources instead:" >&2
+    echo "bin/lint: Mirror=/ToolsTreeMirror=/Snapshot=/ToolsTreeSnapshot= all leave live pockets reachable (#96) — pin via mkosi.sandbox sources instead:" >&2
     echo "$failopen" >&2
     exit 1
 fi


### PR DESCRIPTION
mkosi v27 (systemd/mkosi#4421) adds `ToolsTreeSnapshot=`, closing `Snapshot='s` tools-tree scope gap. It still rides apt's deb822 `Snapshot:` field on live URIs (verified in v27's `installer/apt.py`), so it fails open like the rest — the sandbox-tree URI pin stays. This adds the new setting to the fail-open ban and notes v27 in the #96 rationale.