### PR TITLE
fetch-attest-gpu: fail closed when libnvat's deps do not resolve on the host

### DIFF
--- a/bin/confos-fetch-attest-gpu
+++ b/bin/confos-fetch-attest-gpu
@@ -54,9 +54,16 @@ ln -sf "libnvat.so.1" "$LIBDIR/libnvat.so"
 # versioned ICU). Everything else libnvat needs — libz, liblzma, libstdc++,
 # libgcc_s — has a stable soname present in the base. Auto-discovered via ldd
 # so the exact versions libnvat was built against travel with it.
+# A dep the host cannot resolve is a dep the guest will not have either:
+# the binary then fails to load at boot, taking CPU attestation down with
+# it. Fail here instead. Point LD_LIBRARY_PATH at copies of the exact
+# sonames libnvat wants (e.g. libicu*.so.74, libxml2.so.2 from a 24.04 tree)
+# when the host ships another major.
 echo "bundling libnvat's versioned deps (ICU + libxml2)"
+missing=$(ldd "$LIBNVAT" 2>/dev/null | awk '/libicu|libxml2/ && /not found/{print $1}')
+[[ -z "$missing" ]] || die "libnvat's deps do not resolve on this host: $(echo $missing) — install matching versions or set LD_LIBRARY_PATH to copies of them."
 for lib in $(ldd "$LIBNVAT" 2>/dev/null | awk '/libicu|libxml2/{print $3}'); do
-    [[ -f "$lib" ]] || continue
+    [[ -f "$lib" ]] || die "libnvat dep $lib is not a file."
     b="$(basename "$lib")"
     install -m0644 "$(readlink -f "$lib")" "$LIBDIR/$b"
     echo "  bundled $b"


### PR DESCRIPTION
`confos-fetch-attest-gpu` discovers libnvat's versioned deps (ICU, libxml2) with `ldd` on the build host and skips any it cannot resolve. On a host whose ICU major differs from libnvat's (Ubuntu 26.04 ships ICU 78; libnvat wants 74 and libxml2.so.2) it bundles nothing, prints nothing, and the resulting node image carries an `attestation-api` that cannot load in the guest, so CPU attestation is down on that node.

Refuse to stage when a dep is unresolved, and name the fix (matching libraries, or `LD_LIBRARY_PATH` to copies of the exact sonames).

Found while reproducing the sealed node image build for [c8s#522](https://github.com/confidential-dot-ai/c8s/pull/522) on a 26.04 host.