### PR TITLE
chore!: bump mkosi to v27 — rolls measurements

### DIFF
--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -23,7 +23,7 @@ jobs:
         uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
 
       - name: Setup mkosi
-        uses: systemd/mkosi@84af20892b61c8e177e391f997ded8b4cb5514f2 # v26
+        uses: systemd/mkosi@4736cd836108a97772142c461c49f1ddb4172348 # v27
 
       - name: Compute runner-image cache term
         # ImageOS/ImageVersion are runner-process env vars, not workflow env

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ qemu-system-x86_64 \
 
 ## Installation
 
-Confidential OS Builder runs on Ubuntu Linux. Clone the confos repo and run `bin/setup` to install everything you'll need (mkosi v26, qemu utils, swtpm, rust, cargo-nextest).
+Confidential OS Builder runs on Ubuntu Linux. Clone the confos repo and run `bin/setup` to install everything you'll need (mkosi v27, qemu utils, swtpm, rust, cargo-nextest).
 
 ```bash
 git clone https://github.com/confidential-dot-ai/confidential-os-builder.git

--- a/bin/setup
+++ b/bin/setup
@@ -22,7 +22,7 @@ test -e "$HOME/.local/bin/env" && . "$HOME/.local/bin/env"
 which uv
 
 echo "==> Installing mkosi..."
-which mkosi || uv tool install git+https://github.com/systemd/mkosi.git@v26
+which mkosi || uv tool install git+https://github.com/systemd/mkosi.git@v27
 which mkosi
 
 echo "==> Installing rust..."

--- a/docs/REPRODUCIBILITY.md
+++ b/docs/REPRODUCIBILITY.md
@@ -80,8 +80,8 @@ deb hashes, and any mismatch falls back to a fresh snapshot install.
 CI and `bin/setup` install host deps only through it, and `bin/lint`
 rejects raw apt installs elsewhere in `bin/` and `.github/`.
 
-mkosi itself is pinned to v26 — `bin/setup` and CI install exactly
-`mkosi.git@v26`, and `mkosi.conf` enforces `MinimumVersion=26` as a
+mkosi itself is pinned to v27 — `bin/setup` and CI install exactly
+`mkosi.git@v27`, and `mkosi.conf` enforces `MinimumVersion=27` as a
 floor — since mkosi's own behavior is part of the build's determinism.
 The Rust toolchain that builds the `confos` binary is *not* pinned:
 confos's contributions to the measured artifacts (the DSDT early-cpio,

--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -17,7 +17,7 @@ plain KVM or emulation for booting.
 ```bash
 git clone https://github.com/confidential-dot-ai/confidential-os-builder.git
 cd confidential-os-builder
-bin/setup        # installs mkosi v26, qemu-utils, swtpm, iasl, ovmf, rust, cargo-nextest
+bin/setup        # installs mkosi v27, qemu-utils, swtpm, iasl, ovmf, rust, cargo-nextest
 sudo apt install qemu-system-x86   # the emulator itself — bin/setup does NOT install it
 ```
 

--- a/mkosi/base/mkosi.conf
+++ b/mkosi/base/mkosi.conf
@@ -1,5 +1,5 @@
 [Config]
-MinimumVersion=26
+MinimumVersion=27
 
 [Distribution]
 Architecture=x86-64

--- a/mkosi/kernel-builder/mkosi.conf
+++ b/mkosi/kernel-builder/mkosi.conf
@@ -1,5 +1,5 @@
 [Config]
-MinimumVersion=26
+MinimumVersion=27
 
 [Distribution]
 Architecture=x86-64


### PR DESCRIPTION
Bumps the mkosi pin everywhere it lives: `bin/setup`, the CI action SHA (v27 tag commit `4736cd8`), `MinimumVersion=` in both image configs, and the docs. mkosi version shapes measured bytes, so this rolls measurements once.

The sandbox-tree apt pinning stays: v27's `ToolsTreeSnapshot=` (systemd/mkosi#4421) closes the tools-tree scope gap but still rides apt's fail-open deb822 `Snapshot:` field — see #115.