### PR TITLE
fix(build): exempt dropin-local mkosi.extra/skeleton trees from the symlink check

### DIFF
--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -803,12 +803,14 @@ const MKOSI_CONF_D: &str = "mkosi.conf.d";
 /// link (`mkosi.conf.d/shared.conf -> ../../common/shared.conf`, valid in the
 /// consumer's repo) dangles or resolves to an unrelated file in *this* repo.
 fn reject_escaping_symlinks(root: &Path) -> anyhow::Result<()> {
-    // The exempt subtrees sit at any extras-dir root: the profile root, or a
-    // `mkosi.conf.d/<dir>` dropin reached from one — mkosi parses each dropin
-    // dir as a top-level dir, recursively. The two flags thread that state
-    // through the recursion the same way reject_escaping_includes' anchor
-    // does, so the exemption fires exactly where mkosi resolves the default
-    // trees (a stray `subdir/mkosi.conf.d/x` mints no extras root).
+    // The exempt subtrees sit at extras-dir roots. An extras-dir root is the
+    // profile root, or a `mkosi.conf.d/<dir>` dropin reached from one —
+    // mkosi parses every dropin dir as a top-level dir, recursively.
+    //
+    // The two flags track that chain through the recursion, mirroring the
+    // anchors of reject_escaping_includes below. So the exemption fires
+    // exactly where mkosi resolves the default trees, and a stray
+    // `subdir/mkosi.conf.d/x` gets no exemption.
     fn walk(
         root: &Path,
         rel: &Path,
@@ -1568,10 +1570,9 @@ mod tests {
 
     #[test]
     fn reject_escaping_symlinks_exempts_dropin_local_image_relative_trees() {
-        // mkosi resolves mkosi.extra/mkosi.skeleton inside mkosi.conf.d/<dir>
-        // dropins too (each dropin dir is parsed as a top-level dir,
-        // recursively), so their image-relative links get the same exemption
-        // as the profile root's.
+        // Dropins get the same exemption as the profile root: mkosi parses
+        // each mkosi.conf.d/<dir> as a top-level dir, recursively, and
+        // resolves mkosi.extra/mkosi.skeleton there too.
         let root = TempDir::new().unwrap();
         for dropin in [
             "mkosi.conf.d/10-gpu",
@@ -1587,8 +1588,8 @@ mod tests {
         }
         reject_escaping_symlinks(root.path()).unwrap();
 
-        // An mkosi.extra somewhere mkosi would not resolve one stays
-        // unexempt, even under a dir merely named mkosi.conf.d.
+        // No exemption where mkosi would not resolve a tree — not even
+        // under a dir merely named mkosi.conf.d.
         for stray in ["subdir/mkosi.extra", "subdir/mkosi.conf.d/x/mkosi.extra"] {
             let root = TempDir::new().unwrap();
             let stray = root.path().join(stray);

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -800,13 +800,19 @@ const IMAGE_RELATIVE_SUBTREES: [&str; 2] = ["mkosi.extra", "mkosi.skeleton"];
 /// consumer's repo) dangles or resolves to an unrelated file in *this* repo.
 fn reject_escaping_symlinks(root: &Path) -> anyhow::Result<()> {
     fn walk(root: &Path, rel: &Path) -> anyhow::Result<()> {
-        // Only the profile root can hold the exempt subtrees.
-        let at_root = rel.as_os_str().is_empty();
+        // The exempt subtrees sit at any extras-dir root: the profile root or
+        // a nested `mkosi.conf.d/<dir>` — mkosi resolves the default trees in
+        // both, exactly like the Include= anchors below.
+        let at_extras_root = rel.as_os_str().is_empty()
+            || rel
+                .parent()
+                .and_then(Path::file_name)
+                .is_some_and(|n| n == "mkosi.conf.d");
         for entry in fs_err::read_dir(root.join(rel))? {
             let entry = entry?;
             let name = entry.file_name();
             let ft = entry.file_type()?;
-            if at_root && IMAGE_RELATIVE_SUBTREES.iter().any(|s| name == *s) {
+            if at_extras_root && IMAGE_RELATIVE_SUBTREES.iter().any(|s| name == *s) {
                 // The exemption covers links *inside* these trees; the roots
                 // themselves are copied on the host, so a symlinked root is
                 // still re-parented by staging.
@@ -1546,6 +1552,35 @@ mod tests {
         .unwrap();
 
         reject_escaping_symlinks(root).unwrap();
+    }
+
+    #[test]
+    fn reject_escaping_symlinks_exempts_dropin_local_image_relative_trees() {
+        // mkosi resolves mkosi.extra/mkosi.skeleton inside mkosi.conf.d/<dir>
+        // dropins too (each dropin dir is parsed as a top-level dir), so their
+        // image-relative links get the same exemption as the profile root's.
+        let root = TempDir::new().unwrap();
+        let root = root.path();
+        let dropin = root.join("mkosi.conf.d/10-gpu");
+        fs_err::create_dir_all(dropin.join("mkosi.extra/usr/bin")).unwrap();
+        std::os::unix::fs::symlink(
+            "/usr/lib/systemd/systemd",
+            dropin.join("mkosi.extra/usr/bin/init"),
+        )
+        .unwrap();
+
+        reject_escaping_symlinks(root).unwrap();
+
+        // But a symlinked tree root in a dropin is still rejected, and an
+        // mkosi.extra somewhere mkosi would not resolve one stays unexempt.
+        std::os::unix::fs::symlink("/outside", dropin.join("mkosi.skeleton")).unwrap();
+        assert!(reject_escaping_symlinks(root).is_err());
+        fs_err::remove_file(dropin.join("mkosi.skeleton")).unwrap();
+
+        let stray = root.join("subdir/mkosi.extra");
+        fs_err::create_dir_all(&stray).unwrap();
+        std::os::unix::fs::symlink("/etc/hosts", stray.join("hosts")).unwrap();
+        assert!(reject_escaping_symlinks(root).is_err());
     }
 
     #[test]

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -126,7 +126,7 @@ pub fn run(args: &BuildArgs) -> anyhow::Result<()> {
     fs_err::create_dir_all(&mkosi_local_extra)?;
 
     if let Some(ref extra) = args.extra {
-        copy_extra(extra, &mkosi_local_extra)?;
+        copy_tree(extra, &mkosi_local_extra)?;
     }
 
     // Check mkosi is available up front, before any expensive work; the
@@ -748,7 +748,7 @@ fn stage_profile_dirs(
         // staged dir, or the next run hard-errors on it.
         fs_err::create_dir_all(&target)?;
         fs_err::write(target.join(STAGED_PROFILE_MARKER), b"")?;
-        copy_extra(dir, &target)?;
+        copy_tree(dir, &target)?;
         tracing::info!("out-of-tree profile {name} staged from {}", dir.display());
         if !profiles.contains(&name) {
             profiles.push(name);
@@ -934,7 +934,7 @@ fn escapes_root(rel_parent: &Path, target: &Path) -> bool {
 /// - `dst` is created if missing.
 /// - Files preserve their unix mode bits.
 /// - Symlinks are copied as symlinks (target path verbatim, not dereferenced).
-fn copy_extra(src: &Path, dst: &Path) -> anyhow::Result<()> {
+fn copy_tree(src: &Path, dst: &Path) -> anyhow::Result<()> {
     use std::os::unix::fs::PermissionsExt;
 
     fs_err::create_dir_all(dst)?;
@@ -951,7 +951,7 @@ fn copy_extra(src: &Path, dst: &Path) -> anyhow::Result<()> {
             }
             std::os::unix::fs::symlink(&target, &to)?;
         } else if ft.is_dir() {
-            copy_extra(&from, &to)?;
+            copy_tree(&from, &to)?;
         } else {
             fs_err::copy(&from, &to)?;
             let mode = fs_err::metadata(&from)?.permissions().mode();
@@ -1701,25 +1701,25 @@ mod tests {
     }
 
     #[test]
-    fn copy_extra_copies_files_at_root() {
+    fn copy_tree_copies_files_at_root() {
         let src = TempDir::new().unwrap();
         let dst = TempDir::new().unwrap();
         fs_err::write(src.path().join("a.txt"), b"hello").unwrap();
 
-        copy_extra(src.path(), dst.path()).unwrap();
+        copy_tree(src.path(), dst.path()).unwrap();
 
         let copied = fs_err::read(dst.path().join("a.txt")).unwrap();
         assert_eq!(copied, b"hello");
     }
 
     #[test]
-    fn copy_extra_copies_nested_directories() {
+    fn copy_tree_copies_nested_directories() {
         let src = TempDir::new().unwrap();
         let dst = TempDir::new().unwrap();
         fs_err::create_dir_all(src.path().join("etc/foo")).unwrap();
         fs_err::write(src.path().join("etc/foo/bar.conf"), b"x=1").unwrap();
 
-        copy_extra(src.path(), dst.path()).unwrap();
+        copy_tree(src.path(), dst.path()).unwrap();
 
         assert_eq!(
             fs_err::read(dst.path().join("etc/foo/bar.conf")).unwrap(),
@@ -1728,14 +1728,14 @@ mod tests {
     }
 
     #[test]
-    fn copy_extra_preserves_file_modes() {
+    fn copy_tree_preserves_file_modes() {
         let src = TempDir::new().unwrap();
         let dst = TempDir::new().unwrap();
         let path = src.path().join("script");
         fs_err::write(&path, b"#!/bin/sh\n").unwrap();
         fs_err::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).unwrap();
 
-        copy_extra(src.path(), dst.path()).unwrap();
+        copy_tree(src.path(), dst.path()).unwrap();
 
         let mode = fs_err::metadata(dst.path().join("script"))
             .unwrap()
@@ -1746,13 +1746,13 @@ mod tests {
     }
 
     #[test]
-    fn copy_extra_preserves_symlinks() {
+    fn copy_tree_preserves_symlinks() {
         let src = TempDir::new().unwrap();
         let dst = TempDir::new().unwrap();
         fs_err::write(src.path().join("target"), b"t").unwrap();
         std::os::unix::fs::symlink("target", src.path().join("link")).unwrap();
 
-        copy_extra(src.path(), dst.path()).unwrap();
+        copy_tree(src.path(), dst.path()).unwrap();
 
         let link_meta = fs_err::symlink_metadata(dst.path().join("link")).unwrap();
         assert!(link_meta.file_type().is_symlink());
@@ -1761,43 +1761,43 @@ mod tests {
     }
 
     #[test]
-    fn copy_extra_empty_source_is_ok() {
+    fn copy_tree_empty_source_is_ok() {
         let src = TempDir::new().unwrap();
         let dst = TempDir::new().unwrap();
-        copy_extra(src.path(), dst.path()).unwrap();
+        copy_tree(src.path(), dst.path()).unwrap();
         // dst should exist and be empty
         assert!(dst.path().exists());
         assert_eq!(fs_err::read_dir(dst.path()).unwrap().count(), 0);
     }
 
     #[test]
-    fn copy_extra_creates_destination_if_missing() {
+    fn copy_tree_creates_destination_if_missing() {
         let src = TempDir::new().unwrap();
         let dst_parent = TempDir::new().unwrap();
         let dst = dst_parent.path().join("does/not/exist/yet");
         fs_err::write(src.path().join("f"), b"x").unwrap();
 
-        copy_extra(src.path(), &dst).unwrap();
+        copy_tree(src.path(), &dst).unwrap();
 
         assert_eq!(fs_err::read(dst.join("f")).unwrap(), b"x");
     }
 
     #[test]
-    fn copy_extra_fails_on_nonexistent_source() {
+    fn copy_tree_fails_on_nonexistent_source() {
         let parent = TempDir::new().unwrap();
         let src = parent.path().join("nonexistent-child");
         let dst = TempDir::new().unwrap();
-        let result = copy_extra(&src, dst.path());
+        let result = copy_tree(&src, dst.path());
         assert!(result.is_err());
     }
 
     #[test]
-    fn copy_extra_fails_on_file_source() {
+    fn copy_tree_fails_on_file_source() {
         let parent = TempDir::new().unwrap();
         let src = parent.path().join("a-file");
         fs_err::write(&src, b"x").unwrap();
         let dst = TempDir::new().unwrap();
-        let result = copy_extra(&src, dst.path());
+        let result = copy_tree(&src, dst.path());
         assert!(result.is_err());
     }
 

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -793,21 +793,28 @@ fn sweep_stale_staged_profiles(profiles_root: &Path) -> anyhow::Result<()> {
 /// than on the host, so re-parenting the profile cannot break them.
 const IMAGE_RELATIVE_SUBTREES: [&str; 2] = ["mkosi.extra", "mkosi.skeleton"];
 
+/// Directory whose subdirectories mkosi parses as nested extras dirs. Both
+/// validators below key their recursion on this name; keep them in sync.
+const MKOSI_CONF_D: &str = "mkosi.conf.d";
+
 /// Reject symlinks in a profile's config tree that point outside the profile.
 ///
 /// Staging re-parents the dir under `mkosi.profiles/<name>/`, so an escaping
 /// link (`mkosi.conf.d/shared.conf -> ../../common/shared.conf`, valid in the
 /// consumer's repo) dangles or resolves to an unrelated file in *this* repo.
 fn reject_escaping_symlinks(root: &Path) -> anyhow::Result<()> {
-    fn walk(root: &Path, rel: &Path) -> anyhow::Result<()> {
-        // The exempt subtrees sit at any extras-dir root: the profile root or
-        // a nested `mkosi.conf.d/<dir>` — mkosi resolves the default trees in
-        // both, exactly like the Include= anchors below.
-        let at_extras_root = rel.as_os_str().is_empty()
-            || rel
-                .parent()
-                .and_then(Path::file_name)
-                .is_some_and(|n| n == "mkosi.conf.d");
+    // The exempt subtrees sit at any extras-dir root: the profile root, or a
+    // `mkosi.conf.d/<dir>` dropin reached from one — mkosi parses each dropin
+    // dir as a top-level dir, recursively. The two flags thread that state
+    // through the recursion the same way reject_escaping_includes' anchor
+    // does, so the exemption fires exactly where mkosi resolves the default
+    // trees (a stray `subdir/mkosi.conf.d/x` mints no extras root).
+    fn walk(
+        root: &Path,
+        rel: &Path,
+        at_extras_root: bool,
+        in_dropin_container: bool,
+    ) -> anyhow::Result<()> {
         for entry in fs_err::read_dir(root.join(rel))? {
             let entry = entry?;
             let name = entry.file_name();
@@ -839,12 +846,17 @@ fn reject_escaping_symlinks(root: &Path) -> anyhow::Result<()> {
                     );
                 }
             } else if ft.is_dir() {
-                walk(root, &rel_child)?;
+                walk(
+                    root,
+                    &rel_child,
+                    in_dropin_container,
+                    at_extras_root && name == MKOSI_CONF_D,
+                )?;
             }
         }
         Ok(())
     }
-    walk(root, Path::new(""))
+    walk(root, Path::new(""), true, false)
 }
 
 /// Reject `Include=` values in the profile's mkosi config files that resolve
@@ -865,7 +877,7 @@ fn reject_escaping_includes(root: &Path, anchor: &Path) -> anyhow::Result<()> {
             reject_escaping_include_lines(root, anchor, &rel)?;
         }
     }
-    let confd = anchor.join("mkosi.conf.d");
+    let confd = anchor.join(MKOSI_CONF_D);
     if !root.join(&confd).is_dir() {
         return Ok(());
     }
@@ -1557,30 +1569,37 @@ mod tests {
     #[test]
     fn reject_escaping_symlinks_exempts_dropin_local_image_relative_trees() {
         // mkosi resolves mkosi.extra/mkosi.skeleton inside mkosi.conf.d/<dir>
-        // dropins too (each dropin dir is parsed as a top-level dir), so their
-        // image-relative links get the same exemption as the profile root's.
+        // dropins too (each dropin dir is parsed as a top-level dir,
+        // recursively), so their image-relative links get the same exemption
+        // as the profile root's.
         let root = TempDir::new().unwrap();
-        let root = root.path();
-        let dropin = root.join("mkosi.conf.d/10-gpu");
-        fs_err::create_dir_all(dropin.join("mkosi.extra/usr/bin")).unwrap();
-        std::os::unix::fs::symlink(
-            "/usr/lib/systemd/systemd",
-            dropin.join("mkosi.extra/usr/bin/init"),
-        )
-        .unwrap();
+        for dropin in [
+            "mkosi.conf.d/10-gpu",
+            "mkosi.conf.d/10-gpu/mkosi.conf.d/00-fw",
+        ] {
+            let dropin = root.path().join(dropin);
+            fs_err::create_dir_all(dropin.join("mkosi.extra/usr/bin")).unwrap();
+            std::os::unix::fs::symlink(
+                "/usr/lib/systemd/systemd",
+                dropin.join("mkosi.extra/usr/bin/init"),
+            )
+            .unwrap();
+        }
+        reject_escaping_symlinks(root.path()).unwrap();
 
-        reject_escaping_symlinks(root).unwrap();
-
-        // But a symlinked tree root in a dropin is still rejected, and an
-        // mkosi.extra somewhere mkosi would not resolve one stays unexempt.
-        std::os::unix::fs::symlink("/outside", dropin.join("mkosi.skeleton")).unwrap();
-        assert!(reject_escaping_symlinks(root).is_err());
-        fs_err::remove_file(dropin.join("mkosi.skeleton")).unwrap();
-
-        let stray = root.join("subdir/mkosi.extra");
-        fs_err::create_dir_all(&stray).unwrap();
-        std::os::unix::fs::symlink("/etc/hosts", stray.join("hosts")).unwrap();
-        assert!(reject_escaping_symlinks(root).is_err());
+        // An mkosi.extra somewhere mkosi would not resolve one stays
+        // unexempt, even under a dir merely named mkosi.conf.d.
+        for stray in ["subdir/mkosi.extra", "subdir/mkosi.conf.d/x/mkosi.extra"] {
+            let root = TempDir::new().unwrap();
+            let stray = root.path().join(stray);
+            fs_err::create_dir_all(&stray).unwrap();
+            std::os::unix::fs::symlink("/etc/hosts", stray.join("hosts")).unwrap();
+            assert!(
+                reject_escaping_symlinks(root.path()).is_err(),
+                "escaping link under {} must not be exempt",
+                stray.display()
+            );
+        }
     }
 
     #[test]
@@ -1594,15 +1613,19 @@ mod tests {
     #[test]
     fn reject_escaping_symlinks_rejects_symlinked_image_relative_roots() {
         // The exemption is for links inside these trees, not for the roots
-        // themselves being links.
-        for target in ["/outside", "../elsewhere"] {
-            for subtree in IMAGE_RELATIVE_SUBTREES {
-                let root = TempDir::new().unwrap();
-                std::os::unix::fs::symlink(target, root.path().join(subtree)).unwrap();
-                assert!(
-                    reject_escaping_symlinks(root.path()).is_err(),
-                    "symlinked {subtree} -> {target} must be rejected"
-                );
+        // themselves being links — at the profile root and in dropins alike.
+        for prefix in ["", "mkosi.conf.d/10-gpu"] {
+            for target in ["/outside", "../elsewhere"] {
+                for subtree in IMAGE_RELATIVE_SUBTREES {
+                    let root = TempDir::new().unwrap();
+                    let dir = root.path().join(prefix);
+                    fs_err::create_dir_all(&dir).unwrap();
+                    std::os::unix::fs::symlink(target, dir.join(subtree)).unwrap();
+                    assert!(
+                        reject_escaping_symlinks(root.path()).is_err(),
+                        "symlinked {prefix}/{subtree} -> {target} must be rejected"
+                    );
+                }
             }
         }
     }


### PR DESCRIPTION
## Problem

mkosi resolves the default `mkosi.extra`/`mkosi.skeleton` trees inside every `mkosi.conf.d/<dir>` dropin, not just at the profile root: `parse_config_one` treats each dropin dir as a top-level dir, recursively.

`reject_escaping_symlinks` only exempted the trees at the profile root. A legitimate profile with image-relative symlinks in a dropin-local tree was falsely rejected.

## Fix

The exemption now applies at every extras-dir root. The walk threads that state through its recursion, mirroring the anchors `reject_escaping_includes` already models — so the exemption fires exactly where mkosi resolves the trees, and nowhere else.

After this PR:

- **Exempt:** image-relative links inside `mkosi.extra`/`mkosi.skeleton` at the profile root or in any dropin, nested dropins included.
- **Rejected:** a symlinked tree root, at the profile root and in dropins alike.
- **Rejected:** an `mkosi.extra` anywhere mkosi wouldn't resolve one (e.g. `subdir/mkosi.conf.d/x/`).

One deliberate tightening: on main, a symlinked tree root inside a dropin slipped through when its target stayed in-profile. It now fails with "must be a real directory" — the roots are copied on the host, so staging re-parents them either way.

## Commits

1. `refactor`: mechanical `copy_extra` → `copy_tree` rename. It has been the profile-config copier too since profile staging landed.
2. `fix`: exempt dropin-local trees.
3. `fix`: anchor the exemption to mkosi's resolution chain instead of a directory-name match.
4. `docs`: comment readability.

## Notes

- Settles the open question from the profile-staging review, flagged then as unverifiable without mkosi installed; mkosi's source answers it.
- New tests: dropin allow (nested too), symlinked-root reject at root and in dropins, stray trees stay unexempt.
- Full suite passes, clippy clean.
