### PR TITLE
fix(ci): honor kernel EOL and preserve pin-watch PRs

### DIFF
--- a/.github/scripts/kernel-release
+++ b/.github/scripts/kernel-release
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+kernel_release_error() {
+  echo "kernel-release: $*" >&2
+}
+
+latest_kernel_release() (
+  set -euo pipefail
+
+  if [ "$#" -ne 2 ]; then
+    kernel_release_error "internal usage: latest_kernel_release RELEASES_JSON PINNED_VERSION"
+    exit 2
+  fi
+
+  local releases=$1 pinned=$2 branch matches count latest iseol_type
+  local version_re='^[1-9][0-9]*\.(0|[1-9][0-9]*)(\.(0|[1-9][0-9]*))?$'
+
+  [ -f "$releases" ] || {
+    kernel_release_error "release metadata not found: $releases"
+    exit 1
+  }
+  [[ "$pinned" =~ $version_re ]] || {
+    kernel_release_error "invalid pinned kernel version: $pinned"
+    exit 1
+  }
+
+  branch=${pinned%.*}
+  # A series' first release is two-part (for example 6.17, not 6.17.0).
+  # In that case stripping the last component would produce only the major.
+  case "$branch" in
+    *.*) ;;
+    *) branch=$pinned ;;
+  esac
+
+  if ! matches=$(jq -ce --arg prefix "$branch." '
+    if (.releases | type) != "array" then
+      error("releases must be an array")
+    else
+      [
+        .releases[]
+        | select(
+            ((.moniker == "stable") or (.moniker == "longterm"))
+            and (.version | type == "string")
+            and ((.version + ".") | startswith($prefix))
+          )
+      ]
+    end
+  ' "$releases"); then
+    kernel_release_error "invalid kernel.org release metadata"
+    exit 1
+  fi
+
+  count=$(jq -r length <<<"$matches")
+  if [ "$count" -eq 0 ]; then
+    kernel_release_error "kernel branch $branch is EOL or absent from kernel.org"
+    exit 1
+  fi
+  if [ "$count" -ne 1 ]; then
+    kernel_release_error "kernel.org returned $count stable records for branch $branch"
+    exit 1
+  fi
+
+  iseol_type=$(jq -r '.[0] | if has("iseol") then (.iseol | type) else "missing" end' <<<"$matches")
+  if [ "$iseol_type" != boolean ]; then
+    kernel_release_error "kernel.org returned invalid iseol metadata for branch $branch"
+    exit 1
+  fi
+  if jq -e '.[0].iseol' <<<"$matches" >/dev/null; then
+    kernel_release_error "kernel branch $branch is EOL on kernel.org"
+    exit 1
+  fi
+
+  latest=$(jq -er '.[0].version' <<<"$matches")
+  [[ "$latest" =~ $version_re ]] || {
+    kernel_release_error "kernel.org returned an invalid stable version: $latest"
+    exit 1
+  }
+  printf '%s\n' "$latest"
+)
+
+main() {
+  if [ "$#" -ne 2 ]; then
+    echo "usage: kernel-release RELEASES_JSON PINNED_VERSION" >&2
+    return 2
+  fi
+  latest_kernel_release "$1" "$2"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  main "$@"
+fi

--- a/.github/scripts/tests/test-kernel-release.sh
+++ b/.github/scripts/tests/test-kernel-release.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+TEST_SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+readonly TEST_SCRIPT_DIR
+readonly KERNEL_RELEASE="$TEST_SCRIPT_DIR/../kernel-release"
+
+fail() {
+  echo "test-kernel-release: $*" >&2
+  exit 1
+}
+
+test_dir=$(mktemp -d "${TMPDIR:-/tmp}/test-kernel-release.XXXXXXXX")
+trap 'rm -rf "$test_dir"' EXIT
+
+case_number=0
+expect_release() {
+  local pinned=$1 expected=$2 metadata=$3 manifest actual
+  case_number=$((case_number + 1))
+  manifest="$test_dir/case-${case_number}.json"
+  printf '%s\n' "$metadata" >"$manifest"
+  if ! actual=$(bash "$KERNEL_RELEASE" "$manifest" "$pinned"); then
+    fail "$pinned should resolve to $expected"
+  fi
+  [ "$actual" = "$expected" ] || fail "$pinned resolved to $actual, want $expected"
+}
+
+expect_failure() {
+  local pinned=$1 message=$2 metadata=$3 manifest
+  case_number=$((case_number + 1))
+  manifest="$test_dir/case-${case_number}.json"
+  printf '%s\n' "$metadata" >"$manifest"
+  if bash "$KERNEL_RELEASE" "$manifest" "$pinned" \
+    >"$test_dir/unexpected.stdout" 2>"$test_dir/unexpected.stderr"; then
+    fail "$pinned unexpectedly resolved"
+  fi
+  grep -q "$message" "$test_dir/unexpected.stderr" || {
+    cat "$test_dir/unexpected.stderr" >&2
+    fail "$pinned did not report $message"
+  }
+}
+
+expect_release 6.18.4 6.18.4 \
+  '{"releases":[{"version":"6.18.4","moniker":"longterm","iseol":false}]}'
+expect_release 6.18.3 6.18.4 \
+  '{"releases":[{"version":"6.18.4","moniker":"longterm","iseol":false}]}'
+expect_release 7.3 7.3 \
+  '{"releases":[{"version":"7.3","moniker":"stable","iseol":false}]}'
+
+expect_failure 6.16.12 'is EOL on kernel.org' \
+  '{"releases":[{"version":"6.16.12","moniker":"stable","iseol":true}]}'
+expect_failure 6.18.4 'invalid iseol metadata' \
+  '{"releases":[{"version":"6.18.4","moniker":"longterm"}]}'
+expect_failure 6.17.9 'is EOL or absent' \
+  '{"releases":[{"version":"6.18.4","moniker":"longterm","iseol":false}]}'
+expect_failure 6.18.3 'returned 2 stable records' \
+  '{"releases":[{"version":"6.18.4","moniker":"longterm","iseol":false},{"version":"6.18.3","moniker":"stable","iseol":false}]}'
+expect_failure '6.18.*' 'invalid pinned kernel version' \
+  '{"releases":[]}'
+
+echo "kernel release metadata tests passed"

--- a/.github/workflows/pin-watch.yml
+++ b/.github/workflows/pin-watch.yml
@@ -44,19 +44,60 @@ jobs:
           git config user.name "pin-watch"
           git config user.email "actions@github.com"
 
-      # Open (or refresh) a PR carrying whatever the caller changed. Skip an
-      # unchanged open PR, but recover a same-tree orphan branch by opening
-      # its missing PR. A lease prevents overwriting an unexpected writer.
+      # Open a candidate-keyed PR carrying only the paths the caller allows.
+      # Existing review branches are immutable; a same-tree orphan branch can
+      # still recover by opening its missing PR.
       - name: Define open_pr helper
         run: |
           cat > /tmp/open_pr <<'SH'
-          open_pr() { # <branch> <title> <body>
-            local branch="$1" title="$2" body="$3"
-            local open_pr_number remote_oid remote_ref remote_status
+          open_pr() { # <branch> <PR-family prefix> <title> <body> <allowed path>...
+            if (( $# < 5 )); then
+              echo "pin-watch: open_pr requires at least one allowed path" >&2
+              return 2
+            fi
+            local branch="$1" family="$2" title="$3" body="$4"
+            shift 4
+            local -a paths=("$@")
+            local changes line path allowed open_pr_number remote_oid remote_ref remote_status
 
+            changes=$(git status --short --untracked-files=all)
+            [ -n "$changes" ] || {
+              echo "pin-watch: no generated changes for $branch" >&2
+              return 1
+            }
+            while IFS= read -r line; do
+              allowed=false
+              for path in "${paths[@]}"; do
+                if [ "$line" = " M $path" ]; then
+                  allowed=true
+                  break
+                fi
+              done
+              if [ "$allowed" != true ]; then
+                echo "pin-watch: refusing unexpected worktree entry: $line" >&2
+                return 1
+              fi
+            done <<<"$changes"
+
+            open_pr_number=$(
+              gh pr list --state open --limit 100 \
+                --json headRefName,isCrossRepository,number |
+                jq -r --arg prefix "$family" \
+                  '[.[] | select(.isCrossRepository == false and (.headRefName | startswith($prefix)))][0].number // empty'
+            )
+            if [ -n "$open_pr_number" ]; then
+              git restore --worktree -- "${paths[@]}"
+              echo "pin-watch: PR #$open_pr_number is already open; leaving $branch untouched"
+              return 0
+            fi
+
+            git add -- "${paths[@]}"
+            [ -z "$(git diff --name-only)" ] || {
+              echo "pin-watch: an allowed path still has unstaged changes" >&2
+              return 1
+            }
             git checkout -b "$branch"
-            git commit -am "$title"
-            open_pr_number=$(gh pr list --head "$branch" --state open --json number --jq '.[0].number')
+            git commit -m "$title"
 
             remote_oid=
             if remote_ref=$(git ls-remote --exit-code --heads origin "refs/heads/$branch"); then
@@ -67,23 +108,25 @@ jobs:
               [ "$remote_status" -eq 2 ] || return "$remote_status"
             fi
 
-            if [ -n "$remote_oid" ] &&
-              [ "$(git rev-parse 'HEAD^{tree}')" = "$(git rev-parse "$remote_oid^{tree}")" ]; then
-              git checkout -
-              if [ -n "$open_pr_number" ]; then
-                echo "pin-watch: $branch already has the proposed tree in PR #$open_pr_number"
-                return 0
+            if [ -n "$remote_oid" ]; then
+              if [ "$(git rev-parse 'HEAD^{tree}')" != "$(git rev-parse "$remote_oid^{tree}")" ]; then
+                echo "pin-watch: $branch contains a different tree; refusing to overwrite it" >&2
+                return 1
               fi
             else
-              if [ -n "$remote_oid" ]; then
-                git push --force-with-lease="refs/heads/$branch:$remote_oid" origin "HEAD:refs/heads/$branch"
-              else
-                git push origin "HEAD:refs/heads/$branch"
-              fi
-              git checkout -
+              git push origin "HEAD:refs/heads/$branch"
             fi
+            git checkout -
 
-            if [ -z "$open_pr_number" ]; then
+            open_pr_number=$(
+              gh pr list --state open --limit 100 \
+                --json headRefName,isCrossRepository,number |
+                jq -r --arg prefix "$family" \
+                  '[.[] | select(.isCrossRepository == false and (.headRefName | startswith($prefix)))][0].number // empty'
+            )
+            if [ -n "$open_pr_number" ]; then
+              echo "pin-watch: PR #$open_pr_number was opened concurrently"
+            else
               gh pr create --head "$branch" --title "$title" --body "$body"
             fi
           }
@@ -107,10 +150,15 @@ jobs:
           [ "$age" -gt 35 ] || exit 0
           new=$(date -u -d '1 day ago' +%Y%m%dT000000Z)
           sed -i "s/${cur}/${new}/" mkosi/*/mkosi.sandbox/etc/apt/sources.list.d/mkosi.sources
-          moved=$(git diff --name-only | paste -sd' ' -)
-          open_pr "pin-watch/snapshot" \
+          mapfile -t moved < <(git diff --name-only -- \
+            'mkosi/*/mkosi.sandbox/etc/apt/sources.list.d/mkosi.sources')
+          (( ${#moved[@]} > 0 ))
+          moved_summary=$(printf '%s ' "${moved[@]}")
+          open_pr "pin-watch/snapshot-${new}" \
+            "pin-watch/snapshot" \
             "mkosi: bump the apt snapshot pin to ${new} — ${age} days of security updates" \
-            "Automated pin-watch bump ${cur} -> ${new} in: ${moved} (the host-deps closure follows the base pin; sources deliberately skewed behind base keep their own timestamps). Rolls measurements — package versions move to the new snapshot; if the kernel-config drift gate trips, regenerate the snapshot lockfile here. Merge deliberately, ideally batched with other pending rolls."
+            "Automated pin-watch bump ${cur} -> ${new} in: ${moved_summary% } (the host-deps closure follows the base pin; sources deliberately skewed behind base keep their own timestamps). Rolls measurements — package versions move to the new snapshot; if the kernel-config drift gate trips, regenerate the snapshot lockfile here. Merge deliberately, ideally batched with other pending rolls." \
+            "${moved[@]}"
       - name: Kernel — patch drift or EOL
         # Patch drift on the pinned branch -> bump PR with the digest taken
         # from a signature-verified kernel.org sha256sums.asc (an independent
@@ -126,26 +174,10 @@ jobs:
           set -euo pipefail
           source /tmp/open_pr
           . kernel/version
-          kernel_version_re='^[1-9][0-9]*\.(0|[1-9][0-9]*)(\.(0|[1-9][0-9]*))?$'
-          if [[ ! $LINUX_VERSION =~ $kernel_version_re ]]; then
-            echo "::error::invalid pinned kernel version: ${LINUX_VERSION}; expected MAJOR.MINOR[.PATCH]" >&2
-            exit 1
-          fi
-          branch="${LINUX_VERSION%.*}"
-          # A series' first release is two-part (6.17, no .0): it IS its
-          # own branch; stripping past the last dot would yield "6" and
-          # match every 6.x series below.
-          case "$branch" in *.*) ;; *) branch="$LINUX_VERSION";; esac
-          latest=$(curl -fsSL --retry 5 --retry-delay 5 https://www.kernel.org/releases.json |
-            jq -r --arg b "$branch." '[.releases[] | select(.moniker == "stable" or .moniker == "longterm") | .version | select(. + "." | startswith($b))] | first // empty')
-          if [ -z "$latest" ]; then
-            echo "::error::kernel branch ${branch} is EOL on kernel.org — no more backports reach the ${LINUX_VERSION} pin; move to a maintained branch (measurement roll)" >&2
-            exit 1
-          fi
-          if [[ ! $latest =~ $kernel_version_re ]]; then
-            echo "::error::kernel.org returned an invalid stable version: ${latest}; expected MAJOR.MINOR[.PATCH]" >&2
-            exit 1
-          fi
+          releases="$RUNNER_TEMP/kernel-releases.json"
+          curl -fsSL --retry 5 --retry-delay 5 \
+            --output "$releases" https://www.kernel.org/releases.json
+          latest=$(bash .github/scripts/kernel-release "$releases" "$LINUX_VERSION")
           dpkg --compare-versions "$latest" eq "$LINUX_VERSION" && exit 0
           if ! dpkg --compare-versions "$latest" gt "$LINUX_VERSION"; then
             echo "::error::refusing non-forward kernel update ${LINUX_VERSION} -> ${latest}" >&2
@@ -158,6 +190,8 @@ jobs:
             "https://cdn.kernel.org/pub/linux/kernel/v${major}.x/sha256sums.asc"
           sha=$(bash .github/scripts/kernel-checksum "$manifest" "$latest")
           printf 'LINUX_VERSION=%s\nLINUX_TARBALL_SHA256=%s\n' "$latest" "$sha" > kernel/version
-          open_pr "pin-watch/kernel" \
+          open_pr "pin-watch/kernel-${latest}" \
+            "pin-watch/kernel" \
             "kernel: bump to ${latest} — stable backports on the pinned branch" \
-            "Automated pin-watch bump ${LINUX_VERSION} -> ${latest}; the tarball digest comes from a signature-verified kernel.org checksum manifest using the repository-pinned checksum-autosigner key, not from hashing a download. That signature authenticates kernel.org mirror checksum metadata; it is not a developer tarball signature. Rolls measurements; if CI's kernel-config drift gate trips, regenerate the snapshot lockfile in this PR before merging."
+            "Automated pin-watch bump ${LINUX_VERSION} -> ${latest}; the tarball digest comes from a signature-verified kernel.org checksum manifest using the repository-pinned checksum-autosigner key, not from hashing a download. That signature authenticates kernel.org mirror checksum metadata; it is not a developer tarball signature. Rolls measurements; if CI's kernel-config drift gate trips, regenerate the snapshot lockfile in this PR before merging." \
+            kernel/version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,7 @@ jobs:
         steps:
             - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
             - run: bash .github/scripts/tests/test-kernel-checksum.sh
+            - run: bash .github/scripts/tests/test-kernel-release.sh
 
     cargo-deny:
         runs-on: ubuntu-latest


### PR DESCRIPTION
## What problem does this change solve?

The kernel watcher treated the highest version returned by kernel.org as eligible
even when that release line was marked end-of-life. It also reused and force-pushed
shared automation branches, which could replace changes already under review.

## Why is this solution the best option to solve that problem?

The new Bash resolver validates kernel.org's release schema, requires
`iseol == false`, and keeps updates within the pinned release series. The watcher
now uses candidate-specific branches, preserves open in-repository PRs for each pin
family, stages only the expected files, and fails closed on unexpected or
conflicting state. Fork PRs with matching branch names cannot pause automation.

## Validation

- `bash .github/scripts/tests/test-kernel-release.sh` (8 cases)
- `actionlint .github/workflows/pin-watch.yml`
- `shellcheck` on the resolver and its tests
- existing signed kernel-checksum regression test
- `git diff --check`

## Checklist

- [x] `bin/test` passes (191 passed; 5 platform-dependent tests skipped)
- [x] `bin/lint` is warning-free
- [x] `cargo deny check` is not applicable (`Cargo.toml`/`Cargo.lock` unchanged)
- [x] Commit messages follow conventional commits
- [x] No CLI flags changed
- [x] Build output and measurements are unchanged
- [x] Pipeline output remains deterministic
- [x] Kernel config is unchanged
- [x] `kernel/version` is unchanged
